### PR TITLE
Alternate menu icon - tweaked version for docs

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -4,7 +4,7 @@
             <a class="navbar-brand" href="{{ site.baseurl }}/">CAST Figuration</a>
             <div class="clearfix hidden-md-up">
                 <button class="navbar-toggler btn btn-toggler pull-xs-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#cf-topnav" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">
-                    <span aria-hidden="true">&#9776;</span>
+                    <span class="icon-menu" aria-hidden="true">&#8801;</span>
                 </button>
             </div>
             <div class="collapse navbar-toggleable-sm" id="cf-topnav">

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -35,6 +35,14 @@ $docs-color: #246;
     @include button-outline-variant($uibase-50, $uibase-50, $uibase-700);
 }
 
+.icon-menu {
+    display: inline-block;
+    margin-top: -.25rem;
+    font-size: 1.5rem;
+    font-weight: bold;
+    line-height: .75;
+}
+
 .cf-header {
     color: $white;
     background-color: $uibase-900;

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -303,7 +303,7 @@ Our [Collapse widget]({{ site.baseurl }}/widgets/collapse/) allows you to use a 
 {% example html %}
 <nav class="navbar navbar-light bg-faded">
   <button class="navbar-toggler" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar" aria-label="Toggle navigation">
-    &#9776;
+    <span aria-hidden="true">&#8801;</span>
   </button>
   <div class="collapse" id="exCollapsingNavbar">
     <div class="bg-inverse padding-a-1">
@@ -325,7 +325,7 @@ Note the use of the `hidden` option for the [Collapse widget]({{ site.baseurl }}
 {% example html %}
 <nav class="navbar navbar-light bg-faded">
     <a class="navbar-brand" href="#">Responsive navbar</a>
-    <button class="navbar-toggler hidden-lg-up pull-xs-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#respNav0" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">&#9776;</button>
+    <button class="navbar-toggler hidden-lg-up pull-xs-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#respNav0" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">&#8801;</button>
     <div class="collapse navbar-toggleable-md" id="respNav0">
         <ul class="nav navbar-nav">
             <li class="nav-item active">

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -61,6 +61,13 @@ Holder.addTheme("gray", {
     position: static;
     margin: 1rem -1.5rem -1.5rem;
 }
+.icon-menu {
+    display: inline-block;
+    margin-top: -.25rem;
+    font-size: 1.5rem;
+    font-weight: bold;
+    line-height: .75;
+}
 .close-sample .close {
     float: none;
 }
@@ -2831,19 +2838,19 @@ Anchor variants:<br />
   </div>
 </div>
 <nav class="navbar navbar-light bg-faded">
-  <button class="navbar-toggler" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar1">
-    &#9776;
+  <button class="navbar-toggler" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar1" aria-label="Toggle navigation">
+    <span class="icon-menu" aria-hidden="true">&#8801;</span>
   </button>
 </nav>
 
 <h3>Responsive navbar</h3>
 <small>resize screen below 'md' breakpoint</small><br />
 <nav class="navbar navbar-light bg-faded">
-  <button class="navbar-toggler hidden-md-up" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar2">
-    &#9776;
+  <a class="navbar-brand" href="#">Responsive navbar</a>
+  <button class="navbar-toggler hidden-lg-up pull-xs-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar2" aria-label="Toggle navigation">
+    <span class="icon-menu" aria-hidden="true">&#8801;</span>
   </button>
-  <div class="collapse navbar-toggleable-sm" id="exCollapsingNavbar2">
-    <a class="navbar-brand" href="#">Responsive navbar</a>
+  <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar2">
     <ul class="nav navbar-nav">
       <li class="nav-item active">
         <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>


### PR DESCRIPTION
This one has better support for mobile platforms.

Switch to the unicode character for ['IDENTICAL TO' (U+2261)](http://www.fileformat.info/info/unicode/char/2261/browsertest.htm)
from the ['TRIGRAM FOR HEAVEN' (U+2630)](http://www.fileformat.info/info/unicode/char/2630/browsertest.htm)