### PR TITLE
Normalize the component sizes a bit

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -331,15 +331,15 @@ $component-sizes: (
         border-radius:  .1875rem
     ),
     lg: (
-        font-size:      1.25rem,
-        padding-y:      .625rem,
-        padding-x:      1.25rem,
+        font-size:      1.125rem,
+        padding-y:      .5rem,
+        padding-x:      1.125rem,
         border-radius:  .3125rem
     ),
     xl: (
-        font-size:      1.5rem,
-        padding-y:      .75rem,
-        padding-x:      1.5rem,
+        font-size:      1.25rem,
+        padding-y:      .625rem,
+        padding-x:      1.25rem,
         border-radius:  .3125rem
     )
 ) !default;


### PR DESCRIPTION
The `lg` and `xl` sizes were scaling faster than the smaller sizes, this brings them back into alignment more.