### PR TITLE
Form: input and select sizing

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -65,7 +65,8 @@
 }
 
 // Form
-.cf-example > .form-control + .form-control {
+.cf-example > .form-control + .form-control,
+.cf-example > .custom-select + .custom-select {
     margin-top: .5rem;
 }
 

--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -629,7 +629,7 @@ The heights of select elements is a bit off in Internet Explorer, usually just s
 
 {% example html %}
 <select class="form-control form-control-xl">
-  <option>Large select</option>
+  <option>Extra large select</option>
 </select>
 <select class="form-control form-control-lg">
   <option>Large select</option>
@@ -641,7 +641,7 @@ The heights of select elements is a bit off in Internet Explorer, usually just s
   <option>Small select</option>
 </select>
 <select class="form-control form-control-xs">
-  <option>Small select</option>
+  <option>Extra small select</option>
 </select>
 {% endexample %}
 
@@ -909,6 +909,27 @@ Custom `<select>` menus need only a custom class, `.custom-select` to trigger th
 {% endexample %}
 
 Custom selects degrade nicely in IE9, receiving only a handful of overrides to remove the custom `background-image`. **Multiple selects (e.g., `<select multiple>`) are not currently supported.**
+
+Multiple size are also available.
+
+{% example html %}
+<select class="custom-select custom-select-xl">
+  <option>Extra large select</option>
+</select>
+<select class="custom-select custom-select-lg">
+  <option>Large select</option>
+</select>
+<select class="custom-select">
+  <option>Default select</option>
+</select>
+<select class="custom-select custom-select-sm">
+  <option>Small select</option>
+</select>
+<select class="custom-select custom-select-xs">
+  <option>Extra small select</option>
+</select>
+{% endexample %}
+
 
 ### Color Picker
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -411,11 +411,14 @@ $btn-border-radius:             $border-radius !default;
 
 // Forms
 // =====
-// Padding and line-height should match up with buttons
+// Padding and line-height should add up to buttons for inputs and selects
+// An included line-height-delta routine is included to make this easier
 // Implemented horizontal padding will be 1/2 of stated `padding-x`
-$input-padding-y:               $btn-padding-y !default;
+$input-line-height:             1.5 !default;
+$input-line-height-delta:      ($input-line-height - $btn-line-height) !default;
+
+$input-padding-y:               $btn-padding-y - ($input-line-height-delta / 2) !default;
 $input-padding-x:               $btn-padding-x !default;
-$input-line-height:             1.25 !default;
 
 $input-bg:                      $white !default;
 $input-bg-disabled:             $uibase-50 !default;
@@ -439,12 +442,15 @@ $input-group-addon-border-color: $input-border-color !default;
 
 $form-inline-breakpoint:         sm !default;
 
+// Base input/select height calculation
+// Additional ones for each size are done during size processing generation
+$input-height:      (($font-size-base * $input-line-height) + ($input-padding-y * 2)) !default;
+$select-height:     calc(#{$input-height} + #{($border-width * 2)}) !default;
+
+
 // Form icons
 // =====
 // Use some functions to recolor icons to match context colors
-//$icon-success: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%235cb85c' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E") !default;
-//$icon-warning: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23f0ad4e' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E") !default;
-//$icon-danger: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23d9534f' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E") !default;
 $icon-success: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{palette-context-nohash('success', 500)}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E") !default;
 $icon-warning: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{palette-context-nohash('warning', 500)}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E") !default;
 $icon-danger: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{palette-context-nohash('danger', 500)}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='#{palette-context-nohash('danger', 500)}' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E") !default;

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -128,8 +128,9 @@
 //
 // Includes IE9-specific hacks (noted by ` \9`).
 .custom-select {
-    display: inline-block;
-    max-width: 100%;
+    display: block;
+    width: 100%;
+    height: $select-height;
     padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
     padding-right: $custom-select-padding-x \9;
     color: $custom-select-color;
@@ -169,17 +170,20 @@
     }
 }
 
-.custom-select-sm {
-    padding-top: $custom-select-padding-y;
-    padding-bottom: $custom-select-padding-y;
-    font-size: $custom-select-sm-font-size;
+// Select sizes
+@each $size, $dims in $component-sizes {
+    $font-size:     map-get($dims, "font-size");
+    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
+    $padding-x:     map-get($dims, "padding-x");
+    $input-height-size:     (($font-size * $input-line-height) + ($padding-y * 2));
+    $select-height-size:    calc(#{$input-height-size} + #{($border-width * 2)});
 
-    // &:not([multiple]) {
-    //   height: 26px;
-    //   min-height: 26px;
-    // }
+    .custom-select-#{$size} {
+        height: $select-height-size;
+        padding: $padding-y ($padding-x / 2);
+        font-size:  $font-size;
+    }
 }
-
 
 // File
 // Custom file input.

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -204,9 +204,9 @@ input[type="month"] {
     $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
 
     .form-control-#{$size} {
+        height: $select-height-size;
         padding: $padding-y ($padding-x / 2);
         font-size: $font-size;
-        height: $select-height-size;
         @include border-radius($border-radius);
 
         // Color input - reduce horizontal padding otherwise visualy unsable in Chrome

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -1,18 +1,11 @@
 // scss-lint:disable QualifyingElement
 
-// Base height calculation
-// Additional ones for each size and select
-
-// TODO: look at height calcs for select - still a bit off in IE 9 +
-$input-height:      (($font-size-base * $input-line-height) + ($input-padding-y * 2)) !default;
-$select-height:     calc(#{$input-height} + #{($border-width * 2)}) !default;
-
 // Textual form controls
 .form-control {
     display: block;
     width: 100%;
-    // // Make inputs at least the height of their button counterpart (base line-height + padding + border)
-    // height: $input-height;
+    // // Make inputs the height of their button counterpart (line-height + padding + border)
+    height: $select-height;
     padding: $input-padding-y ($input-padding-x / 2);
     font-size: $font-size-base;
     line-height: $input-line-height;
@@ -75,13 +68,15 @@ select.form-control {
     // Sizes
     @each $size, $dims in $component-sizes {
         $font-size:     map-get($dims, "font-size");
-        $padding-y:     map-get($dims, "padding-y");
+        $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
+        $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
+        $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
 
         &.form-control-#{$size}:not([size]):not([multiple]),
         .input-group-#{$size} &.form-control:not([size]):not([multiple]) {
-            $input-height:      (($font-size * $input-line-height) + ($padding-y * 2));
-            $select-height:     calc(#{$input-height} + #{($border-width * 2)});
-            height: $select-height;
+            height: $select-height-size;
+            padding-top: $padding-y;
+            padding-bottom: $padding-y;
         }
     }
 
@@ -116,11 +111,14 @@ select.form-control {
 // Label sizes
 @each $size, $dims in $component-sizes {
     $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y");
+    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
+    $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
+    $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
 
     .form-control-label-#{$size} {
-        padding-top: $input-padding-y;
-        padding-bottom: $input-padding-y;
+        height: $select-height-size;
+        padding-top: $padding-y;
+        padding-bottom: $padding-y;
         font-size:  $font-size;
     }
 }
@@ -158,12 +156,12 @@ input[type="month"] {
 
     @each $size, $dims in $component-sizes {
         $font-size:     map-get($dims, "font-size");
-        $padding-y:     map-get($dims, "padding-y");
+        $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
+        $input-height-size: (($font-size * $input-line-height) + ($padding-y * 2));
 
         &.form-control-#{$size},
         .input-group-#{$size} &.form-control {
-            $input-height: (($font-size * $input-line-height) + ($padding-y * 2));
-            line-height: $input-height;
+            line-height: $input-height-size;
         }
     }
 }
@@ -199,13 +197,16 @@ input[type="month"] {
 // issue documented in https://github.com/twbs/bootstrap/issues/15074.
 @each $size, $dims in $component-sizes {
     $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y");
+    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
     $padding-x:     map-get($dims, "padding-x");
     $border-radius: map-get($dims, "border-radius");
+    $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
+    $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
 
     .form-control-#{$size} {
         padding: $padding-y ($padding-x / 2);
         font-size: $font-size;
+        height: $select-height-size;
         @include border-radius($border-radius);
 
         // Color input - reduce horizontal padding otherwise visualy unsable in Chrome

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -21,9 +21,7 @@
             @include form-control-focus(darken($border-color, 20%));
         } @else {
             &:focus {
-                border-color: darken($border-color, 10%);
-                $shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 6px lighten($border-color, 20%);
-                @include box-shadow($shadow);
+                box-shadow: $input-box-shadow, 0 0 6px lighten($border-color, 20%);
             }
         }
     }

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -1,0 +1,236 @@
+﻿<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<title>Figuration - Flexbox Input Group</title>
+
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
+
+<script type="text/javascript" src="../vendor/jquery.min.js"></script>
+<script type="text/javascript" src="../../dist/js/figuration.js"></script>
+
+<script type="text/javascript" src="../../docs/assets/js/vendor/holder.min.js"></script>
+<script type="text/javascript">
+Holder.addTheme("gray", {
+    bg: "#999",
+    fg: "#111",
+    size: 12,
+    font: 'sans-serif',
+    fontweight: "normal"
+});
+</script>
+
+<style>
+.select-sizing .btn {
+    vertical-align: top;
+}
+
+.form-control + .form-control,
+.custom-select + .custom-select {
+    margin-top: .5rem;
+}
+</style>
+
+</head>
+<body>
+
+<div class="container">
+
+<h3>Select Sizing Comparison:</h3>
+<div class="select-sizing">
+    <form class="row">
+      <div class="col-md-2 text-right">
+        <button type="button" class="btn btn-primary btn-xs">Test</button>
+      </div>
+      <fieldset class="form-group col-md-3">
+        <label for="size0-0" class="sr-only">Example label</label>
+        <input type="text" class="form-control form-control-xs" id="size0-0" placeholder="Example input">
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size0-1" class="sr-only">Example select</label>
+        <select class="form-control form-control-xs" id="size0-1">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size0-2" class="sr-only">Example select</label>
+        <select class="custom-select custom-select-xs" id="size0-2">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+    </form>
+    <form class="row">
+      <div class="col-md-2 text-right">
+        <button type="button" class="btn btn-primary btn-sm">Test</button>
+      </div>
+      <fieldset class="form-group col-md-3">
+        <label for="size1-0" class="sr-only">Example label</label>
+        <input type="text" class="form-control form-control-sm" id="size1-0" placeholder="Example input">
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size1-1" class="sr-only">Example select</label>
+        <select class="form-control form-control-sm" id="size1-1">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size1-2" class="sr-only">Example select</label>
+        <select class="custom-select custom-select-sm" id="size1-2">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+    </form>
+    <form class="row">
+      <div class="col-md-2 text-right">
+        <button type="button" class="btn btn-primary">Test</button>
+      </div>
+      <fieldset class="form-group col-md-3">
+        <label for="size2-0" class="sr-only">Example label</label>
+        <input type="text" class="form-control" id="size2-0" placeholder="Example input">
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size2-1" class="sr-only">Example select</label>
+        <select class="form-control" id="size2-1">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size2-2" class="sr-only">Example select</label>
+        <select class="custom-select" id="size2-2">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+    </form>
+    <form class="row">
+      <div class="col-md-2 text-right">
+        <button type="button" class="btn btn-primary btn-lg">Test</button>
+      </div>
+      <fieldset class="form-group col-md-3">
+        <label for="size3-0" class="sr-only">Example label</label>
+        <input type="text" class="form-control form-control-lg" id="size3-0" placeholder="Example input">
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size3-1" class="sr-only">Example select</label>
+        <select class="form-control form-control-lg" id="size3-1">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size3-2" class="sr-only">Example select</label>
+        <select class="custom-select custom-select-lg" id="size3-2">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+    </form>
+    <form class="row">
+      <div class="col-md-2 text-right">
+        <button type="button" class="btn btn-primary btn-xl">Test</button>
+      </div>
+      <fieldset class="form-group col-md-3">
+        <label for="size4-0" class="sr-only">Example label</label>
+        <input type="text" class="form-control form-control-xl" id="size4-0" placeholder="Example input">
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size4-1" class="sr-only">Example select</label>
+        <select class="form-control form-control-xl" id="size4-1">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+      <fieldset class="form-group col-md-3">
+        <label for="size4-2" class="sr-only">Example select</label>
+        <select class="custom-select custom-select-xl" id="size4-2">
+          <option>1</option>
+          <option>2</option>
+          <option>3</option>
+          <option>4</option>
+          <option>5</option>
+        </select>
+      </fieldset>
+    </form>
+</div> <!-- /.select-sizing -->
+
+<hr />
+
+<h3>Select Sizing:</h3>
+<div class="margin-b-1">
+    <select class="form-control form-control-xl">
+        <option>Extra large select</option>
+    </select>
+    <select class="form-control form-control-lg">
+        <option>Large select</option>
+    </select>
+    <select class="form-control">
+        <option>Default select</option>
+    </select>
+    <select class="form-control form-control-sm">
+        <option>Small select</option>
+    </select>
+    <select class="form-control form-control-xs">
+        <option>Extra small select</option>
+    </select>
+</div>
+
+<hr />
+
+<h3>Custom Select Sizing:</h3>
+<div class="margin-b-1">
+    <select class="custom-select custom-select-xl">
+        <option>Extra large select</option>
+    </select>
+    <select class="custom-select custom-select-lg">
+        <option>Large select</option>
+    </select>
+    <select class="custom-select">
+        <option>Default select</option>
+    </select>
+    <select class="custom-select custom-select-sm">
+        <option>Small select</option>
+    </select>
+    <select class="custom-select custom-select-xs">
+        <option>Extra small select</option>
+    </select>
+</div>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Rework the `.form-control` for input and selects along with sizing for `.custom-select`.  The inputs at their respective size levels should now be equal to the respective `.btn` heights.  There is a bit of calculation going on now to get all the height calculations to work out, and keep the text legible.

The IE9 sizing issue should be resolved and fonts sitting too low (and getting clipped) in select inputs should no longer happen.

Also make `.custom-select` to work more like `select.form-control`.

Slight tweak to form shadows (when enabled).

