### PR TITLE
Reset Firefox to 'latest' for Sauce

### DIFF
--- a/grunt/sauce_browsers.yml
+++ b/grunt/sauce_browsers.yml
@@ -13,7 +13,7 @@
   {
     browserName: "firefox",
     platform: "OS X 10.11",
-    version: "latest-1"
+    version: "latest"
   },
 
   # Mac Opera not currently supported by Sauce Labs
@@ -47,7 +47,7 @@
   {
     browserName: "firefox",
     platform: "Windows 10",
-    version: "latest-1"
+    version: "latest"
   },
 
   # Win Opera 15+ not currently supported by Sauce Labs


### PR DESCRIPTION
Sauce Labs has updated to Firefox v47.0.1 which should resolve Selenium issue.

More information at Sauce Labs [support issue](https://support.saucelabs.com/customer/portal/questions/16341558-problem-with-executing-script-via-webdriver-in-firefox-47)