### PR TITLE
v2 - utlity rename

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -2,7 +2,7 @@
     <div class="container">
         <nav>
             <a class="navbar-brand" href="{{ site.baseurl }}/">CAST Figuration</a>
-            <div class="clearfix hidden-lg-up">
+            <div class="clearfix hide-lg-up">
                 <button class="navbar-toggler btn btn-toggler float-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#cf-topnav" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">
                     <span class="icon-menu" aria-hidden="true">&#8801;</span>
                 </button>

--- a/docs/assets/scss/_responsive-tests.scss
+++ b/docs/assets/scss/_responsive-tests.scss
@@ -67,27 +67,27 @@
 }
 
 @include media-breakpoint-only(xs) {
-    .hidden-xs-only {
+    .hide-xs-only {
         display: none !important;
     }
 }
 @include media-breakpoint-only(sm) {
-    .hidden-sm-only {
+    .hide-sm-only {
         display: none !important;
     }
 }
 @include media-breakpoint-only(md) {
-    .hidden-md-only {
+    .hide-md-only {
         display: none !important;
     }
 }
 @include media-breakpoint-only(lg) {
-    .hidden-lg-only {
+    .hide-lg-only {
         display: none !important;
     }
 }
 @include media-breakpoint-only(xl) {
-    .hidden-xl-only {
+    .hide-xl-only {
         display: none !important;
     }
 }

--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -73,7 +73,7 @@ Alerts can also contain additional HTML elements like headings and paragraphs.
 <div class="alert alert-success" role="alert">
   <h4 class="alert-heading">Well done!</h4>
   <p>You successfully read this important alert message. This example text is going to run a bit longer so that you can see how spacing within an alert works with this kind of content.</p>
-  <p class="margin-b-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
+  <p class="mb-0">Whenever you need to, be sure to use margin utilities to keep things nice and tidy.</p>
 </div>
 {% endexample %}
 

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -10,9 +10,9 @@ A lightweight, flexible component that can optionally extend the entire viewport
 
 {% example html %}
 <div class="jumbotron">
-  <h1 class="display-3">Hello, world!</h1>
+  <h1>Hello, world!</h1>
   <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>
-  <hr class="m-y-2">
+  <hr class="my-2">
   <p>It uses utility classes for typography and spacing to space content out within the larger container.</p>
   <p class="lead">
     <a class="btn btn-primary btn-lg" href="#" role="button">Learn more</a>
@@ -25,7 +25,7 @@ To make the jumbotron full width, and without rounded corners, add the `.jumbotr
 {% example html %}
 <div class="jumbotron jumbotron-fluid">
   <div class="container">
-    <h1 class="display-3">Fluid jumbotron</h1>
+    <h1>Fluid jumbotron</h1>
     <p class="lead">This is a modified jumbotron that occupies the entire horizontal space of its parent.</p>
   </div>
 </div>

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -67,7 +67,7 @@ The `.navbar-brand` can be applied to most elements, but an anchor works best as
 </nav>
 
 <nav class="navbar navbar-light bg-faded">
-  <h1 class="navbar-brand margin-b-0">Navbar</h1>
+  <h1 class="navbar-brand mb-0">Navbar</h1>
 </nav>
 
 {% endexample %}
@@ -306,7 +306,7 @@ Our [Collapse widget]({{ site.baseurl }}/widgets/collapse/) allows you to use a 
     <span aria-hidden="true">&#8801;</span>
   </button>
   <div class="collapse" id="exCollapsingNavbar">
-    <div class="bg-inverse padding-a-1">
+    <div class="bg-inverse p-1">
       <h4>Collapsed content</h4>
       Toggleable via the navbar button.
     </div>
@@ -325,7 +325,7 @@ Note the use of the `hidden` option for the [Collapse widget]({{ site.baseurl }}
 {% example html %}
 <nav class="navbar navbar-light bg-faded">
     <a class="navbar-brand" href="#">Responsive navbar</a>
-    <button class="navbar-toggler hidden-lg-up float-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#respNav0" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">&#8801;</button>
+    <button class="navbar-toggler hide-lg-up float-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#respNav0" data-cfw-collapse-hidden="false" aria-label="Toggle navigation">&#8801;</button>
     <div class="collapse navbar-toggleable-md" id="respNav0">
         <ul class="nav navbar-nav">
             <li class="nav-item active">

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -30,7 +30,7 @@ Simple pagination, great for apps and search results. The large block is hard to
     <li class="page-item"><a class="page-link" href="#">3</a></li>
     <li class="page-item"><a class="page-link" href="#">4</a></li>
     <li class="page-item"><a class="page-link" href="#">5</a></li>
-    <li class="page-item margin-l-0_5">
+    <li class="page-item ml-0_5">
       <a class="page-link" href="#" aria-label="Next">
         <span aria-hidden="true">&raquo;</span>
         <span class="sr-only">Next</span>

--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -902,7 +902,7 @@ Add other states to your custom forms with our validation classes.
     <span class="custom-control-description">Check this custom checkbox</span>
   </label>
 </div>
-<div class="form-group has-danger margin-b-0">
+<div class="form-group has-danger mb-0">
   <label class="custom-control custom-checkbox">
     <input type="checkbox" class="custom-control-input">
     <span class="custom-control-indicator"></span>

--- a/docs/content/images.md
+++ b/docs/content/images.md
@@ -46,7 +46,7 @@ You might also want to check the [border utilites]({{ site.baseurl }}/utilities/
 
 ## Aligning Images
 
-Align images with the [helper float classes]({{ site.baseurl }}/utilities/responsive-floats/) or [text alignment classes]({{ site.baseurl }}/utilities/typography/#text-alignment). `block`-level images can be centered using [the `.margin-x-auto` margin utility class]({{ site.baseurl }}/utilities/spacing/#horizontal-centering).
+Align images with the [helper float classes]({{ site.baseurl }}/utilities/responsive-floats/) or [text alignment classes]({{ site.baseurl }}/utilities/typography/#text-alignment). `block`-level images can be centered using [the `.mx-auto` margin utility class]({{ site.baseurl }}/utilities/spacing/#horizontal-centering).
 
 <div class="cf-example clearfix">
   <img data-src="holder.js/200x200" class="img-rounded float-left" alt="A generic square placeholder image with rounded corners">
@@ -59,11 +59,11 @@ Align images with the [helper float classes]({{ site.baseurl }}/utilities/respon
 {% endhighlight %}
 
 <div class="cf-example clearfix">
-  <img data-src="holder.js/200x200" class="img-rounded margin-x-auto display-block" alt="A generic square placeholder image with rounded corners">
+  <img data-src="holder.js/200x200" class="img-rounded mx-auto d-block" alt="A generic square placeholder image with rounded corners">
 </div>
 
 {% highlight html %}
-<img src="..." class="img-rounded margin-x-auto display-block" alt="...">
+<img src="..." class="img-rounded mx-auto d-block" alt="...">
 {% endhighlight %}
 
 <div class="cf-example clearfix">

--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -117,7 +117,7 @@ For quoting blocks of content from another source within your document. Wrap `<b
 
 {% example html %}
 <blockquote class="blockquote">
-  <p class="margin-b-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+  <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
 </blockquote>
 {% endexample %}
 
@@ -127,7 +127,7 @@ Add a `<footer class="blockquote-footer">` for identifying the source. Wrap the 
 
 {% example html %}
 <blockquote class="blockquote">
-  <p class="margin-b-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+  <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
 </blockquote>
 {% endexample %}
@@ -138,7 +138,7 @@ Add `.blockquote-reverse` for a blockquote with right-aligned content.
 
 {% example html %}
 <blockquote class="blockquote blockquote-reverse">
-  <p class="margin-b-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+  <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
 </blockquote>
 {% endexample %}

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -24,34 +24,78 @@
         <h1>Figuration Grid Examples</h1>
         <p class="lead">Basic grid layouts to help get you familiar with building within the grid system.</p>
 
+        <p>
+            Here we are showing the two different styles for grid layouts using the opt-in flexbox classes.
+            They are designated as follows:
+        </p>
+        <ul>
+            <li><strong>normal:</strong> float model</li>
+            <li><strong>flex:</strong> opt-in flexbox model</li>
+        </ul>
+
         <h2>Five grid tiers</h2>
         <p>There are five tiers to the grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
 
+        normal:
         <div class="row">
           <div class="col-4">.col-4</div>
           <div class="col-4">.col-4</div>
           <div class="col-4">.col-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+          <div class="col-4">.col-4</div>
+          <div class="col-4">.col-4</div>
+          <div class="col-4">.col-4</div>
+        </div>
 
+        normal:
         <div class="row">
           <div class="col-sm-4">.col-sm-4</div>
           <div class="col-sm-4">.col-sm-4</div>
           <div class="col-sm-4">.col-sm-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+          <div class="col-sm-4">.col-sm-4</div>
+          <div class="col-sm-4">.col-sm-4</div>
+          <div class="col-sm-4">.col-sm-4</div>
+        </div>
 
+        normal:
         <div class="row">
           <div class="col-md-4">.col-md-4</div>
           <div class="col-md-4">.col-md-4</div>
           <div class="col-md-4">.col-md-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+          <div class="col-md-4">.col-md-4</div>
+          <div class="col-md-4">.col-md-4</div>
+          <div class="col-md-4">.col-md-4</div>
+        </div>
 
+        normal:
         <div class="row">
           <div class="col-lg-4">.col-lg-4</div>
           <div class="col-lg-4">.col-lg-4</div>
           <div class="col-lg-4">.col-lg-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+          <div class="col-lg-4">.col-lg-4</div>
+          <div class="col-lg-4">.col-lg-4</div>
+          <div class="col-lg-4">.col-lg-4</div>
+        </div>
 
+        normal:
         <div class="row">
+          <div class="col-xl-4">.col-xl-4</div>
+          <div class="col-xl-4">.col-xl-4</div>
+          <div class="col-xl-4">.col-xl-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
           <div class="col-xl-4">.col-xl-4</div>
           <div class="col-xl-4">.col-xl-4</div>
           <div class="col-xl-4">.col-xl-4</div>
@@ -59,7 +103,14 @@
 
         <h2>Three equal columns</h2>
         <p>Get three equal-width columns <strong>starting at desktops and scaling to extra large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
+        normal:
         <div class="row">
+            <div class="col-md-4">.col-md-4</div>
+            <div class="col-md-4">.col-md-4</div>
+            <div class="col-md-4">.col-md-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-md-4">.col-md-4</div>
             <div class="col-md-4">.col-md-4</div>
             <div class="col-md-4">.col-md-4</div>
@@ -67,7 +118,14 @@
 
         <h2>Three unequal columns</h2>
         <p>Get three columns <strong>starting at desktops and scaling to extra large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
+        normal:
         <div class="row">
+            <div class="col-md-3">.col-md-3</div>
+            <div class="col-md-6">.col-md-6</div>
+            <div class="col-md-3">.col-md-3</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-md-3">.col-md-3</div>
             <div class="col-md-6">.col-md-6</div>
             <div class="col-md-3">.col-md-3</div>
@@ -75,7 +133,13 @@
 
         <h2>Two columns</h2>
         <p>Get two columns <strong>starting at desktops and scaling to extra large desktops</strong>.</p>
+        normal:
         <div class="row">
+            <div class="col-md-8">.col-md-8</div>
+            <div class="col-md-4">.col-md-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-md-8">.col-md-8</div>
             <div class="col-md-4">.col-md-4</div>
         </div>
@@ -88,7 +152,19 @@
         <h2>Two columns with two nested columns</h2>
         <p>Per the documentation, nesting is easy&mdash;just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to extra large desktops</strong>, with another two (equal widths) within the larger column.</p>
         <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
+        normal:
         <div class="row">
+            <div class="col-md-8">
+                .col-md-8
+                <div class="row">
+                    <div class="col-md-6">.col-md-6</div>
+                    <div class="col-md-6">.col-md-6</div>
+                </div>
+            </div>
+            <div class="col-md-4">.col-md-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-md-8">
                 .col-md-8
                 <div class="row">
@@ -104,16 +180,37 @@
         <h2>Mixed: mobile and desktop</h2>
         <p>The grid system has five tiers of classes: xs (extra small), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
         <p>Each tier of classes scales up, meaning if you plan on setting the same widths for xs and sm, you only need to specify xs.</p>
+        normal:
         <div class="row">
             <div class="col-12 col-md-8">.col-12 .col-md-8</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-12 col-md-8">.col-12 .col-md-8</div>
+            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+        </div>
+
+        normal:
         <div class="row">
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
+        </div>
+
+        normal:
         <div class="row">
+            <div class="col-6">.col-6</div>
+            <div class="col-6">.col-6</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-6">.col-6</div>
             <div class="col-6">.col-6</div>
         </div>
@@ -121,11 +218,25 @@
         <hr />
 
         <h2>Mixed: mobile, tablet, and desktop</h2>
+        normal:
         <div class="row">
             <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
             <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
         </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
+            <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
+        </div>
+
+        normal:
         <div class="row">
+            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
@@ -135,6 +246,7 @@
 
         <h2>Column clearing</h2>
         <p>Use <a href="../layout/grid/#example-responsive-column-resets">responsive column resets</a> at specific breakpoints to prevent awkward wrapping with uneven content.</p>
+        normal:
         <div class="row">
             <div class="col-6 col-sm-3">
                 .col-6 .col-sm-3
@@ -144,7 +256,22 @@
             <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
             <!-- Add the extra clearfix for only the required viewport -->
-            <div class="clearfix hidden-sm-up"></div>
+            <div class="clearfix hide-sm-up"></div>
+
+            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+        </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-6 col-sm-3">
+                .col-6 .col-sm-3
+                <br />
+                Resize your viewport or check it out on your phone for an example.
+            </div>
+            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+
+            <!-- Add the extra clearfix for only the required viewport -->
+            <div class="clearfix hide-sm-up"></div>
 
             <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
             <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
@@ -154,13 +281,215 @@
 
         <h2>Offset, push, and pull resets</h2>
         <p>Reset offsets, pushes, and pulls at specific breakpoints.</p>
+        normal:
         <div class="row">
             <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
             <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
         </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
+            <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
+        </div>
+
+        normal:
         <div class="row">
             <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
             <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
+        </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
+            <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
+        </div>
+
+        <hr />
+
+        <h2>Nested float/flex Examples</h2>
+
+        normal:
+        <div class="row">
+            <div class="col-md-8">
+                .col-md-8
+                <div class="row row-flex">
+                    <div class="col-md-6">.col-md-6<br />more</div>
+                    <div class="col-md-6">.col-md-6</div>
+                </div>
+            </div>
+            <div class="col-md-4">.col-md-4</div>
+        </div>
+        flex:
+        <div class="row row-flex">
+            <div class="col-md-8">
+                .col-md-8
+                <div class="row">
+                    <div class="col-md-6">.col-md-6<br />more</div>
+                    <div class="col-md-6">.col-md-6</div>
+                </div>
+            </div>
+            <div class="col-md-4">.col-md-4</div>
+        </div>
+
+        <hr />
+
+        <h2>Auto layout columns</h2>
+
+        <p>When flexbox is enabled, you can utilize breakpoint specific column classes for equal width columns.</p>
+
+        <code>xs</code> breakpoint
+        <div class="row row-flex">
+            <div class="col">
+                1 of 2
+            </div>
+            <div class="col">
+                1 of 2
+            </div>
+        </div>
+
+        <code>md</code> breakpoint
+        <div class="row row-flex">
+            <div class="col-md">
+                1 of 3
+            </div>
+            <div class="col-md">
+                1 of 3
+            </div>
+            <div class="col-md">
+                1 of 3
+            </div>
+        </div>
+
+        <code>xs</code> breakpoint
+        <div class="row row-flex">
+            <div class="col">
+                1 of 5
+            </div>
+            <div class="col">
+                1 of 5
+            </div>
+            <div class="col">
+                1 of 5
+            </div>
+            <div class="col">
+                1 of 5
+            </div>
+            <div class="col">
+                1 of 5
+            </div>
+        </div>
+
+        <hr />
+
+        <h2>Vertical Flex Alignment</h2>
+
+        <div class="row row-flex flex-top">
+            <div class="col">
+                <code>.flex-*-top</code>
+            </div>
+            <div class="col">
+                1 of 3
+            </div>
+            <div class="col">
+                Align top - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dolor felis pretium!
+            </div>
+        </div>
+
+        <div class="row row-flex flex-middle">
+            <div class="col">
+                <code>.flex-*-middle</code>
+            </div>
+            <div class="col">
+                1 of 3
+            </div>
+            <div class="col">
+                Align middle - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dolor felis pretium!
+            </div>
+        </div>
+
+        <div class="row row-flex flex-bottom">
+            <div class="col">
+                <code>.flex-*-bottom</code>
+            </div>
+            <div class="col">
+                1 of 3
+            </div>
+            <div class="col">
+                Align bottom - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dolor felis pretium!
+            </div>
+        </div>
+
+        <div class="row row-flex flex-stretch">
+            <div class="col">
+                <code>.flex-*-stretch</code>
+            </div>
+            <div class="col">
+                1 of 3
+            </div>
+            <div class="col">
+                Equal height - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dolor felis pretium!
+            </div>
+        </div>
+
+        <div class="row row-flex" style="height: 7rem;">
+            <div class="col flex-self-top">
+                align top
+            </div>
+            <div class="col flex-self-middle">
+                align middle
+            </div>
+            <div class="col flex-self-bottom">
+                align bottom
+            </div>
+            <div class="col flex-self-stretch">
+                align stretch
+            </div>
+        </div>
+
+        <h2>Horizontal Flex Alignment</h2>
+
+        <div class="row row-flex flex-left">
+            <div class="col-4">
+                aligned to
+            </div>
+            <div class="col-4">
+                the left
+            </div>
+        </div>
+
+        <div class="row row-flex flex-center">
+            <div class="col-4">
+                aligned to
+            </div>
+            <div class="col-4">
+                the center
+            </div>
+        </div>
+
+        <div class="row row-flex flex-right">
+            <div class="col-4">
+                aligned to
+            </div>
+            <div class="col-4">
+                the right
+            </div>
+        </div>
+
+        <div class="row row-flex flex-around">
+            <div class="col-4">
+                aliged to
+            </div>
+            <div class="col-4">
+                the space around
+            </div>
+        </div>
+
+        <div class="row row-flex flex-between">
+            <div class="col-4">
+                aligned to
+            </div>
+            <div class="col-4">
+                the space between
+            </div>
         </div>
 
     </div> <!-- /container -->

--- a/docs/get-started/download.md
+++ b/docs/get-started/download.md
@@ -15,10 +15,10 @@ group: get-started
 ## Quick Download
 
 <div data-cfw="equalize" data-cfw-equalize-target=".card-block">
-  <div class="row margin-t-2" data-cfw="equalize" data-cfw-equalize-target=".card-footer">
+  <div class="row mt-2" data-cfw="equalize" data-cfw-equalize-target=".card-footer">
     <div class="col-sm-6">
       <div class="card card-download">
-        <h3 class="h4 card-header card-inverse margin-b-0" style="background-color: #246;">Compiled</h3>
+        <h3 class="h4 card-header card-inverse" style="background-color: #246;">Compiled</h3>
         <div class="card-block">
 {% markdown %}
 Download just the compiled and minified CSS and JavaScript. Doesn't include any documentation or original source files.
@@ -31,7 +31,7 @@ Download just the compiled and minified CSS and JavaScript. Doesn't include any 
     </div>
     <div class="col-sm-6">
       <div class="card card-download">
-        <h3 class="h4 card-header card-inverse margin-b-0" style="background-color: #246;">Source Files</h3>
+        <h3 class="h4 card-header card-inverse" style="background-color: #246;">Source Files</h3>
         <div class="card-block">
 {% markdown %}
 Download everything: source Sass, JavaScript, and documentation files. **Requires a Sass compiler, [Autoprefixer](https://github.com/postcss/autoprefixer), [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes), and [some setup]({{ site.baseurl }}/get-started/build-tools/#tooling-setup).**

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -216,7 +216,7 @@ Build on the previous example by creating even more dynamic and powerful layouts
   <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
   <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
   <!-- Optional: clear the XS cols if their content doesn't match in height -->
-  <div class="clearfix hidden-sm-up"></div>
+  <div class="clearfix hide-sm-up"></div>
   <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
 </div>
 {% endexample %}
@@ -247,7 +247,7 @@ With the four tiers of grids available you're bound to run into issues where, at
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
   <!-- Add the extra clearfix for only the required viewport -->
-  <div class="clearfix hidden-sm-up"></div>
+  <div class="clearfix hide-sm-up"></div>
 
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
   <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>

--- a/docs/layout/overview.md
+++ b/docs/layout/overview.md
@@ -182,7 +182,7 @@ Since Figuration is built as a mobile first framework, we have created our class
 
 Classes that apply to all breakpoints, from `xs` to `xl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
 
-Building from the base component or utility name, classes are named using the format `.base-{direction}-{dimension}` for `xs` and `.base-{breakpoint}-{direction}-{dimension}` for `sm`, `md`, `lg`, and `xl`.
+Building from the base component or utility name, most classes are named using the format `.base-{direction}-{dimension}` for `xs` and `.base-{breakpoint}-{direction}-{dimension}` for `sm`, `md`, `lg`, and `xl`.  In the case of some utilites that have abbreviated names, such as the [spacing utilities]({{ site.baseurl }}/utilities/spacing), the format is `.abbr{direction}-{breakpoint}-{dimension}`.
 
 The only special case is where there are `*-up` or `*-down` variants for certain components or classes, the breakpoint designation.  Only then is the minimum breakpoint designation used in the class name.
 

--- a/docs/layout/responsive-utilities.md
+++ b/docs/layout/responsive-utilities.md
@@ -16,10 +16,10 @@ Try to use these on a limited basis and avoid creating entirely different versio
 
 ##  Available classes
 
-* The `.hidden-*-up` classes hide the element when the viewport is at the given breakpoint or wider. For example, `.hidden-md-up` hides an element on medium, large, and extra-large viewports.
-* The `.hidden-*-down` classes hide the element when the viewport is at the given breakpoint or smaller. For example, `.hidden-md-down` hides an element on extra-small, small, and medium viewports.
+* The `.hide-*-up` classes hide the element when the viewport is at the given breakpoint or wider. For example, `.hide-md-up` hides an element on medium, large, and extra-large viewports.
+* The `.hide-*-down` classes hide the element when the viewport is at the given breakpoint or smaller. For example, `.hide-md-down` hides an element on extra-small, small, and medium viewports.
 * There are no explicit "visible"/"show" responsive utility classes; you make an element visible by simply not hiding it at that breakpoint size.
-* You can combine one `.hidden-*-up` class with one `.hidden-*-down` class to show an element only on a given interval of screen sizes. For example, `.hidden-sm-down.hidden-xl-up` shows the element only on medium and large viewports. Using multiple `.hidden-*-up` classes or multiple `.hidden-*-down` classes is redundant and pointless.
+* You can combine one `.hide-*-up` class with one `.hide-*-down` class to show an element only on a given interval of screen sizes. For example, `.hide-sm-down.hide-xl-up` shows the element only on medium and large viewports. Using multiple `.hide-*-up` classes or multiple `.hide-*-down` classes is redundant and pointless.
 * These classes don't attempt to accommodate less common cases where an element's visibility can't be expressed as a single contiguous range of viewport breakpoint sizes; you will instead need to use custom CSS in such cases.
 
 <div class="table-responsive">
@@ -51,7 +51,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
     </thead>
     <tbody>
       <tr>
-        <th scope="row"><code>.hidden-xs-down</code></th>
+        <th scope="row"><code>.hide-xs-down</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
@@ -59,7 +59,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-visible">Visible</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-sm-down</code></th>
+        <th scope="row"><code>.hide-sm-down</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible</td>
@@ -67,7 +67,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-visible">Visible</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-md-down</code></th>
+        <th scope="row"><code>.hide-md-down</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
@@ -75,7 +75,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-visible">Visible</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-lg-down</code></th>
+        <th scope="row"><code>.hide-lg-down</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
@@ -83,7 +83,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-visible">Visible</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-xl-down</code></th>
+        <th scope="row"><code>.hide-xl-down</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
@@ -91,7 +91,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-hidden">Hidden</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-xs-up</code></th>
+        <th scope="row"><code>.hide-xs-up</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
@@ -99,7 +99,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-hidden">Hidden</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-sm-up</code></th>
+        <th scope="row"><code>.hide-sm-up</code></th>
         <td class="is-visible">Visible</td>
         <td class="is-hidden">Hidden</td>
         <td class="is-hidden">Hidden</td>
@@ -107,7 +107,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-hidden">Hidden</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-md-up</code></th>
+        <th scope="row"><code>.hide-md-up</code></th>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
         <td class="is-hidden">Hidden</td>
@@ -115,7 +115,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-hidden">Hidden</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-lg-up</code></th>
+        <th scope="row"><code>.hide-lg-up</code></th>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
@@ -123,7 +123,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-hidden">Hidden</td>
       </tr>
       <tr>
-        <th scope="row"><code>.hidden-xl-up</code></th>
+        <th scope="row"><code>.hide-xl-up</code></th>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
         <td class="is-visible">Visible</td>
@@ -147,22 +147,22 @@ Try to use these on a limited basis and avoid creating entirely different versio
     </thead>
     <tbody>
       <tr>
-        <th><code>.visible-print-block</code></th>
+        <th><code>.print-show-block</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
       </tr>
       <tr>
-        <th><code>.visible-print-inline</code></th>
+        <th><code>.print-show-inline</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
       </tr>
       <tr>
-        <th><code>.visible-print-inline-block</code></th>
+        <th><code>.print-show-inline-block</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
       </tr>
       <tr>
-        <th><code>.hidden-print</code></th>
+        <th><code>.print-hide</code></th>
         <td class="is-visible">Visible</td>
         <td class="is-hidden">Hidden</td>
       </tr>
@@ -178,41 +178,20 @@ Green checkmarks indicate the element **is visible** in your current viewport.
 
 <div class="row responsive-utilities-test visible-on">
   <div class="col-6 col-sm-3">
-    <span class="hidden-sm-up visible">&#10004; Visible on extra small</span>
-    <span class="hidden-xs-down not-visible">Extra small</span>
+    <span class="hide-sm-up visible">&#10004; Visible on extra small</span>
+    <span class="hide-xs-down not-visible">Extra small</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-md-up visible">&#10004; Visible on small or narrower</span>
-    <span class="hidden-sm-down not-visible">Small or narrower</span>
+    <span class="hide-md-up visible">&#10004; Visible on small or narrower</span>
+    <span class="hide-sm-down not-visible">Small or narrower</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-lg-up visible">&#10004; Visible on medium or narrower</span>
-    <span class="hidden-md-down not-visible">Medium or narrower</span>
+    <span class="hide-lg-up visible">&#10004; Visible on medium or narrower</span>
+    <span class="hide-md-down not-visible">Medium or narrower</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-xl-up visible">&#10004; Visible on large or narrower</span>
-    <span class="hidden-lg-down not-visible">Large or narrower</span>
-  </div>
-</div>
-
-<hr />
-
-<div class="row responsive-utilities-test visible-on">
-  <div class="col-6 col-sm-3">
-    <span class="hidden-xs-down visible">&#10004; Visible on small or wider</span>
-    <span class="hidden-sm-up not-visible">Small or wider</span>
-  </div>
-  <div class="col-6 col-sm-3">
-    <span class="hidden-sm-down visible">&#10004; Visible on medium or wider</span>
-    <span class="hidden-md-up not-visible">Medium or wider</span>
-  </div>
-  <div class="col-6 col-sm-3">
-    <span class="hidden-md-down visible">&#10004; Visible on large or wider</span>
-    <span class="hidden-lg-up not-visible">Large or wider</span>
-  </div>
-  <div class="col-6 col-sm-3">
-    <span class="hidden-lg-down visible">&#10004; Visible on extra large</span>
-    <span class="hidden-xl-up not-visible">Extra large</span>
+    <span class="hide-xl-up visible">&#10004; Visible on large or narrower</span>
+    <span class="hide-lg-down not-visible">Large or narrower</span>
   </div>
 </div>
 
@@ -220,23 +199,44 @@ Green checkmarks indicate the element **is visible** in your current viewport.
 
 <div class="row responsive-utilities-test visible-on">
   <div class="col-6 col-sm-3">
-    <span class="hidden-sm-up visible">&#10004; Your viewport is exactly extra small</span>
-    <span class="hidden-xs-down not-visible">Your viewport is NOT exactly extra small</span>
+    <span class="hide-xs-down visible">&#10004; Visible on small or wider</span>
+    <span class="hide-sm-up not-visible">Small or wider</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-xs-down hidden-md-up visible">&#10004; Your viewport is exactly small</span>
-    <span class="hidden-sm-only not-visible">Your viewport is NOT exactly small</span>
+    <span class="hide-sm-down visible">&#10004; Visible on medium or wider</span>
+    <span class="hide-md-up not-visible">Medium or wider</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-sm-down hidden-lg-up visible">&#10004; Your viewport is exactly medium</span>
-    <span class="hidden-md-only not-visible">Your viewport is NOT exactly medium</span>
+    <span class="hide-md-down visible">&#10004; Visible on large or wider</span>
+    <span class="hide-lg-up not-visible">Large or wider</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-md-down hidden-xl-up visible">&#10004; Your viewport is exactly large</span>
-    <span class="hidden-lg-only not-visible">Your viewport is NOT exactly large</span>
+    <span class="hide-lg-down visible">&#10004; Visible on extra large</span>
+    <span class="hide-xl-up not-visible">Extra large</span>
+  </div>
+</div>
+
+<hr />
+
+<div class="row responsive-utilities-test visible-on">
+  <div class="col-6 col-sm-3">
+    <span class="hide-sm-up visible">&#10004; Your viewport is exactly extra small</span>
+    <span class="hide-xs-down not-visible">Your viewport is NOT exactly extra small</span>
   </div>
   <div class="col-6 col-sm-3">
-    <span class="hidden-lg-down visible">&#10004; Your viewport is exactly extra large</span>
-    <span class="hidden-xl-only not-visible">Your viewport is NOT exactly extra large</span>
+    <span class="hide-xs-down hide-md-up visible">&#10004; Your viewport is exactly small</span>
+    <span class="hide-sm-only not-visible">Your viewport is NOT exactly small</span>
+  </div>
+  <div class="col-6 col-sm-3">
+    <span class="hide-sm-down hide-lg-up visible">&#10004; Your viewport is exactly medium</span>
+    <span class="hide-md-only not-visible">Your viewport is NOT exactly medium</span>
+  </div>
+  <div class="col-6 col-sm-3">
+    <span class="hide-md-down hide-xl-up visible">&#10004; Your viewport is exactly large</span>
+    <span class="hide-lg-only not-visible">Your viewport is NOT exactly large</span>
+  </div>
+  <div class="col-6 col-sm-3">
+    <span class="hide-lg-down visible">&#10004; Your viewport is exactly extra large</span>
+    <span class="hide-xl-only not-visible">Your viewport is NOT exactly extra large</span>
   </div>
 </div>

--- a/docs/utilities/borders.md
+++ b/docs/utilities/borders.md
@@ -19,7 +19,7 @@ Add a class to your element to round the corners.  You can target various sides 
 
 Where *sides* is one of:
 
-* `a` - for `all` 4 corners of the element
+* blank - for `all` 4 corners of the element
 * `t` - for both corners on the `top` side
 * `b` - for both corners on the `bottom` side
 * `r` - for both corners on the `right` side
@@ -31,8 +31,8 @@ Where *sides* is one of:
 
 
 <div class="cf-example">
-    <div class="margin-b-1">
-        <img data-src="holder.js/100x100/?text=All" class="radius-a" alt="A generic square placeholder image with rounded corners" />
+    <div class="mb-1">
+        <img data-src="holder.js/100x100/?text=All" class="radius" alt="A generic square placeholder image with rounded corners" />
         <img data-src="holder.js/100x100/?text=Top" class="radius-t" alt="A generic square placeholder image with rounded corners on the top edge" />
         <img data-src="holder.js/100x100/?text=Bottom" class="radius-b" alt="A generic square placeholder image with rounded corners on the bottom edge" />
         <img data-src="holder.js/100x100/?text=Right" class="radius-r" alt="A generic square placeholder image with rounded corners on the right edge" />
@@ -48,7 +48,7 @@ Where *sides* is one of:
 
 {% highlight html %}
 <!-- Sides -->
-<img src="..." class="radius-a" alt="...">
+<img src="..." class="radius" alt="...">
 <img src="..." class="radius-t" alt="...">
 <img src="..." class="radius-b" alt="...">
 <img src="..." class="radius-r" alt="...">
@@ -68,15 +68,15 @@ A few sizes are available using the [component sizing options]({{ site.baseurl }
 By default the `xs` and `sm` sizes are the same radius.  Also the `lg` and `xl` sizes are the same radius.
 
 <div class="cf-example">
-    <img data-src="holder.js/100x100?text=Small" class="radius-a-sm" alt="A generic square placeholder image with lightly rounded corners" />
-    <img data-src="holder.js/100x100?text=Default" class="radius-a" alt="A generic square placeholder image with rounded corners" />
-    <img data-src="holder.js/100x100?text=Large" class="radius-a-lg" alt="A generic square placeholder image with more rounded corners" />
+    <img data-src="holder.js/100x100?text=Small" class="radius-sm" alt="A generic square placeholder image with lightly rounded corners" />
+    <img data-src="holder.js/100x100?text=Default" class="radius" alt="A generic square placeholder image with rounded corners" />
+    <img data-src="holder.js/100x100?text=Large" class="radius-lg" alt="A generic square placeholder image with more rounded corners" />
 </div>
 
 {% highlight html %}
-<img src="..." class="radius-a-sm" alt="...">
-<img src="..." class="radius-a" alt="...">
-<img src="..." class="radius-a-lg" alt="...">
+<img src="..." class="radius-sm" alt="...">
+<img src="..." class="radius" alt="...">
+<img src="..." class="radius-lg" alt="...">
 {% endhighlight %}
 
 ### Removing

--- a/docs/utilities/display-property.md
+++ b/docs/utilities/display-property.md
@@ -7,39 +7,39 @@ group: utilities
 Control an element's [`display` property](https://developer.mozilla.org/en-US/docs/Web/CSS/display).
 
 Available utilities:
-- `.display-block` sets `display: block;`
-- `.display-flex` sets `display: flex;`
-- `.display-inline` sets `display: inline;`
-- `.display-inline-block` sets `display: inline-block;`
-- `.display-table`sets `display: table;`
-- `.display-table-cell`  sets `display: table-cell;`
+- `.d-block` sets `display: block;`
+- `.d-flex` sets `display: flex;`
+- `.d-inline` sets `display: inline;`
+- `.d-inline-block` sets `display: inline-block;`
+- `.d-table`sets `display: table;`
+- `.d-table-cell`  sets `display: table-cell;`
 
-These classes are also available in repsonsive variants, in the form of `.display{-breakpoint}-{value}`, such as `.display-lg-block`. Please refer to how our [breakpoint nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) is used.
+These classes are also available in responsive variants, in the form of `.d{-breakpoint}-{value}`, such as `.d-lg-block`. Please refer to how our [breakpoint nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) is used.
 
-While we also have a `.display-none` utility to make an element `display: none;`, using the [responsive utilities]({{ site.baseurl }}/layout/responsive-utilities/) would be a better option.
+While we also have a `.d-none` utility to make an element `display: none;`, using the [responsive utilities]({{ site.baseurl }}/layout/responsive-utilities/) would be a better option.
 
 {% example html %}
-<div class="display-inline bg-success">Inline</div>
-<div class="display-inline bg-success">Inline</div>
+<div class="d-inline bg-success">Inline</div>
+<div class="d-inline bg-success">Inline</div>
 
-<span class="display-block bg-primary">Block</span>
+<span class="d-block bg-primary">Block</span>
 
-<div class="display-inline-block bg-warning">
+<div class="d-inline-block bg-warning">
   <h3>inline-block</h3>
   Paint the fence!
 </div>
-<div class="display-inline-block bg-warning">
+<div class="d-inline-block bg-warning">
   <h3>inline-block</h3>
   Sand the floor!
 </div>
 
-<div class="display-table bg-info">
+<div class="d-table bg-info">
     Table
-    <div class="display-table">
-        <div class="display-table-cell bg-danger">
+    <div class="d-table">
+        <div class="d-table-cell bg-danger">
             Table Cell
         </div>
-        <div class="display-table-cell bg-warning">
+        <div class="d-table-cell bg-warning">
             Table Cell
         </div>
     </div>

--- a/docs/utilities/screen-readers-visibility.md
+++ b/docs/utilities/screen-readers-visibility.md
@@ -16,7 +16,7 @@ Hide content without sacrificing accessibility.
 
 Hide an element to all devices **except screen readers** with `.sr-only`. Combine `.sr-only` with `.sr-only-focusable` to show the element again when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
 
-There are also repsonsive variants available in the form `.sr-only-{breakpoint}-{up/down}`.  For example, to visually hide content, **except for screen readers**, for a `sm` or smaller screens you would use `.sr-only-sm-down`.
+There are also responsive variants available in the form `.sr-only-{breakpoint}-{up/down}`.  For example, to visually hide content, **except for screen readers**, for a `sm` or smaller screens you would use `.sr-only-sm-down`.
 
 These classes are exceptionally useful helping to follow [accessibility best practices]({{ site.baseurl }}/get-started/accessibility).
 
@@ -36,13 +36,13 @@ These classes are exceptionally useful helping to follow [accessibility best pra
 
 ## Hidden Content
 
-Force an element to be hidden (including for screen readers) with the use of `.hidden-{breakpoint}-{up/down}` classes. These classes use `!important` to avoid specificity conflicts. For example, to hide content for `lg` or larger screens you would use `.hidden-lg-up`.
+Force an element to be hidden (including for screen readers) with the use of `.hide-{breakpoint}-{up/down}` classes. These classes use `!important` to avoid specificity conflicts. For example, to hide content for `lg` or larger screens you would use `.hide-lg-up`.
 
 A section on the [responsive utilities layout page]({{ site.baseurl }}/layout/responsive-utilities/#available-classes) gives more detail about how these classes and breakpoints are related.
 
 {% highlight html %}
-<span class="hidden-lg-up">...</span>
-<span class="hidden-sm-down">...</span>
+<span class="hide-lg-up">...</span>
+<span class="hide-sm-down">...</span>
 {% endhighlight %}
 
 ## Invisible Content

--- a/docs/utilities/sizing-positioning.md
+++ b/docs/utilities/sizing-positioning.md
@@ -14,20 +14,20 @@ Gain a little more control over your layout.
 
 ## Widths/Heights
 
-Easily make an element as wide as its parent using the `.width-100` utility class, which sets `width: 100%`.
+Easily make an element as wide as its parent using the `.w-100` utility class, which sets `width: 100%`.
 
 {% example html %}
-<img class="width-100" data-src="holder.js/200px100?outline=yes&text=Width%20%3D%20100%25" alt="Width = 100%">
+<img class="w-100" data-src="holder.js/200px100?outline=yes&text=Width%20%3D%20100%25" alt="Width = 100%">
 {% endexample %}
 
-There is also a `.height-100` utility class, which sets `height: 100%`.  However, it probabaly won't always work the way you think it should.  Some good information can be found in this article &mdash; [How Do You Set the Height of an HTML Element to 100%?](http://webdesign.about.com/od/csstutorials/f/set-css-height-100-percent.htm)
+There is also a `.h-100` utility class, which sets `height: 100%`.  However, it probabaly won't always work the way you think it should.  Some good information can be found in this article &mdash; [How Do You Set the Height of an HTML Element to 100%?](http://webdesign.about.com/od/csstutorials/f/set-css-height-100-percent.htm)
 
 {% example html %}
 <div class="cf-example-height">
-    <div class="bg-gray-50 padding-x-3 display-inline-block" style="height: 150px;">
-        <div class="height-100 bg-gray-300 text-center padding-a-1 display-inline-block">
+    <div class="bg-gray-50 px-2 d-inline-block" style="height: 150px;">
+        <div class="h-100 bg-gray-300 text-center p-1 d-inline-block">
             Full height<br />
-            <code>.height-100</code>
+            <code>.h-100</code>
         </div>
     </div>
 </div>
@@ -35,10 +35,10 @@ There is also a `.height-100` utility class, which sets `height: 100%`.  However
 
 ## Fixed Positioning
 
-The `.position-f-t` class can be used to easily position elements at the top of the viewport and make them as wide as the viewport. **Be sure you understand the ramifications of fixed-position elements within your project.** Here's how the class is defined:
+The `.pos-f-t` class can be used to easily position elements at the top of the viewport and make them as wide as the viewport. **Be sure you understand the ramifications of fixed-position elements within your project.** Here's how the class is defined:
 
 {% highlight scss %}
-.position-f-t {
+.pos-f-t {
   position: fixed;
   top: 0;
   right: 0;

--- a/docs/utilities/spacing.md
+++ b/docs/utilities/spacing.md
@@ -4,75 +4,74 @@ title: Spacing
 group: utilities
 ---
 
-Assign `margin` or `padding` to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are generated from a Sass map with values ranging from `0.25rem` to `3rem`.
+Assign `margin` or `padding` to an element or a subset of its sides with shorthand classes. Includes support for individual properties, all properties, and vertical and horizontal properties. Classes are generated from a Sass map with values ranging from `0.25rem` to `2rem`.
 
-The classes are named using the format: `{property}{-breakpoint}-{sides}-{size}`.
+The classes are named using the format: `{property}{sides}{-breakpoint}-{size}`.
 
 Where *property* is one of:
 
-* `margin` - for classes that set `margin`
-* `padding` - for classes that set `padding`
+* `m` - for classes that set `margin`
+* `p` - for classes that set `padding`
 
-Where *breakpoint* is one of the repsonsive breakpoints, if above the minimum `xs` size.  Please refer to how our [breakpoint nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) is used.
+Where *breakpoint* is one of the responsive breakpoints, if above the minimum `xs` size.  Please refer to how our [breakpoint nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) is used.
 
 Where *sides* is one of:
 
+* blank - for classes that set a `margin` or `padding` on all 4 sides of the element
 * `t` - for classes that set `margin-top` or `padding-top`
 * `b` - for classes that set `margin-bottom` or `padding-bottom`
 * `l` - for classes that set `margin-left` or `padding-left`
 * `r` - for classes that set `margin-right` or `padding-right`
 * `x` - for classes that set both `*-left` and `*-right`
 * `y` - for classes that set both `*-top` and `*-bottom`
-* `a` - for classes that set a `margin` or `padding` on all 4 sides of the element
 
 Where *size* is one of:
 
 * `0` - for classes that eliminate the `margin` or `padding` by setting it to `0`
-* `0_25` - (by default) for classes that set the `margin` or `padding` to `$spacer-x * 0.25` or `$spacer-y * 0.25`
-* `0_5` - (by default) for classes that set the `margin` or `padding` to `$spacer-x * 0.5` or `$spacer-y * 0.5`
-* `1` - (by default) for classes that set the `margin` or `padding` to `$spacer-x` or `$spacer-y`
-* `1_5` - (by default) for classes that set the `margin` or `padding` to `$spacer-x * 1.5` or `$spacer-y * 1.5`
-* `2` - (by default) for classes that set the `margin` or `padding` to `$spacer-x * 2` or `$spacer-y * 2`
-* `3` - (by default) for classes that set the `margin` or `padding` to `$spacer-x * 3` or `$spacer-y * 3`
+* `0_25` - for classes that set the property to `$spacer-x * 0.25` or `$spacer-y * 0.25`
+* `0_5` - for classes that set the property to `$spacer-x * 0.5` or `$spacer-y * 0.5`
+* `1` - for classes that set the property to `$spacer-x` or `$spacer-y`
+* `1_5` - for classes that set the property to `$spacer-x * 1.5` or `$spacer-y * 1.5`
+* `2` - for classes that set the property to `$spacer-x * 2` or `$spacer-y * 2`
 
 (You can add more sizes by adding entries to the `$spacers` Sass map variable.)
 
 Here are some representative examples of these classes:
 
 {% highlight scss %}
-.margin-t-0 {
+.mt-0 {
   margin-top: 0 !important;
 }
 
-.margin-l-1 {
+.ml-1 {
   margin-left: $spacer-x !important;
 }
 
-.margin-md-t-1 {
-  margin-top: $spacer-x !important;
+.mt-md-1 {
+  margin-top: $spacer-y !important;
 }
 
-.padding-x-1_5 {
+.px-1_5 {
   padding-left: ($spacer-x * 1.5) !important;
   padding-right: ($spacer-x * 1.5) !important;
 }
 
-.padding-a-3 {
-  padding: ($spacer-y * 3) ($spacer-x * 3) !important;
+.p-2 {
+  padding: ($spacer-y * 2) ($spacer-x * 2) !important;
 }
 {% endhighlight %}
 
 ## Horizontal Centering
-Additionally, we also include an `.margin-x-auto` class for horizontally centering fixed-width block level content by setting the horizontal margins to `auto`.
+Additionally, we also include an `.mx-auto` class for horizontally centering fixed-width block level content by setting the horizontal margins to `auto`.
 
 <div class="cf-example">
-  <div class="margin-x-auto" style="width: 200px; background-color: rgba(86,61,124,.15);">
+  <div class="mx-auto" style="width: 200px; background-color: rgba(86,61,124,.15);">
     Centered element
   </div>
 </div>
 
 {% highlight html %}
-<div class="margin-x-auto" style="width: 200px;">
+<div class="mx-auto" style="width: 200px;">
   Centered element
 </div>
 {% endhighlight %}

--- a/docs/utilities/vertical-alignment.md
+++ b/docs/utilities/vertical-alignment.md
@@ -56,12 +56,12 @@ Using table cells.
 Slightly more complex uses, such as being able to align items in a row, become quick and easy.
 
 {% example html %}
-<div class="bg-gray-50 width-100 display-table">
-    <div class="display-table-cell valign-bottom">
+<div class="bg-gray-50 w-100 d-table">
+    <div class="d-table-cell valign-bottom">
         <a href="#">View more in teacher's guide</a> |
         <a href="#">Common Core alignment</a>
     </div>
-    <div class="display-table-cell valign-bottom text-right">
+    <div class="d-table-cell valign-bottom text-right">
         <button type="button" class="btn btn-primary btn-lg">Continue</button>
     </div>
 </div>

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -157,10 +157,6 @@ $spacers: (
     2: (
         x: ($spacer-x * 2),
         y: ($spacer-y * 2)
-    ),
-    3: (
-        x: ($spacer-x * 3),
-        y: ($spacer-y * 3)
     )
 ) !default;
 

--- a/scss/mixins/_border-radius.scss
+++ b/scss/mixins/_border-radius.scss
@@ -65,7 +65,7 @@
     // Add the dash for rule naming
     $sizerule: if($size, -#{$size}, "");
 
-    .radius-a#{$sizerule} {
+    .radius#{$sizerule} {
         @include border-radius($radius);
     }
     .radius-t#{$sizerule} {

--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -5,12 +5,12 @@
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {
-        .display#{$bprule}-none { display: none !important; }
-        .display#{$bprule}-block { display: block !important; }
-        .display#{$bprule}-flex { display: flex !important; }
-        .display#{$bprule}-inline-block { display: inline-block !important; }
-        .display#{$bprule}-inline { display: inline !important; }
-        .display#{$bprule}-table { display: table !important; }
-        .display#{$bprule}-table-cell { display: table-cell !important; }
+        .d#{$bprule}-none { display: none !important; }
+        .d#{$bprule}-block { display: block !important; }
+        .d#{$bprule}-flex { display: flex !important; }
+        .d#{$bprule}-inline-block { display: inline-block !important; }
+        .d#{$bprule}-inline { display: inline !important; }
+        .d#{$bprule}-table { display: table !important; }
+        .d#{$bprule}-table-cell { display: table-cell !important; }
     }
 }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -25,7 +25,7 @@
                 $length-x:   map-get($lengths, x);
                 $length-y:   map-get($lengths, y);
 
-                .#{$abbrev}#{$bprule}-#{$size}  { #{$prop}:        $length-y $length-x !important; } // All sides
+                .#{$abbrev}#{$bprule}-#{$size} { #{$prop}:         $length-y $length-x !important; } // All sides
                 .#{$abbrev}t#{$bprule}-#{$size} { #{$prop}-top:    $length-y !important; }
                 .#{$abbrev}r#{$bprule}-#{$size} { #{$prop}-right:  $length-x !important; }
                 .#{$abbrev}b#{$bprule}-#{$size} { #{$prop}-bottom: $length-y !important; }

--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -1,17 +1,17 @@
 // scss-lint:disable ImportantRule
 
 // Width
-.width-100 {
+.w-100 {
     width: 100% !important;
 }
 
 // Height
-.height-100 {
+.h-100 {
     height: 100% !important;
 }
 
 // Margin and Padding
-.margin-x-auto {
+.mx-auto {
     margin-right: auto !important;
     margin-left:  auto !important;
 }
@@ -20,23 +20,23 @@
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {
-        @each $prop, $abbrev in (margin: margin, padding: padding) {
+        @each $prop, $abbrev in (margin: m, padding: p) {
             @each $size, $lengths in $spacers {
                 $length-x:   map-get($lengths, x);
                 $length-y:   map-get($lengths, y);
 
-                .#{$abbrev}#{$bprule}-a-#{$size} { #{$prop}:        $length-y $length-x !important; } // a = All sides
-                .#{$abbrev}#{$bprule}-t-#{$size} { #{$prop}-top:    $length-y !important; }
-                .#{$abbrev}#{$bprule}-r-#{$size} { #{$prop}-right:  $length-x !important; }
-                .#{$abbrev}#{$bprule}-b-#{$size} { #{$prop}-bottom: $length-y !important; }
-                .#{$abbrev}#{$bprule}-l-#{$size} { #{$prop}-left:   $length-x !important; }
+                .#{$abbrev}#{$bprule}-#{$size}  { #{$prop}:        $length-y $length-x !important; } // All sides
+                .#{$abbrev}t#{$bprule}-#{$size} { #{$prop}-top:    $length-y !important; }
+                .#{$abbrev}r#{$bprule}-#{$size} { #{$prop}-right:  $length-x !important; }
+                .#{$abbrev}b#{$bprule}-#{$size} { #{$prop}-bottom: $length-y !important; }
+                .#{$abbrev}l#{$bprule}-#{$size} { #{$prop}-left:   $length-x !important; }
 
                 // Axes
-                .#{$abbrev}#{$bprule}-x-#{$size} {
+                .#{$abbrev}x#{$bprule}-#{$size} {
                     #{$prop}-right:  $length-x !important;
                     #{$prop}-left:   $length-x !important;
                 }
-                .#{$abbrev}#{$bprule}-y-#{$size} {
+                .#{$abbrev}y#{$bprule}-#{$size} {
                     #{$prop}-top:    $length-y !important;
                     #{$prop}-bottom: $length-y !important;
                 }
@@ -46,7 +46,7 @@
 }
 
 // Positioning
-.position-f-t {
+.pos-f-t {
     position: fixed;
     top: 0;
     right: 0;

--- a/scss/utilities/_visibility.scss
+++ b/scss/utilities/_visibility.scss
@@ -11,12 +11,12 @@
 
 // Hidden utilities
 @each $bp in map-keys($grid-breakpoints) {
-    .hidden-#{$bp}-up {
+    .hide-#{$bp}-up {
         @include media-breakpoint-up($bp) {
             display: none !important;
         }
     }
-    .hidden-#{$bp}-down {
+    .hide-#{$bp}-down {
         @include media-breakpoint-down($bp) {
             display: none !important;
         }
@@ -25,21 +25,21 @@
 
 // Print utilities
 // Media queries are placed on the inside to be mixin-friendly.
-.visible-print-block {
+.print-show-block {
     display: none !important;
 
     @media print {
         display: block !important;
     }
 }
-.visible-print-inline {
+.print-show-inline {
     display: none !important;
 
     @media print {
         display: inline !important;
     }
 }
-.visible-print-inline-block {
+.print-show-inline-block {
     display: none !important;
 
     @media print {
@@ -47,7 +47,7 @@
     }
 }
 
-.hidden-print {
+.print-hide {
     @media print {
         display: none !important;
     }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1375,7 +1375,7 @@ Showing a <kbd>kdb sample</kbd>
 </div>
 
 <h3>Custom Forms: Checkbox</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <label class="custom-control custom-checkbox">
     <input type="checkbox" class="custom-control-input">
     <span class="custom-control-indicator"></span>
@@ -1383,7 +1383,7 @@ Showing a <kbd>kdb sample</kbd>
   </label>
 </div>
 
-<div class="margin-b-1">
+<div class="mb-1">
   <label class="custom-control custom-checkbox">
     <input type="checkbox" class="custom-control-input">
     <span class="custom-control-indicator"></span>
@@ -1392,7 +1392,7 @@ Showing a <kbd>kdb sample</kbd>
 </div>
 
 <h3>Custom Forms: Radio</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <label class="custom-control custom-radio">
     <input id="radio1" name="radio" type="radio" class="custom-control-input">
     <span class="custom-control-indicator"></span>
@@ -1406,7 +1406,7 @@ Showing a <kbd>kdb sample</kbd>
 </div>
 
 <h3>Custom Forms: Disabled</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <label class="custom-control custom-checkbox">
     <input type="checkbox" class="custom-control-input" disabled>
     <span class="custom-control-indicator"></span>
@@ -1440,7 +1440,7 @@ Showing a <kbd>kdb sample</kbd>
 </div>
 
 <h3>Custom Forms: Stacked</h3>
-<div class="custom-controls-stacked margin-b-1">
+<div class="custom-controls-stacked mb-1">
   <label class="custom-control custom-radio">
     <input id="radioStacked1" name="radio-stacked" type="radio" class="custom-control-input">
     <span class="custom-control-indicator"></span>
@@ -1453,7 +1453,7 @@ Showing a <kbd>kdb sample</kbd>
   </label>
 </div>
 
-<div class="custom-controls-stacked margin-b-1">
+<div class="custom-controls-stacked mb-1">
   <label class="custom-control custom-radio">
     <input id="checkStacked1" type="checkbox" class="custom-control-input">
     <span class="custom-control-indicator"></span>
@@ -1468,7 +1468,7 @@ Showing a <kbd>kdb sample</kbd>
 
 
 <h3>Custom Forms: Select Menu</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <select class="custom-select">
     <option selected>Open this select menu</option>
     <option value="1">One</option>
@@ -1478,12 +1478,12 @@ Showing a <kbd>kdb sample</kbd>
 </div>
 
 <h3>Custom Forms: Color Picker</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <input class="custom-color" type="color" value="#117dba" id="color">
 </div>
 
 <h3>Custom Forms: File Browser</h3>
-<div class="margin-b-1">
+<div class="mb-1">
   <label class="custom-file">
     <input type="file" id="file" class="custom-file-input">
     <span class="custom-file-control"></span>

--- a/test/visual/flexbox-grid.html
+++ b/test/visual/flexbox-grid.html
@@ -283,7 +283,7 @@
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
         <!-- Add the extra clearfix for only the required viewport -->
-        <div class="clearfix hidden-sm-up"></div>
+        <div class="clearfix hide-sm-up"></div>
 
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
@@ -298,7 +298,7 @@
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
 
         <!-- Add the extra clearfix for only the required viewport -->
-        <div class="clearfix hidden-sm-up"></div>
+        <div class="clearfix hide-sm-up"></div>
 
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
         <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -191,7 +191,7 @@ Holder.addTheme("gray", {
 <hr />
 
 <h3>Select Sizing:</h3>
-<div class="margin-b-1">
+<div class="mb-1">
     <select class="form-control form-control-xl">
         <option>Extra large select</option>
     </select>
@@ -212,7 +212,7 @@ Holder.addTheme("gray", {
 <hr />
 
 <h3>Custom Select Sizing:</h3>
-<div class="margin-b-1">
+<div class="mb-1">
     <select class="custom-select custom-select-xl">
         <option>Extra large select</option>
     </select>


### PR DESCRIPTION
Ok, this is a big one.  The generated CSS is getting rather large due to all the features being pushed in. The palette system is 16k alone.

In order to save on some size, at the sacrifice of readability, but I think it is needed.   This re-aligns us with Bootstrap in some areas, and diverges in others.

Changes include:
### Spacing utils
- `.padding-{breakpoint}-{side}*` now `.p{side}-{breakpoint)` - so instead of  `'padding-sm-l-1` it is now `.pl-sm-1`
- same goes for margins
- dropped the `$spacer * 3` variant

### Display utils
  - `.display-*` is now `.d-*`

### Visibility utils
  - `.hidden-*` is now `.hide-8`
  - '.hidden-print` is now `.print-hide`
  - `.visible-print-*` is now `.print-show-*`

### Sizing/positioning utils:
  - `.width-100` is now `.w-100`
  - `.height-100` is now `.h-100`
  - `.position-*` is now `.pos-*`
