### PR TITLE
rename modal settings to match use case

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -852,8 +852,8 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 $modal-dialog-margin:           .625rem !default;
 $modal-dialog-sm-up-margin-y:   1.875rem !default;
 
-$modal-header-padding-y:         .75rem !default;
-$modal-header-padding-x:         1rem !default;
+$modal-header-padding-y:        .75rem !default;
+$modal-header-padding-x:        1rem !default;
 $modal-title-line-height:       $line-height-base !default;
 
 $modal-inner-padding-y:         .75rem !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -852,8 +852,8 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 $modal-dialog-margin:           .625rem !default;
 $modal-dialog-sm-up-margin-y:   1.875rem !default;
 
-$modal-title-padding-y:         .75rem !default;
-$modal-title-padding-x:         1rem !default;
+$modal-header-padding-y:         .75rem !default;
+$modal-header-padding-x:         1rem !default;
 $modal-title-line-height:       $line-height-base !default;
 
 $modal-inner-padding-y:         .75rem !default;

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -78,7 +78,7 @@
 // Modal header
 // Top section of the modal w/ title and dismiss
 .modal-header {
-    padding: $modal-title-padding-y $modal-title-padding-x;
+    padding: $modal-header-padding-y $modal-header-padding-x;
     border-bottom: $modal-header-border-width solid $modal-header-border-color;
     @include clearfix;
 }


### PR DESCRIPTION
rename Sass settings `$modal-title-padding-*` to `$modal-header-padding-*` to match where the settings are being used