### PR TITLE
Reset position for close button in tooltips

### DIFF
--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -83,6 +83,7 @@
 // Close
 .tooltip {
     .close {
+        position: static;
         padding: 0 .15em;
         font-size: 1.25rem;
         color: $white;
@@ -94,3 +95,4 @@
         }
     }
 }
+


### PR DESCRIPTION
Fixes when a 'click' trigger tooltip is used inside an `.alert` container, the close button is moved outside the tip box.