### PR TITLE
Increase max-width for `lg` and `xl` containers

### DIFF
--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -100,8 +100,8 @@ The example pixel values are calculated based upon assumption where the average 
         <td>None (auto)</td>
         <td>576px (36rem)</td>
         <td>720px (45rem)</td>
-        <td>940px (58.75rem)</td>
-        <td>1140px (71.25rem)</td>
+        <td>960px (60rem)</td>
+        <td>1152px (72rem)</td>
       </tr>
       <tr>
         <th class="text-nowrap" scope="row">Class prefix</th>

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -3,10 +3,17 @@
 // Copy settings from this file into the provided `_custom.scss` to override the defaults.
 // This allows for customization without changing core files.
 
-@mixin _assert-ascending($map, $map-name) {
+@mixin _assert-ascending($map, $map-type, $map-name) {
     $prev-key: null;
     $prev-num: null;
     @each $key, $num in $map {
+        // Handle %-based container max-width by using the breakpoint dimension
+        // to generate a rem-based size to compare with.
+        @if $map-type == "container" and unit($num) == "%" {
+            $bp-num: map-get($grid-breakpoints, $key);
+            $num: strip-unit(($num / 100%) * $bp-num) * 1rem;
+        }
+
         @if $prev-num == null {
             // Do nothing
         } @else if not comparable($prev-num, $num) {
@@ -149,19 +156,19 @@ $grid-breakpoints: (
     lg: bp-to-em(992px),
     xl: bp-to-em(1200px)
 ) !default;
-@include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
+@include _assert-ascending($grid-breakpoints, "breakpoint", "$grid-breakpoints");
 
 
 // Grid containers
 // =====
 // Define the maximum width of `.container` for different screen sizes.
 $container-max-widths: (
-    sm: rem-calc(576px),
+    sm: rem-calc(576px),    // allow for some growth for `sm` screens
     md: rem-calc(720px),
-    lg: rem-calc(940px),
-    xl: rem-calc(1140px)
+    lg: rem-calc(960px),
+    xl: rem-calc(1152px)
 ) !default;
-@include _assert-ascending($container-max-widths, "$container-max-widths");
+@include _assert-ascending($container-max-widths, "container", "$container-max-widths");
 
 
 // Grid columns


### PR DESCRIPTION
Slight bump in size, plus it gets the containers evenly divisible by both 12 (col #) and 16 (base em).