### PR TITLE
v2- Add global option for generating smallest breakpoint CSS rules

### DIFF
--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -14,7 +14,7 @@ Customize Figuration with our built-in custom variables file and easily toggle g
 
 ## Customizing Variables
 
-Figuration ships with a `_custom.scss` file for an easy method of overriding the default variables found in `_settings.scss`. Copy and paste relevant lines from `_settings.scss` into the custom file, modify the values, and recompile your Sass to change our default values. **Be sure to remove the `!default` flag from override values.**
+Figuration ships with a `/scss/_custom.scss` file for an easy method of overriding the default variables found in `/scss/_settings.scss`. Copy and paste relevant lines from `/scss/_settings.scss` into the `/scss/_custom.scss` file, modify the values, and recompile your Sass to change our default values. **Be sure to remove the `!default` flag from override values.**
 
 For example, to change out the `background-color` and `color` for the `<body>`, you'd do the following:
 
@@ -44,6 +44,7 @@ You can find and customize these variables for key global options in our `_setti
 | `$enable-print-styles`      | `true` (default) or `false`        | Enables predefined style overrides used when printing.                                           |
 | `$enable-palette`           | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500`, etc.). |
 | `$enable-sizing`            | `true` (default) or `false`        | Enables the generation of CSS classes for component sizes, and also for some utilites. (e.g. `.btn-sm`, `.radius-t-xs`, etc.). |
+| `$enable-bp-smallest`       | `true` or `false` (default)        | Enables the generation of CSS classes for breakpoint sizes that include the smallest breakpoint designator. (e.g. `.col-xs-12`).  Also refer to the [Breakpoint Nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) section. |
 | `$enable-flex-opt`          | `true` (default) or `false`        | Enables the opt-in flexbox model using classes, such as `.row-flex`.                             |
 | `$enable-flex-full`         | `true` or `false` (default)        | Enables the full flexbox model where all supported components will use `display: flex;`.         |
 

--- a/docs/layout/overview.md
+++ b/docs/layout/overview.md
@@ -178,7 +178,7 @@ The Sass mixin for the above example look like that shown beneath:
 
 ## Breakpoint Nomenclature
 
-Since Figuration is built as a mobile first framework, we have created our class naming structure to **not** use the smallest breakpoint designation, except for a few certain instances.
+Since Figuration is built as a mobile first framework, by default, we have created our class naming structure to **not** use the smallest breakpoint designation, except for a few certain instances.  However, this is configurable for custom builds by overriding `$enable-bp-smallest` option referenced in the [Global Options]({{ site.baseurl }}/get-started/options/#global-options) settings.
 
 Classes that apply to all breakpoints, from `xs` to `xl`, have no breakpoint abbreviation in them. This is because those classes are applied from `min-width: 0` and up, and thus are not bound by a media query. The remaining breakpoints, however, do include a breakpoint abbreviation.
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -50,6 +50,7 @@ $enable-grid-classes:   true !default;      // true
 $enable-print-styles:   true !default;      // true
 $enable-palette:        true !default;      // true
 $enable-sizing:         true !default;      // true
+$enable-bp-smallest:    false !default;     // false
 $enable-flex-full:      false !default;     // false -- all-in flex mode
 $enable-flex-opt:       true !default;      // true -- opt-in via class mode
 

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -61,7 +61,7 @@
 //    -lg
 @function breakpoint-designator($name, $breakpoints: $grid-breakpoints) {
     $min: map-get($breakpoints, $name);
-    @return if($min != 0, -#{$name}, "");
+    @return if($min != 0 or $enable-bp-smallest, -#{$name}, "");
 }
 
 // Media of at least the minimum breakpoint width. No query for the smallest breakpoint.


### PR DESCRIPTION
Add `$enable-bp-smallest` to Sass global options to generate CSS rules that include the smallest breakpoint (`xs` by default).

By default this option is `false` to keep with our current mobile-first naming scheme.

When set to `true`, all grid, utility, and anything that uses the responsive breakpoints will get the `-xs` inserted into the name.

For example, the default is to generate a `.col-12` rule for full width columns.  When set to `true` the `.col-12` will be replaced with `.col-xs-12`.  Same thing for utilities, `.padding-0` is replaced with `.padding-xs-0`.

This might be useful for others who would like a more structured naming scheme.