### PR TITLE
v2 - Widget-Modal: tweak modal sizes

### DIFF
--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -224,7 +224,7 @@ To take advantage of the grid system within a modal, just nest `.container-fluid
 
 ### Optional Sizes
 
-Modals have two optional sizes, provided by Bootstrap's base CSS, available via modifier classes to be placed on a `.modal-dialog`.
+Modals have two optional sizes, provided by Figuration's base CSS, available via modifier classes to be placed on a `.modal-dialog`.
 
 <div class="modal" id="modalLg">
     <div class="modal-dialog modal-lg">

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -877,9 +877,9 @@ $modal-header-border-width:     $modal-content-border-width !default;
 $modal-footer-border-width:     $modal-header-border-width !default;
 $modal-border-radius:           .3rem !default;
 
-$modal-sm:                      rem-calc(300px) !default;
-$modal-md:                      rem-calc(600px) !default;
-$modal-lg:                      rem-calc(900px) !default;
+$modal-sm:                      rem-calc(304px) !default; // 304px=>19rem
+$modal-md:                      rem-calc(528px) !default; // 528px=>33rem
+$modal-lg:                      rem-calc(896px) !default; // 896px=>56rem
 
 $modal-breakpoint:              sm !default; // When to start scaling up modal width
 $modal-lg-breakpoint:           lg !default; // The minimum breakpoint to allow `.modal-lg`


### PR DESCRIPTION
- Reduce regular (md) modal size to be a bit more responsive friendly.
- Tweak all sizes to result in whole number rem output.
- Also remove incorrect framework name.