### PR TITLE
Column min height only when truly empty

### DIFF
--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -42,6 +42,10 @@
         min-height: 1px;
         padding-right: ($grid-gutter-width / 2);
         padding-left:  ($grid-gutter-width / 2);
+
+        &:empty {
+            min-height: 1px;
+        }
     }
 
     @each $breakpoint in map-keys($grid-breakpoints) {


### PR DESCRIPTION
Columns collapse when there is no content, but setting a `min-height` can cause visual issues when animating the `height` to/from `0`.