### PR TITLE
Flexbox: Grid - remove redundant properties

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -126,11 +126,9 @@
 
             // Provide basic `.col-{bp}` classes for equal-width flexbox columns
             %col-flex-basic-#{$breakpoint} {
-                position: relative;
                 flex-basis: 0;
                 flex-grow: 1;
                 max-width: 100%;
-                min-height: 1px;
                 padding-right: ($gutter / 2);
                 padding-left:  ($gutter / 2);
             }


### PR DESCRIPTION
position and min-height are included in the base extend