### PR TITLE
Rework IOS radio/checkbox fix

### DIFF
--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -15,9 +15,7 @@ $select-height:     unquote("calc(#{$input-height} + #{($border-width * 2)})") !
     // height: $input-height;
     padding: $input-padding-y ($input-padding-x / 2);
     font-size: $font-size-base;
-    // scss-lint:disable ImportantRule
-    line-height: $input-line-height !important;
-    // scss-lint:enable ImportantRule
+    line-height: $input-line-height;
     color: $input-color;
     background-color: $input-bg;
     // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214.

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -309,7 +309,7 @@ button:focus {
     outline: 5px auto -webkit-focus-ring-color;
 }
 
-input:not([type="checkbox"]):not([type="radio"]),
+input,
 button,
 select,
 textarea {
@@ -321,6 +321,14 @@ textarea {
     line-height: inherit;
     // iOS adds rounded borders by default
     border-radius: 0;
+}
+[type="checkbox"] {
+    -webkit-appearance: checkbox;
+    -webkit-border-radius: 5px;
+}
+[type="radio"] {
+    -webkit-appearance: radio;
+    -webkit-border-radius: 8px;
 }
 
 textarea {

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -322,14 +322,17 @@ textarea {
     // iOS adds rounded borders by default
     border-radius: 0;
 }
+// scss-lint:disable VendorPrefix
 [type="checkbox"] {
-    -webkit-appearance: checkbox;
     -webkit-border-radius: 5px;
+    -webkit-appearance: checkbox;
+
 }
 [type="radio"] {
-    -webkit-appearance: radio;
     -webkit-border-radius: 8px;
+    -webkit-appearance: radio;
 }
+// scss-lint:enable VendorPrefix
 
 textarea {
     // Textareas should really only resize vertically so they don't break their (horizontal) containers.


### PR DESCRIPTION
The previous fix was messing with the default forms and with `.form-control`