### PR TITLE
v2 - remove redundant media query items

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -203,7 +203,7 @@ $grid-columns:      12 !default;
 // These settings affect container, row, and col components.
 // If modifying, you will also have to adjust the `$container-max-widths`
 // values also to prevent horizontal scrolling.
-$grid-gutter-width: 1.875rem !default;
+$grid-gutter-width: 2rem !default;
 $grid-gutter-widths: (
     xs: $grid-gutter-width,
     sm: $grid-gutter-width,
@@ -319,6 +319,7 @@ $drag-text-shadow:      0 .0625rem 0 #fff !default;
 // Component sizes
 // =====
 // Used for button, button groups, pagination, form-control, and input-group
+// 'md' is considered to be the default size, so no classes for this size designator are generated, as in *no* `.btn-md`.
 $component-sizes: (
     xs: (
         font-size:      .75rem,
@@ -331,7 +332,7 @@ $component-sizes: (
         padding-y:      .25rem,
         padding-x:      .5rem,
         border-radius:  .1875rem
-   ),
+    ),
     lg: (
         font-size:      1.25rem,
         padding-y:      .625rem,

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -217,37 +217,39 @@
 
 // Card deck gutters
 @each $breakpoint, $gutter in $card-deck-gutter-widths {
-    @include media-breakpoint-up($breakpoint) {
-        @if $enable-flex-full {
-            .card-deck .card {
-                margin-right: ($gutter / 2);
-                margin-left: ($gutter / 2);
-            }
-
-            .card-deck-wrapper {
-                margin-right: ($gutter / -2);
-                margin-left: ($gutter / -2);
-            }
-        } @else {
-            .card-deck {
-                border-spacing: $gutter 0;
-            }
-            .card-deck-wrapper {
-                margin-right: (-$gutter);
-                margin-left: (-$gutter);
-            }
-
-            @if $enable-flex-opt {
-                .card-deck-flex .card {
+    @include check-gutter-change($breakpoint, $card-deck-gutter-widths) {
+        @include media-breakpoint-up($breakpoint) {
+            @if $enable-flex-full {
+                .card-deck .card {
                     margin-right: ($gutter / 2);
                     margin-left: ($gutter / 2);
                 }
 
-                .card-deck-wrapper .card-deck-flex {
-                    padding-right: ($gutter / 2);
-                    padding-left: ($gutter / 2);
+                .card-deck-wrapper {
+                    margin-right: ($gutter / -2);
+                    margin-left: ($gutter / -2);
+                }
+            } @else {
+                .card-deck {
+                    border-spacing: $gutter 0;
+                }
+                .card-deck-wrapper {
+                    margin-right: (-$gutter);
+                    margin-left: (-$gutter);
                 }
 
+                @if $enable-flex-opt {
+                    .card-deck-flex .card {
+                        margin-right: ($gutter / 2);
+                        margin-left: ($gutter / 2);
+                    }
+
+                    .card-deck-wrapper .card-deck-flex {
+                        padding-right: ($gutter / 2);
+                        padding-left: ($gutter / 2);
+                    }
+
+                }
             }
         }
     }

--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -6,6 +6,7 @@
     .container {
         @include make-container();
         @include make-container-max-widths();
+        max-width: 100%;
     }
 }
 
@@ -61,6 +62,10 @@
     }
 
     @each $breakpoint in map-keys($grid-breakpoints) {
+        .col-#{$breakpoint} {
+            @extend %col;
+        }
+
         @for $i from 1 through $grid-columns {
             .col-#{$breakpoint}-#{$i} {
                 @extend %col;
@@ -87,7 +92,6 @@
 
         @if $enable-flex-opt {
             .row-flex .col-#{$breakpoint} {
-                @extend %col;
                 @extend %col-flex;
             }
         }
@@ -95,18 +99,21 @@
 
     // Create repsonsive grid gutters
     @each $breakpoint in map-keys($grid-breakpoints) {
-        %col-gutter {
-            @include media-breakpoint-up($breakpoint) {
-                $gutter: map-get($grid-gutter-widths, $breakpoint);
-                padding-right: ($gutter / 2);
-                padding-left:  ($gutter / 2);
+        @include check-gutter-change($breakpoint, $grid-gutter-widths) {
+            %col-gutter {
+                @include media-breakpoint-up($breakpoint) {
+                    $gutter: map-get($grid-gutter-widths, $breakpoint);
+                    padding-right: ($gutter / 2);
+                    padding-left:  ($gutter / 2);
+                }
             }
         }
 
+        .col-#{$breakpoint} {
+            @extend %col-gutter;
+        }
+
         @for $i from 1 through $grid-columns {
-            .col-#{$breakpoint} {
-                @extend %col-gutter;
-            }
             .col-#{$breakpoint}-#{$i} {
                 @extend %col-gutter;
             }

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -6,6 +6,19 @@
 //
 // The map defined in the `$grid-breakpoints` global variable is used as the `$breakpoints` argument by default.
 
+// Name of the previous breakpoint, or null for the first breakpoint.
+//
+//    >> breakpoint-prev(sm)
+//    xs
+//    >> breakpoint-prev(sm, (xs: 0, sm: 544px, md: 768px))
+//    xs
+//    >> breakpoint-prev(sm, $breakpoint-names: (xs sm md))
+//    xs
+@function breakpoint-prev($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
+    $n: index($breakpoint-names, $name);
+    @return if($n > 1, nth($breakpoint-names, $n - 1), null);
+}
+
 // Name of the next breakpoint, or null for the last breakpoint.
 //
 //    >> breakpoint-next(sm)
@@ -40,9 +53,10 @@
 }
 
 // String value for breakpoint class name designation.
+// Empty string returned for smallest (first) breakpoint, otherwise prepend '-' to breakpoint name.
 //
 //    >> breakpoint-designator(xs)
-//    `empty string`
+//    "" (empty string)
 //    >> breakpoint-designator(lg)
 //    -lg
 @function breakpoint-designator($name, $breakpoints: $grid-breakpoints) {

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -2,6 +2,21 @@
 //
 // Generate semantic grid columns with these mixins.
 
+@mixin check-gutter-change($breakpoint, $gutters: $grid-gutter-widths) {
+    $prev-breakpoint: breakpoint-prev($breakpoint, $gutters);
+
+    @if $prev-breakpoint {
+        $prev-gutter: map-get($gutters, $prev-breakpoint);
+        $curr-gutter: map-get($gutters, $breakpoint);
+
+        @if $prev-gutter != $curr-gutter {
+            @content;
+        }
+    } @else {
+        @content;
+    }
+}
+
 @mixin make-container($gutters: $grid-gutter-widths) {
     margin-right: auto;
     margin-left: auto;
@@ -10,10 +25,12 @@
     }
 
     @each $breakpoint in map-keys($gutters) {
-        @include media-breakpoint-up($breakpoint) {
-            $gutter: map-get($gutters, $breakpoint);
-            padding-right: ($gutter / 2);
-            padding-left: ($gutter / 2);
+        @include check-gutter-change($breakpoint, $gutters) {
+            @include media-breakpoint-up($breakpoint) {
+                $gutter: map-get($gutters, $breakpoint);
+                padding-right: ($gutter / 2);
+                padding-left: ($gutter / 2);
+            }
         }
     }
 }
@@ -24,17 +41,18 @@
     @each $breakpoint, $container-max-width in $max-widths {
         @include media-breakpoint-up($breakpoint, $breakpoints) {
             width: $container-max-width;
-            max-width: 100%;
         }
     }
 }
 
 @mixin make-row($gutters: $grid-gutter-widths) {
     @each $breakpoint in map-keys($gutters) {
-        @include media-breakpoint-up($breakpoint) {
-            $gutter: map-get($gutters, $breakpoint);
-            margin-right: ($gutter / -2);
-            margin-left: ($gutter / -2);
+        @include check-gutter-change($breakpoint, $gutters) {
+            @include media-breakpoint-up($breakpoint) {
+                $gutter: map-get($gutters, $breakpoint);
+                margin-right: ($gutter / -2);
+                margin-left: ($gutter / -2);
+            }
         }
     }
 


### PR DESCRIPTION
Because `media-breakpoint-up` is used to define gutters, we can check to see if the previous gutter is the same of the current one.  If so, don't add a media query.

A few grid tweaks to reduce reduncancy and fix some missing/incorrect rule creation.

Also fix the base `$grid-gutter-width` to be the documented 2rem.