### PR TITLE
v2 - drop small header sub-tag

### DIFF
--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -57,7 +57,7 @@ You can also use the included utility classes to recolor the secondary text.
 {% example html %}
 <h3>
   Fancy display heading
-  <small>With secondary text</small>
+  <small class="text-muted">With secondary text</small>
 </h3>
 
 <h3>

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -263,7 +263,6 @@ $headings-font-family:      inherit !default;
 $headings-font-weight:      600 !default;
 $headings-line-height:      1.1 !default;
 $headings-color:            inherit !default;
-$headings-small-color:      $uibase-500 !default;
 
 $lead-font-size:    1.25rem !default;
 $lead-font-weight:  600 !default;

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -11,13 +11,6 @@ h6, .h6 {
     font-weight: $headings-font-weight;
     line-height: $headings-line-height;
     color: $headings-color;
-
-    small,
-    .small {
-        font-weight: $font-weight-normal;
-        line-height: 1;
-        color: $headings-small-color;
-    }
 }
 
 h1, .h1 { font-size: $font-size-h1; }
@@ -26,24 +19,6 @@ h3, .h3 { font-size: $font-size-h3; }
 h4, .h4 { font-size: $font-size-h4; }
 h5, .h5 { font-size: $font-size-h5; }
 h6, .h6 { font-size: $font-size-h6; }
-
-h1, .h1,
-h2, .h2,
-h3, .h3 {
-    small,
-    .small {
-        font-size: 65%;
-    }
-}
-
-h4, .h4,
-h5, .h5,
-h6, .h6 {
-    small,
-    .small {
-        font-size: 75%;
-    }
-}
 
 // Lead in
 


### PR DESCRIPTION
Killing the specific CSS for small items in headers. The implemented sub-tag was only changing the color due to being overridden by the `small/.small` definition shortly after in the generated CSS.  This can be better handled with the palette color system.