### PR TITLE
Responsive gutters

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -173,9 +173,21 @@ $container-max-widths: (
 
 // Grid columns
 // =====
-// Set the number of columns and specify the width of the gutters.
+// Set the number of columns
 $grid-columns:      12 !default;
+
+// Grid gutters
+// =====
+// Specify the width of the gutters for each breakpoint
+// These settings affect container, row, and col components
 $grid-gutter-width: 1.875rem !default;
+$grid-gutter-widths: (
+    xs: $grid-gutter-width,
+    sm: $grid-gutter-width,
+    md: $grid-gutter-width,
+    lg: $grid-gutter-width,
+    xl: $grid-gutter-width
+) !default;
 
 
 // Body

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -173,13 +173,15 @@ $container-max-widths: (
 
 // Grid columns
 // =====
-// Set the number of columns
+// Set the number of columns.
 $grid-columns:      12 !default;
 
 // Grid gutters
 // =====
-// Specify the width of the gutters for each breakpoint
-// These settings affect container, row, and col components
+// Specify the width of the gutters for each breakpoint.
+// These settings affect container, row, and col components.
+// If modifying, you will also have to adjust the `$container-max-widths`
+// values also to prevent horizontal scrolling.
 $grid-gutter-width: 1.875rem !default;
 $grid-gutter-widths: (
     xs: $grid-gutter-width,
@@ -755,7 +757,14 @@ $card-padding-x:           1rem !default;
 $card-img-overlay-padding: $card-padding-y $card-padding-x !default;
 
 $card-deck-breakpoint:      sm !default;
-$card-deck-margin:          $grid-gutter-width !default;
+// `xs` gutter is not defined since is it below the `$card-deck-breakpoint` setting
+$card-deck-gutter-widths: (
+    sm: map-get($grid-gutter-widths, sm),
+    md: map-get($grid-gutter-widths, md),
+    lg: map-get($grid-gutter-widths, lg),
+    xl: map-get($grid-gutter-widths, xl),
+) !default;
+
 
 $card-group-breakpoint:     sm !default;
 

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -162,17 +162,12 @@
             @extend %card-deck-flex;
         }
 
-        .card-deck-wrapper {
-            margin-right: ($card-deck-margin / -2);
-            margin-left: ($card-deck-margin / -2);
-        }
     } @else {
         .card-deck {
             display: table;
             width: 100%;
             margin-bottom: $card-spacer-y;
             table-layout: fixed;
-            border-spacing: $card-deck-margin 0;
 
             .card {
                 display: table-cell;
@@ -181,19 +176,9 @@
             }
         }
 
-        .card-deck-wrapper {
-            margin-right: (-$card-deck-margin);
-            margin-left: (-$card-deck-margin);
-        }
-
         @if $enable-flex-opt {
             .card-deck-flex {
                 @extend %card-deck-flex;
-            }
-
-            .card-deck-wrapper .card-deck-flex {
-                padding-right: ($card-deck-margin / 2);
-                padding-left: ($card-deck-margin / 2);
             }
 
             // Remove the padding for IE10+
@@ -226,12 +211,49 @@
         .card {
             flex: 1 0 0;
             width: 1%;
-            margin-right: ($card-deck-margin / 2);
             margin-bottom: 0; // Margin balancing
-            margin-left: ($card-deck-margin / 2);
         }
     }
 }
+
+// Card deck gutters
+@each $breakpoint, $gutter in $card-deck-gutter-widths {
+    @include media-breakpoint-up($breakpoint) {
+        @if $enable-flex-full {
+            .card-deck .card {
+                margin-right: ($gutter / 2);
+                margin-left: ($gutter / 2);
+            }
+
+            .card-deck-wrapper {
+                margin-right: ($gutter / -2);
+                margin-left: ($gutter / -2);
+            }
+        } @else {
+            .card-deck {
+                border-spacing: $gutter 0;
+            }
+            .card-deck-wrapper {
+                margin-right: (-$gutter);
+                margin-left: (-$gutter);
+            }
+
+            @if $enable-flex-opt {
+                .card-deck-flex .card {
+                    margin-right: ($gutter / 2);
+                    margin-left: ($gutter / 2);
+                }
+
+                .card-deck-wrapper .card-deck-flex {
+                    padding-right: ($gutter / 2);
+                    padding-left: ($gutter / 2);
+                }
+
+            }
+        }
+    }
+}
+
 
 // Card group
 @include media-breakpoint-up(#{$card-group-breakpoint}) {

--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -50,8 +50,6 @@
     %col {
         position: relative;
         min-height: 1px; // Prevent collapsing
-        padding-right: ($grid-gutter-width / 2);
-        padding-left:  ($grid-gutter-width / 2);
     }
 
     // In flexbox modes, prevent columns from becoming too narrow when at
@@ -91,6 +89,26 @@
             .row-flex .col-#{$breakpoint} {
                 @extend %col;
                 @extend %col-flex;
+            }
+        }
+    }
+
+    // Create repsonsive grid gutters
+    @each $breakpoint in map-keys($grid-breakpoints) {
+        %col-gutter {
+            @include media-breakpoint-up($breakpoint) {
+                $gutter: map-get($grid-gutter-widths, $breakpoint);
+                padding-right: ($gutter / 2);
+                padding-left:  ($gutter / 2);
+            }
+        }
+
+        @for $i from 1 through $grid-columns {
+            .col-#{$breakpoint} {
+                @extend %col-gutter;
+            }
+            .col-#{$breakpoint}-#{$i} {
+                @extend %col-gutter;
             }
         }
     }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -13,7 +13,7 @@
         @include media-breakpoint-up($breakpoint) {
             $gutter: map-get($gutters, $breakpoint);
             padding-right: ($gutter / 2);
-            padding-left:  ($gutter / 2);
+            padding-left: ($gutter / 2);
         }
     }
 }
@@ -33,7 +33,7 @@
         @include media-breakpoint-up($breakpoint) {
             $gutter: map-get($gutters, $breakpoint);
             margin-right: ($gutter / -2);
-            margin-left:  ($gutter / -2);
+            margin-left: ($gutter / -2);
         }
     }
 

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,13 +2,19 @@
 //
 // Generate semantic grid columns with these mixins.
 
-@mixin make-container($gutter: $grid-gutter-width) {
-    margin-left: auto;
+@mixin make-container($gutters: $grid-gutter-widths) {
     margin-right: auto;
-    padding-left:  ($gutter / 2);
-    padding-right: ($gutter / 2);
+    margin-left: auto;
     @if not $enable-flex-full {
         @include clearfix();
+    }
+
+    @each $breakpoint in map-keys($gutters) {
+        @include media-breakpoint-up($breakpoint) {
+            $gutter: map-get($gutters, $breakpoint);
+            padding-right: ($gutter / 2);
+            padding-left:  ($gutter / 2);
+        }
     }
 }
 
@@ -22,9 +28,14 @@
     }
 }
 
-@mixin make-row($gutter: $grid-gutter-width) {
-    margin-left:  ($gutter / -2);
-    margin-right: ($gutter / -2);
+@mixin make-row($gutters: $grid-gutter-widths) {
+    @each $breakpoint in map-keys($gutters) {
+        @include media-breakpoint-up($breakpoint) {
+            $gutter: map-get($gutters, $breakpoint);
+            margin-right: ($gutter / -2);
+            margin-left:  ($gutter / -2);
+        }
+    }
 
     @if $enable-flex-opt {
         display: block;
@@ -129,8 +140,6 @@
                 flex-basis: 0;
                 flex-grow: 1;
                 max-width: 100%;
-                padding-right: ($gutter / 2);
-                padding-left:  ($gutter / 2);
             }
             @if $enable-flex-full {
                 .col-#{$breakpoint} {


### PR DESCRIPTION
This PR will handle responsive gutter abilities for both the grid and card decks.

For the grid side, changing the per breakpoint gutters will affect the following grid components:

-  `.container`
- `.container-fluid`
- `.row`
- `.col-*`

Since the card deck is designed to a gutter layout similar to the grid, in default (`display: table`) mode it affects:

-  `.card-deck-wrapper` 
- `.card-deck`

in card deck flex modes,  affected items are:

- `.card-deck-wrapper`
- `.card-deck`
- `.card-deck-flex`
- `.card-deck .card`
- `.card-deck-flex .card`