### PR TITLE
v2 - component size generation option

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -40,10 +40,11 @@ You can find and customize these variables for key global options in our `_setti
 | `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                 |
 | `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                    |
 | `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                          |
-| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `container`, `row`, `.col-md-1`, etc.). |
+| `$enable-grid-classes`      | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.container`, `.row`, `.col-md-1`, etc.). |
 | `$enable-print-styles`      | `true` (default) or `false`        | Enables predefined style overrides used when printing.                                           |
-| `$enable-palette`           | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500` etc.). |
-| `$enable-flex-opt`          | `true` (default) or `false`        | Enables the opt-in flexbox model using classes, such as `.row-flex`  .                           |
+| `$enable-palette`           | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500`, etc.). |
+| `$enable-sizing`            | `true` (default) or `false`        | Enables the generation of CSS classes for component sizes, and also for some utilites. (e.g. `.btn-sm`, `.radius-t-xs`, etc.). |
+| `$enable-flex-opt`          | `true` (default) or `false`        | Enables the opt-in flexbox model using classes, such as `.row-flex`.                             |
 | `$enable-flex-full`         | `true` or `false` (default)        | Enables the full flexbox model where all supported components will use `display: flex;`.         |
 
 If both `$enable-flex-opt` and `$enable-flex-full` are set to `true` the `$enable-flex-opt` option will be disabled.

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -49,6 +49,7 @@ $enable-transitions:    true !default;      // true
 $enable-grid-classes:   true !default;      // true
 $enable-print-styles:   true !default;      // true
 $enable-palette:        true !default;      // true
+$enable-sizing:         true !default;      // true
 $enable-flex-full:      false !default;     // false -- all-in flex mode
 $enable-flex-opt:       true !default;      // true -- opt-in via class mode
 
@@ -599,6 +600,7 @@ $list-group-item-heading-margin-bottom: .3em !default;
 $breadcrumb-padding-y:          .75rem !default;
 $breadcrumb-padding-x:          1rem !default;
 $breadcrumb-item-padding:       .5rem !default;
+$breadcrumb-border-radius:      $border-radius !default;
 
 $breadcrumb-bg:                 $uibase-50 !default;
 $breadcrumb-divider-color:      $uibase-400 !default;
@@ -608,25 +610,26 @@ $breadcrumb-divider:            "/" !default;
 
 // Pagination
 // =====
-$pagination-padding-x:                 $btn-padding-x !default;
-$pagination-padding-y:                 $btn-padding-y !default;
+$pagination-padding-x:          $btn-padding-x !default;
+$pagination-padding-y:          $btn-padding-y !default;
 
-$pagination-color:                     $link-color !default;
-$pagination-bg:                        $white !default;
-$pagination-border-width:              $border-width !default;
-$pagination-border-color:              $uibase-300 !default;
+$pagination-color:              $link-color !default;
+$pagination-bg:                 $white !default;
+$pagination-border-width:       $border-width !default;
+$pagination-border-color:       $uibase-300 !default;
+$pagination-border-radius:      $border-radius !default;
 
-$pagination-hover-color:               $link-hover-color !default;
-$pagination-hover-bg:                  $uibase-50 !default;
-$pagination-hover-border:              $uibase-300 !default;
+$pagination-hover-color:        $link-hover-color !default;
+$pagination-hover-bg:           $uibase-50 !default;
+$pagination-hover-border:       $uibase-300 !default;
 
-$pagination-active-color:              $active-color !default;
-$pagination-active-bg:                 $active-bg !default;
-$pagination-active-hover-color:        $active-color !default;
-$pagination-active-hover-bg:           $active-hover-bg !default;
+$pagination-active-color:       $active-color !default;
+$pagination-active-bg:          $active-bg !default;
+$pagination-active-hover-color: $active-color !default;
+$pagination-active-hover-bg:    $active-hover-bg !default;
 
-$pagination-disabled-color:            $uibase-500 !default;
-$pagination-disabled-bg:               darken($uibase-50, 10) !default;
+$pagination-disabled-color:     $uibase-500 !default;
+$pagination-disabled-bg:        darken($uibase-50, 10) !default;
 
 
 // Dropdowns

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -3,7 +3,7 @@
     margin-bottom: $spacer-y;
     list-style: none;
     background-color: $breadcrumb-bg;
-    @include border-radius($border-radius);
+    @include border-radius($breadcrumb-border-radius);
     @include clearfix;
 }
 

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -115,8 +115,10 @@
 
 // Sizing
 // Remix the button sizing classes into new ones for easier manipulation
-@each $size, $dims in $component-sizes {
-    .btn-group-#{$size} > .btn { @extend .btn-#{$size}; }
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        .btn-group-#{$size} > .btn { @extend .btn-#{$size}; }
+    }
 }
 
 // Split button dropdowns
@@ -124,12 +126,14 @@
     padding-right: $btn-padding-x * .75;
     padding-left: $btn-padding-x * .75;
 }
-@each $size, $dims in $component-sizes {
-    $padding-x:     map-get($dims, "padding-x");
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-padding-x: map-get($dims, "padding-x");
 
-    .btn-#{$size} > .dropdown-toggle-split {
-        padding-right: $padding-x * .75;
-        padding-left: $padding-x * .75;
+        .btn-#{$size} > .dropdown-toggle-split {
+            padding-right: $sz-padding-x * .75;
+            padding-left: $sz-padding-x * .75;
+        }
     }
 }
 

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -94,11 +94,13 @@
 
 // Sizing options
 // Remix the default form control sizing classes into new ones for easier manipulation.
-@each $size, $dims in $component-sizes {
-    .input-group-#{$size} > .form-control,
-    .input-group-#{$size} > .input-group-addon,
-    .input-group-#{$size} > .input-group-btn > .btn {
-        @extend .form-control-#{$size};
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        .input-group-#{$size} > .form-control,
+        .input-group-#{$size} > .input-group-addon,
+        .input-group-#{$size} > .input-group-btn > .btn {
+            @extend .form-control-#{$size};
+        }
     }
 }
 
@@ -116,16 +118,18 @@
     @include border-radius($border-radius);
 
     // Sizing
-    @each $size, $dims in $component-sizes {
-        $font-size:     map-get($dims, "font-size");
-        $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-        $padding-x:     map-get($dims, "padding-x");
-        $border-radius: map-get($dims, "border-radius");
+    @if $enable-sizing {
+        @each $size, $dims in $component-sizes {
+            $sz-font-size:     map-get($dims, "font-size");
+            $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+            $sz-padding-x:     map-get($dims, "padding-x");
+            $sz-border-radius: map-get($dims, "border-radius");
 
-        &.form-control-#{$size} {
-            padding: $padding-y $padding-x;
-            font-size: $font-size;
-            @include border-radius($border-radius);
+            &.form-control-#{$size} {
+                padding: $sz-padding-y $sz-padding-x;
+                font-size: $sz-font-size;
+                @include border-radius($sz-border-radius);
+            }
         }
     }
 

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -14,12 +14,12 @@
     &:first-child {
         .page-link {
             margin-left: 0;
-            @include border-left-radius($border-radius);
+            @include border-left-radius($pagination-border-radius);
         }
     }
     &:last-child {
         .page-link {
-            @include border-right-radius($border-radius);
+            @include border-right-radius($pagination-border-radius);
         }
     }
 
@@ -65,13 +65,15 @@
 
 
 // Sizing
-@each $size, $dims in $component-sizes {
-    $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y");
-    $padding-x:     map-get($dims, "padding-x");
-    $border-radius: map-get($dims, "border-radius");
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y");
+        $sz-padding-x:     map-get($dims, "padding-x");
+        $sz-border-radius: map-get($dims, "border-radius");
 
-    .pagination-#{$size} {
-        @include pagination-size($padding-y, $padding-x, $font-size, $border-radius);
+        .pagination-#{$size} {
+            @include pagination-size($sz-padding-y, $sz-padding-x, $sz-font-size, $sz-border-radius);
+        }
     }
 }

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -115,14 +115,16 @@ fieldset[disabled] a.btn {
 }
 
 // Button sizes
-@each $size, $dims in $component-sizes {
-    $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y");
-    $padding-x:     map-get($dims, "padding-x");
-    $border-radius: map-get($dims, "border-radius");
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y");
+        $sz-padding-x:     map-get($dims, "padding-x");
+        $sz-border-radius: map-get($dims, "border-radius");
 
-    .btn-#{$size} {
-        @include button-size($padding-y, $padding-x, $font-size, $border-radius);
+        .btn-#{$size} {
+            @include button-size($sz-padding-y, $sz-padding-x, $sz-font-size, $sz-border-radius);
+        }
     }
 }
 

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -172,17 +172,19 @@
 }
 
 // Select sizes
-@each $size, $dims in $component-sizes {
-    $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-    $padding-x:     map-get($dims, "padding-x");
-    $input-height-size:     (($font-size * $input-line-height) + ($padding-y * 2));
-    $select-height-size:    calc(#{$input-height-size} + #{($border-width * 2)});
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+        $sz-padding-x:     map-get($dims, "padding-x");
+        $sz-input-height:  (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
+        $sz-select-height: calc(#{$sz-input-height} + #{($border-width * 2)});
 
-    .custom-select-#{$size} {
-        height: $select-height-size;
-        padding: $padding-y ($padding-x / 2);
-        font-size:  $font-size;
+        .custom-select-#{$size} {
+            height: $sz-select-height;
+            padding: $sz-padding-y ($sz-padding-x / 2);
+            font-size: $sz-font-size;
+        }
     }
 }
 

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -66,17 +66,19 @@ select.form-control {
     }
 
     // Sizes
-    @each $size, $dims in $component-sizes {
-        $font-size:     map-get($dims, "font-size");
-        $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-        $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
-        $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
+    @if $enable-sizing {
+        @each $size, $dims in $component-sizes {
+            $sz-font-size:     map-get($dims, "font-size");
+            $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+            $sz-input-height:  (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
+            $sz-select-height: calc(#{$sz-input-height} + #{($border-width * 2)});
 
-        &.form-control-#{$size}:not([size]):not([multiple]),
-        .input-group-#{$size} &.form-control:not([size]):not([multiple]) {
-            height: $select-height-size;
-            padding-top: $padding-y;
-            padding-bottom: $padding-y;
+            &.form-control-#{$size}:not([size]):not([multiple]),
+            .input-group-#{$size} &.form-control:not([size]):not([multiple]) {
+                height: $sz-select-height;
+                padding-top: $sz-padding-y;
+                padding-bottom: $sz-padding-y;
+            }
         }
     }
 
@@ -113,17 +115,17 @@ textarea.form-control {
     margin-bottom: 0; // Override the `<label>` default
 }
 // Label sizes
-@each $size, $dims in $component-sizes {
-    $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-    $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
-    $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
 
-    .form-control-label-#{$size} {
-        height: $select-height-size;
-        padding-top: $padding-y;
-        padding-bottom: $padding-y;
-        font-size:  $font-size;
+        .form-control-label-#{$size} {
+            padding-top: calc(#{$sz-padding-y} + #{$border-width});
+            padding-bottom: calc(#{$sz-padding-y} + #{$border-width});
+            margin-bottom: 0;
+            font-size: $sz-font-size;
+        }
     }
 }
 
@@ -158,14 +160,16 @@ input[type="month"] {
         line-height: $input-height;
     }
 
-    @each $size, $dims in $component-sizes {
-        $font-size:     map-get($dims, "font-size");
-        $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-        $input-height-size: (($font-size * $input-line-height) + ($padding-y * 2));
+    @if $enable-sizing {
+        @each $size, $dims in $component-sizes {
+            $sz-font-size:    map-get($dims, "font-size");
+            $sz-padding-y:    map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+            $sz-input-height: (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
 
-        &.form-control-#{$size},
-        .input-group-#{$size} &.form-control {
-            line-height: $input-height-size;
+            &.form-control-#{$size},
+            .input-group-#{$size} &.form-control {
+                line-height: $sz-input-height;
+            }
         }
     }
 }
@@ -184,10 +188,12 @@ input[type="month"] {
     // Remove default margin from `p`
     margin-bottom: 0;
 
-    @each $size, $dims in $component-sizes {
-        &.form-control-#{$size} {
-            padding-right: 0;
-            padding-left: 0;
+    @if $enable-sizing {
+        @each $size, $dims in $component-sizes {
+            &.form-control-#{$size} {
+                padding-right: 0;
+                padding-left: 0;
+            }
         }
     }
 }
@@ -199,24 +205,26 @@ input[type="month"] {
 //
 // The `.form-group-* form-control` variations are sadly duplicated to avoid the
 // issue documented in https://github.com/twbs/bootstrap/issues/15074.
-@each $size, $dims in $component-sizes {
-    $font-size:     map-get($dims, "font-size");
-    $padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $font-size / 2);
-    $padding-x:     map-get($dims, "padding-x");
-    $border-radius: map-get($dims, "border-radius");
-    $input-height-size:      (($font-size * $input-line-height) + ($padding-y * 2));
-    $select-height-size:     calc(#{$input-height-size} + #{($border-width * 2)});
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+        $sz-padding-x:     map-get($dims, "padding-x");
+        $sz-border-radius: map-get($dims, "border-radius");
+        $sz-input-height:  (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
+        $sz-select-height: calc(#{$sz-input-height} + #{($border-width * 2)});
 
-    .form-control-#{$size} {
-        height: $select-height-size;
-        padding: $padding-y ($padding-x / 2);
-        font-size: $font-size;
-        @include border-radius($border-radius);
+        .form-control-#{$size} {
+            height: $sz-select-height;
+            padding: $sz-padding-y ($sz-padding-x / 2);
+            font-size: $sz-font-size;
+            @include border-radius($sz-border-radius);
 
-        // Color input - reduce horizontal padding otherwise visualy unsable in Chrome
-        &[type="color"] {
-            padding-top: ($input-padding-y / 2);
-            padding-bottom: ($input-padding-y / 2);
+            // Color input - reduce horizontal padding otherwise visualy unsable in Chrome
+            &[type="color"] {
+                padding-top: ($input-padding-y / 2);
+                padding-bottom: ($input-padding-y / 2);
+            }
         }
     }
 }

--- a/scss/utilities/_radius.scss
+++ b/scss/utilities/_radius.scss
@@ -8,11 +8,13 @@
 @include radius-corners($radius-border-radius);
 
 // Radius - Component sizes
-@each $size, $dims in $component-sizes {
-    $border-radius: map-get($dims, "border-radius");
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-border-radius: map-get($dims, "border-radius");
 
-    @include radius-sides($border-radius, $size);
-    @include radius-corners($border-radius, $size);
+        @include radius-sides($sz-border-radius, $size);
+        @include radius-corners($sz-border-radius, $size);
+    }
 }
 
 // Radius removal

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -45,6 +45,9 @@ Holder.addTheme("gray", {
       <div class="col-md-2 text-right">
         <button type="button" class="btn btn-primary btn-xs">Test</button>
       </div>
+      <div class="col-md-1">
+        <label class="form-control-label-xs">Label</label>
+      </div>
       <fieldset class="form-group col-md-3">
         <label for="size0-0" class="sr-only">Example label</label>
         <input type="text" class="form-control form-control-xs" id="size0-0" placeholder="Example input">
@@ -73,6 +76,9 @@ Holder.addTheme("gray", {
     <form class="row">
       <div class="col-md-2 text-right">
         <button type="button" class="btn btn-primary btn-sm">Test</button>
+      </div>
+      <div class="col-md-1">
+        <label class="form-control-label-sm">Label</label>
       </div>
       <fieldset class="form-group col-md-3">
         <label for="size1-0" class="sr-only">Example label</label>
@@ -103,6 +109,9 @@ Holder.addTheme("gray", {
       <div class="col-md-2 text-right">
         <button type="button" class="btn btn-primary">Test</button>
       </div>
+      <div class="col-md-1">
+        <label class="form-control-label">Label</label>
+      </div>
       <fieldset class="form-group col-md-3">
         <label for="size2-0" class="sr-only">Example label</label>
         <input type="text" class="form-control" id="size2-0" placeholder="Example input">
@@ -132,6 +141,9 @@ Holder.addTheme("gray", {
       <div class="col-md-2 text-right">
         <button type="button" class="btn btn-primary btn-lg">Test</button>
       </div>
+      <div class="col-md-1">
+        <label class="form-control-label-lg">Label</label>
+      </div>
       <fieldset class="form-group col-md-3">
         <label for="size3-0" class="sr-only">Example label</label>
         <input type="text" class="form-control form-control-lg" id="size3-0" placeholder="Example input">
@@ -160,6 +172,9 @@ Holder.addTheme("gray", {
     <form class="row">
       <div class="col-md-2 text-right">
         <button type="button" class="btn btn-primary btn-xl">Test</button>
+      </div>
+      <div class="col-md-1">
+        <label class="form-control-label-xl">Label</label>
       </div>
       <fieldset class="form-group col-md-3">
         <label for="size4-0" class="sr-only">Example label</label>


### PR DESCRIPTION
Add `$enable-sizing` option to `_settings.css` to toggle generation of component sizing classes.

Also fixed the sizing routines so that they no longer override global vars resulting in incorrect settings for later components.

A few more tweaks to the `.form-control-label-{size}` routine to remove forced height and get the alignment a bit more correct.

Also added new vars for border-radius on breadcrumb and pagination components.