### PR TITLE
v2 - Utilities-Display: responsive rework

### DIFF
--- a/docs/utilities/display-property.md
+++ b/docs/utilities/display-property.md
@@ -4,11 +4,19 @@ title: Display Property
 group: utilities
 ---
 
-Use `.display-block`, `.display-inline`, `.display-inline-block`, `.display-flex`, `.display-table`, and `.display-table-cell` to simply set an element's [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display) to `block`, `inline`, `inline-block`, `flex`, `table`, or `table-cell` (respectively).
+Control an element's [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
 
-These classes are also available in repsonsive variants, in the form of `.display-{breakpoint}-{value}`, such as `.display-lg-block`.
+Available utilities:
+- `.display-block` sets `display: block;`
+- `.display-flex` sets `display: flex;`
+- `.display-inline` sets `display: inline;`
+- `.display-inline-block` sets `display: inline-block;`
+- `.display-table`sets `display: table;`
+- `.display-table-cell`  sets `display: table-cell;`
 
-To make an element `display: none`, use our [responsive utilities]({{ site.baseurl }}/layout/responsive-utilities/) instead.
+These classes are also available in repsonsive variants, in the form of `.display{-breakpoint}-{value}`, such as `.display-lg-block`.
+
+While we also have a `.display-none` utility to make an element `display: none;`, using the [responsive utilities]({{ site.baseurl }}/layout/responsive-utilities/) would be a better option.
 
 {% example html %}
 <div class="display-inline bg-success">Inline</div>

--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -1,32 +1,16 @@
 // scss-lint:disable ImportantRule
 
 // Display utilities
-.display-block {
-    display: block !important;
-}
-.display-inline-block {
-    display: inline-block !important;
-}
-.display-inline {
-    display: inline !important;
-}
-.display-flex {
-    display: flex !important;
-}
-.display-table {
-    display: table !important;
-}
-.display-table-cell {
-    display: table-cell !important;
-}
-
 @each $breakpoint in map-keys($grid-breakpoints) {
+    $bprule: breakpoint-designator($breakpoint);
+
     @include media-breakpoint-up($breakpoint) {
-        .display-#{$breakpoint}-block { display: block !important; }
-        .display-#{$breakpoint}-inline-block { display: inline-block !important; }
-        .display-#{$breakpoint}-inline { display: inline !important; }
-        .display-#{$breakpoint}-flex { display: flex !important; }
-        .display-#{$breakpoint}-table { display: table !important; }
-        .display-#{$breakpoint}-table-cell { display: table-cell !important; }
+        .display#{$bprule}-none { display: none !important; }
+        .display#{$bprule}-block { display: block !important; }
+        .display#{$bprule}-flex { display: flex !important; }
+        .display#{$bprule}-inline-block { display: inline-block !important; }
+        .display#{$bprule}-inline { display: inline !important; }
+        .display#{$bprule}-table { display: table !important; }
+        .display#{$bprule}-table-cell { display: table-cell !important; }
     }
 }


### PR DESCRIPTION
Remove the base `.display-*` utilities and implement the new breakpoint designator.

Quick rework of docs page too.