### PR TITLE
Update display for .card-column .card

### DIFF
--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -319,7 +319,7 @@
         column-gap: $card-columns-sm-up-column-gap;
 
         .card {
-            display: inline-block;
+            display: inline-table;
             width: 100%; // Don't let them exceed the column width
         }
     }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3248,6 +3248,12 @@ Anchor variants:<br />
         Footer
       </div>
     </div>
+
+    <h3>Card - link test</h3>
+    <a href="#" class="card card-block">
+      <h4 class="card-text">Entire card as link</h4>
+      <p class="card-text">This is some text</p>
+    </a>
  </div>
 
 <h3>Card group</h3>
@@ -3345,6 +3351,10 @@ Anchor variants:<br />
       <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
+  <a href="#" class="card card-block">
+    <h4 class="card-text">Entire card as link</h4>
+    <p class="card-text">This is some text</p>
+  </a>
   <div class="card card-block">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>


### PR DESCRIPTION
Using `display: inline-block;` causes some strange spacing issues in Firefox between card items.

Using `display: block;` tends to break cards in pieces across columns in both Firefox and Chrome.

`display: inline-table;` seems to resolve both these issues.