### PR TITLE
Flexbox: Cards

### DIFF
--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -492,7 +492,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
 
 Only applies to small devices and above.
 
-If you wish to have a card deck that matches the grid layout, you will need to use the `.card-deck-wrapper` for both the `float` and `flexbox` styles.  Note that unless you are using the full flexbox mode, there will be a horizontal scroll is used within a full body-width `.container-fluid` element.  This can be mitigated by using `overflow: hidden;` style on a wrapping container.
+If you wish to have a card deck that matches the grid layout, you will need to use the `.card-deck-wrapper` for both the `table` and `flexbox` styles.  Note that unless you are using the full flexbox mode, there will be a horizontal scroll is used within a full body-width `.container-fluid` element.  This can be mitigated by using `overflow: hidden;` style on a wrapping container.
 
 {% example html %}
 <div class="card-deck-wrapper">

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -457,7 +457,7 @@ Use card groups to render cards as a single, attached element with equal width a
 
 Only applies to small devices and above.
 
-Groups have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  If using the opt-in method, simply add a `.card-group-flex` class to the `.card-group` element.
+Groups have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  To use the opt-in method, simply add a `.card-group-flex` class to the `.card-group` element.
 
 {% example html %}
 <div class="card-group">
@@ -494,7 +494,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
 
 Only applies to small devices and above.
 
-Decks have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  If using the opt-in method, simply add a `.card-deck-flex` class to the `.card-deck` element.
+Decks have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  To use the opt-in method, simply add a `.card-deck-flex` class to the `.card-deck` element.
 
 If you wish to have a card deck that matches the grid layout, you will need to use the `.card-deck-wrapper` for both the `table` and `flexbox` styles.  Note that unless you are using the full flexbox mode, there will be a horizontal scroll is used within a full body-width `.container-fluid` element.  This can be mitigated by using `overflow: hidden;` style on a wrapping container.
 

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -492,6 +492,8 @@ Need a set of equal width and height cards that aren't attached to one another? 
 
 Only applies to small devices and above.
 
+If you wish to have a card deck that matches the grid layout, you will need to use the `.card-deck-wrapper` for both the `float` and `flexbox` styles.  Note that unless you are using the full flexbox mode, there will be a horizontal scroll is used within a full body-width `.container-fluid` element.  This can be mitigated by using `overflow: hidden;` style on a wrapping container.
+
 {% example html %}
 <div class="card-deck-wrapper">
   <div class="card-deck">

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -457,6 +457,8 @@ Use card groups to render cards as a single, attached element with equal width a
 
 Only applies to small devices and above.
 
+Groups have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  If using the opt-in method, simply add a `.card-group-flex` class to the `.card-group` element.
+
 {% example html %}
 <div class="card-group">
   <div class="card">
@@ -491,6 +493,8 @@ Only applies to small devices and above.
 Need a set of equal width and height cards that aren't attached to one another? Use card decks. By default, card decks require two wrapping elements: `.card-deck-wrapper` and a `.card-deck`. We use table styles for the sizing and the gutters on `.card-deck`. The `.card-deck-wrapper` is used to negative margin out the `border-spacing` on the `.card-deck`.
 
 Only applies to small devices and above.
+
+Decks have support for both a `table` style layout, along with both the opt-in flexbox and [full flexbox](/layout/flexbox#full-flexbox-mode) modes.  If using the opt-in method, simply add a `.card-deck-flex` class to the `.card-deck` element.
 
 If you wish to have a card deck that matches the grid layout, you will need to use the `.card-deck-wrapper` for both the `table` and `flexbox` styles.  Note that unless you are using the full flexbox mode, there will be a horizontal scroll is used within a full body-width `.container-fluid` element.  This can be mitigated by using `overflow: hidden;` style on a wrapping container.
 

--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -40,7 +40,7 @@ You can find and customize these variables for key global options in our `_setti
 | `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                 |
 | `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                    |
 | `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                          |
-| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `container`, `row', `.col-md-1`, etc.). |
+| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `container`, `row`, `.col-md-1`, etc.). |
 | `$enable-print-styles`      | `true` (default) or `false`        | Enables predefined style overrides used when printing.                                           |
 | `$enable-palette`           | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500` etc.). |
 | `$enable-flex-opt`          | `true` (default) or `false`        | Enables the opt-in flexbox model using classes, such as `.row-flex`  .                           |

--- a/docs/layout/flexbox.md
+++ b/docs/layout/flexbox.md
@@ -14,9 +14,11 @@ Flexbox support is coming to Figuration.  The goal is to have both an opt-in sys
 
 ## What's Included
 
-Flexbox support is available for a number of Figurations's components:
+Flexbox support is available for a number of Figuration's components:
 
-- [Grid layout]({{ site.baseurl }}/layout/grid/#flexbox), which switches from `float`s to `display: flex;`.
+- [Grid Layout]({{ site.baseurl }}/layout/grid/#flexbox), which switches from `float`s to `display: flex;`.
+- [Card Decks]({{ site.baseurl }}/components/cards/#decks), which switches from `display: table;` to `display: flex;`.
+- [Card Groups]({{ site.baseurl }}/components/cards/#groups), which switches from `display: table;` to `display: flex;`.
 - [Utility classes]({{ site.baseurl }}/components/utilities/#flexbox-alignment), for alignment options for flexbox enabled components.
 - More coming!
 

--- a/docs/layout/flexbox.md
+++ b/docs/layout/flexbox.md
@@ -34,6 +34,18 @@ In a nutshell, flexbox provides simpler and more flexible layout options in CSS.
 
 All these things are possible outside flexbox, but typically require extra hacks and workarounds to do right.
 
+## Opt-in Flexbox Mode
+
+The opt-in mode is compiled into Figuration's base CSS by default.  This can be controlled by changing the `$enable-flex-opt` Sass variable.
+
+To use the opt-in mode, simply add another class to parent element.  More information and caveats can be found in the documentation for each component, see the [What's Included section](#whats-included) above.
+
+A quick list of the opt-in classes are:
+
+- `.row-flex`
+- `.card-deck-flex`
+- `.card-group-flex`
+
 ## Full Flexbox Mode
 
 If you're familiar with modifying variables in Sass---or any other CSS preprocessor---you'll be right at home to move into flexbox mode.

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -729,7 +729,7 @@ $card-padding-y:           1rem !default;
 $card-padding-x:           1rem !default;
 $card-img-overlay-padding: $card-padding-y $card-padding-x !default;
 
-$card-deck-margin:         ($grid-gutter-width / 2) !default;
+$card-deck-margin:         $grid-gutter-width !default;
 
 $card-columns-sm-up-column-gap: 1.25rem !default;
 

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -148,25 +148,71 @@
     @include border-radius(0 0 $card-border-radius $card-border-radius);
 }
 
-// Card set
+// Card deck
+// Some style resetting here for margins across the two variations
+// (one flex, one table). Individual cards have margin-bottom by
+// default, but they're ignored due to table styles. For a consistent design,
+// we've done the same to the flex variation.
+//
+// Those changes are noted by `// Margin balancing`
 @include media-breakpoint-up(sm) {
-    .card-deck {
-        display: table;
-        width: 100%;
-        margin-bottom: $card-spacer-y;
-        table-layout: fixed;
-        border-spacing: $card-deck-margin 0;
+    @if $enable-flex-full {
+        .card-deck {
+            @extend %card-deck-flex;
+        }
 
-        .card {
-            display: table-cell;
-            margin-bottom: 0;
-            vertical-align: top;
+        .card-deck-wrapper {
+            margin-right: ($card-deck-margin / -2);
+            margin-left: ($card-deck-margin / -2);
+        }
+    } @else {
+        .card-deck {
+            display: table;
+            width: 100%;
+            margin-bottom: $card-spacer-y;
+            table-layout: fixed;
+            border-spacing: $card-deck-margin 0;
+
+            .card {
+                display: table-cell;
+                margin-bottom: 0;
+                vertical-align: top;
+            }
+        }
+
+        .card-deck-wrapper {
+            margin-right: (-$card-deck-margin);
+            margin-left: (-$card-deck-margin);
+        }
+
+        @if $enable-flex-opt {
+            .card-deck-flex {
+                @extend %card-deck-flex;
+            }
+
+            .card-deck-wrapper .card-deck-flex {
+                padding-right: ($card-deck-margin / 2);
+                padding-left: ($card-deck-margin / 2);
+                margin-right: 0;
+                margin-left: 0;
+            }
         }
     }
 
-    .card-deck-wrapper {
-        margin-right: ($card-deck-margin / -2);
-        margin-left: ($card-deck-margin / -2);
+    // This needs to come later so the CSS if generated after .card-deck
+    %card-deck-flex {
+        display: flex;
+        flex-flow: row wrap;
+        margin-right: 0;
+        margin-bottom: $card-spacer-y; // Margin balancing
+        margin-left: 0;
+
+        .card {
+            flex: 1 0 0;
+            margin-right: ($card-deck-margin / 2);
+            margin-bottom: 0; // Margin balancing
+            margin-left: ($card-deck-margin / 2);
+        }
     }
 }
 

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -219,15 +219,25 @@
 // Card groups
 @include media-breakpoint-up(sm) {
     .card-group {
-        display: table;
-        width: 100%;
-        margin-bottom: $card-spacer-y;
-        table-layout: fixed;
+        @if $enable-flex-full {
+            display: flex;
+            flex-flow: row wrap;
+        } @else {
+            display: table;
+            width: 100%;
+            margin-bottom: $card-spacer-y;
+            table-layout: fixed;
+        }
 
         .card {
-            display: table-cell;
             margin-bottom: 0;
-            vertical-align: top;
+
+            @if $enable-flex-full {
+                flex: 1 0 0;
+            } @else {
+                display: table-cell;
+                vertical-align: top;
+            }
 
             + .card {
                 margin-left: 0;
@@ -264,6 +274,21 @@
                         border-radius: 0;
                     }
                 }
+            }
+        }
+    }
+
+    @if $enable-flex-opt {
+        .card-group-flex {
+            display: flex;
+            flex-flow: row wrap;
+            width: initial;
+            table-layout: initial;
+
+            .card {
+                display: initial;
+                flex: 1 0 0;
+                vertical-align: initial;
             }
         }
     }

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -1,0 +1,236 @@
+﻿<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<title>Figuration - Flexbox Cards</title>
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
+
+<script type="text/javascript" src="../vendor/jquery.min.js"></script>
+<script type="text/javascript" src="../../dist/js/figuration.js"></script>
+
+<script type="text/javascript" src="../../docs/assets/js/vendor/holder.min.js"></script>
+<script type="text/javascript">
+Holder.addTheme("gray", {
+    bg: "#999",
+    fg: "#111",
+    size: 12,
+    font: 'sans-serif',
+    fontweight: "normal"
+});
+</script>
+
+<style>
+.container {
+    border: 1px solid red;
+}
+
+[class^="col-"] {
+    padding-top: .75rem;
+    padding-bottom: .75rem;
+    background-color: rgba(34,68,102,.15);
+    border: 1px solid rgba(34,68,102,.2);
+}
+</style>
+
+<html
+<body>
+
+<div class="container">
+    <h1>Card deck</h1>
+
+    <p>
+        Here we are testing the two different styles for card layouts using the opt-in flexbox classes.
+        They are designated as follows:
+    </p>
+    <ul>
+        <li><strong>normal:</strong> float model</li>
+        <li><strong>flex:</strong> opt-in flexbox model</li>
+    </ul>
+
+    <div class="row">
+        <div class="col-xs-4">.col-xs-4</div>
+        <div class="col-xs-4">.col-xs-4</div>
+        <div class="col-xs-4">.col-xs-4</div>
+    </div>
+
+    normal:
+    <div class="card-deck-wrapper">
+        <div class="card-deck">
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    flex:
+    <div class="card-deck-wrapper">
+        <div class="card-deck card-deck-flex">
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+            <div class="card">
+                <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+                <div class="card-block">
+                    <h4 class="card-title">Card title</h4>
+                    <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+                    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    flex(no wrapper):
+    <div class="card-deck card-deck-flex">
+        <div class="card">
+            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <div class="card-block">
+                <h4 class="card-title">Card title</h4>
+                <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+                <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+            </div>
+        </div>
+        <div class="card">
+            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <div class="card-block">
+                <h4 class="card-title">Card title</h4>
+                <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+                <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+            </div>
+        </div>
+        <div class="card">
+            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <div class="card-block">
+                <h4 class="card-title">Card title</h4>
+                <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+                <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+            </div>
+        </div>
+    </div>
+
+    <hr />
+
+    <div class="row">
+        <div class="col-xs-3">.col-xs-3</div>
+        <div class="col-xs-3">.col-xs-3</div>
+        <div class="col-xs-3">.col-xs-3</div>
+        <div class="col-xs-3">.col-xs-3</div>
+    </div>
+
+    normal:
+    <div class="card-deck-wrapper">
+        <div class="card-deck">
+            <div class="card">
+                <div class="card-block">
+                    Card 1
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 2
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 3
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 4
+                </div>
+            </div>
+        </div>
+    </div>
+
+    flex:
+    <div class="card-deck-wrapper">
+        <div class="card-deck card-deck-flex">
+            <div class="card">
+                <div class="card-block">
+                    Card 1
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 2
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 3
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-block">
+                    Card 4
+                </div>
+            </div>
+        </div>
+    </div>
+
+    flex (no wrapper):
+    <div class="card-deck card-deck-flex">
+        <div class="card">
+            <div class="card-block">
+                Card 1
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-block">
+                Card 2
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-block">
+                Card 3
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-block">
+                Card 4
+            </div>
+        </div>
+    </div>
+
+</div>
+
+</body>
+</html>

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -40,7 +40,9 @@ Holder.addTheme("gray", {
 <body>
 
 <div class="container">
-    <h1>Card deck</h1>
+    <h1>Cards</h1>
+
+    <h2>Deck</h1>
 
     <p>
         Here we are testing the two different styles for card layouts using the opt-in flexbox classes.
@@ -229,6 +231,67 @@ Holder.addTheme("gray", {
             </div>
         </div>
     </div>
+
+    <hr />
+
+    <h2>Group</h2>
+
+    normal:
+    <div class="card-group">
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+    </div>
+
+    flex:
+    <div class="card-group card-group-flex">
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+      <div class="card">
+        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <div class="card-block">
+          <h4 class="card-title">Card title</h4>
+          <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+          <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+        </div>
+      </div>
+    </div>
+
 
 </div>
 

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -292,7 +292,6 @@ Holder.addTheme("gray", {
       </div>
     </div>
 
-
 </div>
 
 </body>

--- a/test/visual/flexbox-grid.html
+++ b/test/visual/flexbox-grid.html
@@ -55,7 +55,7 @@
     </p>
     <ul>
         <li><strong>normal:</strong> float model</li>
-        <li><strong>flex:</strong> flexbox model</li>
+        <li><strong>flex:</strong> opt-in flexbox model</li>
     </ul>
 
     <h2>Five grid tiers</h2>


### PR DESCRIPTION
This will handle adding the flexbox support for card decks and groups.

Some rework of the card deck layout has also been done to get a matching layout between the default `table` and new `flexbox` modes

References: #12 