### PR TITLE
v2 - Custom-file and custom--select tweaks

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -514,9 +514,7 @@ $custom-checkbox-indeterminate-box-shadow:  none !default;
 $custom-radio-radius:               50% !default;
 $custom-radio-checked-icon:         url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='3' fill='%23fff'/%3E%3C/svg%3E") !default;
 
-$custom-select-padding-y:           $input-padding-y !default;
-$custom-select-padding-x:           $input-padding-x !default;
-$custom-select-indicator-padding:   1rem !default; // Extra padding to account for the presence of the background-image based indicator
+$custom-select-indicator-padding:   .75rem !default; // Extra padding to account for the presence of the background-image based indicator
 $custom-select-color:               $input-color !default;
 $custom-select-disabled-color:      $text-muted !default;
 $custom-select-bg:                  $white !default;
@@ -533,13 +531,9 @@ $custom-select-focus-box-shadow:    inset 0 .0625rem .125rem rgba(0,0,0,.075), 0
 $custom-select-sm-padding-y:        .2rem !default;
 $custom-select-sm-font-size:        75% !default;
 
-$custom-file-height:                2.5rem !default;
 $custom-file-width:                 14rem !default;
 $custom-file-focus-box-shadow:      0 0 0 .075rem #fff, 0 0 0 .2rem map-get($context-colors, "primary") !default;
 
-$custom-file-padding-x:             .5rem !default;
-$custom-file-padding-y:             1rem !default;
-$custom-file-line-height:           1.5 !default;
 $custom-file-color:                 $uibase-600 !default;
 $custom-file-bg:                    $white !default;
 $custom-file-border-width:          $border-width !default;

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -127,11 +127,11 @@
     display: block;
     width: 100%;
     height: $select-height;
-    padding: $custom-select-padding-y ($custom-select-padding-x + $custom-select-indicator-padding) $custom-select-padding-y $custom-select-padding-x;
-    padding-right: $custom-select-padding-x \9;
+    padding: $input-padding-y (($input-padding-x / 2) + $custom-select-indicator-padding) $input-padding-y ($input-padding-x / 2);
+    padding-right: ($input-padding-x / 2) \9;
     color: $custom-select-color;
     vertical-align: middle;
-    background: $custom-select-bg $custom-select-indicator no-repeat right $custom-select-padding-x center;
+    background: $custom-select-bg $custom-select-indicator no-repeat right ($input-padding-x / 2) center;
     background-image: none \9;
     background-size: $custom-select-bg-size;
     border: $custom-select-border-width solid $custom-select-border-color;
@@ -180,8 +180,9 @@
             height: $sz-select-height;
             padding: $sz-padding-y ($sz-padding-x / 2);
             padding-right: ($sz-padding-x + $custom-select-indicator-padding);
-            padding-right: $custom-select-padding-x \9;
+            padding-right: ($sz-padding-x / 2) \9;
             font-size: $sz-font-size;
+            background-position: right ($sz-padding-x / 2) center;
         }
         //scss-lint:enable DuplicateProperty
     }
@@ -193,7 +194,7 @@
     position: relative;
     display: inline-block;
     max-width: 100%;
-    height: $custom-file-height;
+    height: $select-height;
     cursor: pointer;
 }
 
@@ -215,9 +216,9 @@
     right: 0;
     left: 0;
     z-index: 5;
-    height: $custom-file-height;
-    padding: $custom-file-padding-x $custom-file-padding-y;
-    line-height: $custom-file-line-height;
+    height: $select-height;
+    padding: $input-padding-y ($input-padding-x / 2);
+    line-height: $input-line-height;
     color: $custom-file-color;
     user-select: none;
     background-color: $custom-file-bg;
@@ -238,9 +239,9 @@
         bottom: -$custom-file-border-width;
         z-index: 6;
         display: block;
-        height: $custom-file-height;
-        padding: $custom-file-padding-x $custom-file-padding-y;
-        line-height: $custom-file-line-height;
+        height: $select-height;
+        padding: $input-padding-y $input-padding-x;
+        line-height: $input-line-height;
         color: $custom-file-button-color;
         background-color: $custom-file-button-bg;
         border: $custom-file-border-width solid $custom-file-border-color;


### PR DESCRIPTION
- Correct the height and padding of `.custom-file` to match input height and button padding.
- Update `.custom-select` background image position to be a better visual match to input text padding.
- Use more global input/select sizing variable to keep things aligned, remove some now unneeded settings vars.