### PR TITLE
Give custom control some size

### DIFF
--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -10,6 +10,7 @@
 .custom-control {
     position: relative;
     display: inline-block;
+    min-height: (1rem * $line-height-base);
     padding-left: $custom-control-gutter;
     margin-bottom: 0;
     cursor: pointer;


### PR DESCRIPTION
Give min-height of one line of text to handle case where a custom control indicator is used without a visual label.  Otherwise the absolute position of the indicator gives a strange layout.