### PR TITLE
Widget-Dropdown: rework

### DIFF
--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -46,7 +46,7 @@ Here is a static example showing the dropdown layout and content pieces.
                     <li><a href="#">Something else here</a></li>
                 </ul>
             </li>
-            <li class="divider"></li>
+            <li class="dropdown-divider"></li>
             <li><a href="#">Separated link</a></li>
         </ul>
     </div>
@@ -60,10 +60,10 @@ Because of the support for nested dropdown menus, it is currently **required to 
 
 {% example html %}
 <div class="dropdown">
-  <a href="#" role="button" class="dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownMenu1">
+  <a href="#" role="button" class="dropdown-toggle" data-cfw="dropdown">
     Dropdown
   </a>
-  <ul class="dropdown-menu" id="dropdownMenu1">
+  <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
     <li><a href="#">Something else here</a></li>
@@ -77,10 +77,10 @@ You can optionally use `<button>` elements in your dropdowns instead of `<a>`s. 
 
 {% example html %}
 <div class="btn-group">
-  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownMenu2">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
     Dropdown
   </button>
-  <ul class="dropdown-menu" id="dropdownMenu2">
+  <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
     <li><a href="#">Something else here</a></li>
@@ -97,10 +97,10 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 {% example html %}
 <div class="btn-group">
   <button type="button" class="btn">Default</button>
-  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownMenu3">
+  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
     <span class="sr-only">Toggle Dropdown</span>
   </button>
-  <ul class="dropdown-menu" id="dropdownMenu3">
+  <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
     <li><a href="#">Something else here</a></li>
@@ -117,12 +117,12 @@ Dropdowns also work in a navbar, but require the use of a wrapping element for p
     <a href="#" class="navbar-brand">Navbar</a>
     <ul class="nav navbar-nav">
         <li class="nav-item dropdown">
-            <a href="#" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownNav1">Dropdown</a>
-            <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownNav1">
+            <a href="#" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+            <ul class="dropdown-menu">
                 <li><a href="#">Action</a></li>
                 <li><a href="#">Another action</a></li>
                 <li><a href="#">Something else here</a></li>
-                <li class="divider"></li>
+                <li class="dropdown-divider"></li>
                 <li><a href="#">Separated link</a></li>
             </ul>
         </li>
@@ -196,22 +196,48 @@ Add `.active` to the `li` item in the dropdown to show a visual emphasis.
 
 ### 'Back' Menu Items
 
-Using the [dropdown widget options](#options) you can have 'back' menu items automatically inserted into all submenus.  These links will close the current submenu and move focus back onto the parent menu item.  This can be useful if the parent menu/submenu item is being hidden, or obscured by the current submenu.
+Using the [`backlink` option](#options), you can have 'back' menu items automatically inserted into all submenus.  These links will close the current submenu and move focus back onto the parent menu item.  This can be useful if the parent menu/submenu item is being hidden, or obscured by the current submenu.
 
-See the [menu alignment](#menu-alignment) section for an example of injected 'back' menu items.
+{% example html %}
+<div class="dropdown">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+        Dropdown
+    </button>
+    <ul class="dropdown-menu">
+        <li><a href="#">Action</a></li>
+        <li><a href="#">Another action</a></li>
+        <li>
+            <a href="#">Something else here</a>
+            <ul>
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li>
+                    <a href="#">Something else here</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-divider"></li>
+        <li class="disabled"><a href="#">Disabled item</a></li>
+    </ul>
+</div>
+{% endexample %}
 
 ## Variants
 
 ### Dropup
 
-Trigger dropdown menus above elements by adding `.dropup` to the parent element.  A `.caret` or `.dropdown-toggle` will reverse direction automatically.
+Trigger dropdown menus above elements by adding `.dropup` to the parent element.  The visual `.caret` or `.dropdown-toggle` for the toggle control will reverse direction automatically.
 
 {% example html %}
 <div class="dropdown dropup">
-  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownVar1">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
     Dropup
   </button>
-  <ul class="dropdown-menu" id="dropdownVar1">
+  <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
     <li><a href="#">Something else here</a></li>
@@ -220,10 +246,10 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 
 <div class="btn-group dropup">
   <button type="button" class="btn">Split Dropup</button>
-  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownVar2">
+  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
     <span class="sr-only">Toggle Dropdown</span>
   </button>
-  <ul class="dropdown-menu" id="dropdownVar2">
+  <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
     <li><a href="#">Something else here</a></li>
@@ -238,11 +264,11 @@ By default, a dropdown menu is automatically positioned 100% from the top and al
 Add `.dropdown-menu-left` to a `.dropdown-menu` to right align the dropdown menu, this will also make all submenus open to the left side.  This can also be combined with `.dropup`.
 
 {% example html %}
-<div class="btn-group dropdown-menu-left" style="float: right;">
-    <button type="button" class="btn btn-primary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownVar3" data-cfw-dropdown-backlink="true">
+<div class="btn-group dropdown-menu-left float-right">
+    <button type="button" class="btn btn-primary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Left
     </button>
-    <ul data-cfw-dropdown-target="dropdownVar3">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li><a href="#">Another action</a></li>
@@ -258,11 +284,11 @@ Add `.dropdown-menu-left` to a `.dropdown-menu` to right align the dropdown menu
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="divider"></li>
+                <li class="dropdown-divider"></li>
                 <li><a href="#">Separated link</a></li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li class="disabled"><a href="#">Disabled link</a></li>
     </ul>
 </div>
@@ -274,10 +300,10 @@ The menu alignment class of `.dropdown-menu-left` will also work with submenu it
 
 {% example html %}
 <div class="btn-group">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub1" data-cfw-dropdown-backlink="true">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Dropdown
     </button>
-    <ul data-cfw-dropdown-target="dropdownSub1">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -318,7 +344,7 @@ The menu alignment class of `.dropdown-menu-left` will also work with submenu it
                 </li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li class="disabled"><a href="#">Separated link</a></li>
     </ul>
 </div>
@@ -334,13 +360,15 @@ Note: The `data-cfw="dropdown"` attribute is relied on for closing dropdown menu
 
 ### Via Data Attributes
 
-Add `data-cfw="dropdown"` and a `data-cfw-dropdown-toggle` with a selector (jQuery style) or string value to then element to automatically assign control of a dropdown element.
-If using a string value, then assign a `data-cfw-dropdown-target` attribute, with a matching value to the element to apply the collapse to.
+Add `data-cfw="dropdown"` to the dropdown toggle element, and the widget will automatically link to the sibling `.dropdown-menu` list element.
+
+Optionally, you can use a `data-cfw-dropdown-toggle` with a selector (jQuery style) or string value to then element to automatically assign control of a dropdown element.
+If using a string value, then assign a `data-cfw-dropdown-target` attribute, with a matching value to the element to apply the control to.
 Be sure to add the class `dropdown-menu` to the dropdown menu to ensure there is no flash of content at page load.
 
 {% highlight html %}
 <div class="dropdown">
-  <a href="#" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownExample">Dropdown trigger</a>
+  <a href="#" role="button" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownExample">Dropdown trigger</a>
   <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownExample">
     ...
   </ul>

--- a/docs/widgets/scrollspy.md
+++ b/docs/widgets/scrollspy.md
@@ -28,7 +28,7 @@ Scroll the area below the navbar and watch the active class change. The dropdown
                 <ul data-cfw-dropdown-target="dropdownS">
                     <li><a href="#one" tabindex="-1">one</a></li>
                     <li><a href="#two" tabindex="-1">two</a></li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#three" tabindex="-1">three</a></li>
                 </ul>
             </li>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -123,19 +123,34 @@
                 'aria-expanded': 'false'
             });
 
-            if ($selfRef.settings.backlink && $selfRef.settings.backtop) {
-                this.$menuElm.prepend('<li class="' + CFW_Widget_Dropdown.CLASSES.backLink + '"><a href="#">' + $selfRef.settings.backtext + '</a></li>');
+            if (this.settings.backlink && this.settings.backtop) {
+                var $backTop = $('<li class="' + CFW_Widget_Dropdown.CLASSES.backLink + '"><a href="#">' + $selfRef.settings.backtext + '</a></li>')
+                    .prependTo(this.$menuElm);
+                if (this.$menuElm.hasClass('dropdown-menu-left')) {
+                    $backTop.addClass('dropdown-back-left');
+                }
             }
 
-            // Check for sub menu items and add indicator and id as needed
+            // Check for sub menu items and add indicator, id, and direction as needed
             this.$menuElm.find('ul').each(function() {
                 var $subMenu = $(this);
                 var $subLink = $subMenu.closest('li').find('a').eq(0);
                 var subLinkID = $selfRef._getID($subLink, 'cfw-dropdown');
                 // var subMenuID = $selfRef._getID($subMenu, 'cfw-dropdown');
 
+                var $dirNode = $subMenu.closest('.dropdown-menu-left, .dropdown-menu-right');
+                if ($dirNode.hasClass('dropdown-menu-left')) {
+                    $subMenu.closest('li').addClass('dropdown-subalign-left');
+                } else {
+                    $subMenu.closest('li').addClass('dropdown-subalign-right');
+                }
+
                 if ($selfRef.settings.backlink) {
-                    $subMenu.prepend('<li class="' + CFW_Widget_Dropdown.CLASSES.backLink + '"><a href="#">' + $selfRef.settings.backtext + '</a></li>');
+                    var $backElm = $('<li class="' + CFW_Widget_Dropdown.CLASSES.backLink + '"><a href="#">' + $selfRef.settings.backtext + '</a></li>')
+                        .prependTo($subMenu);
+                    if ($dirNode.hasClass('dropdown-menu-left')) {
+                        $backElm.addClass('dropdown-back-left');
+                    }
                 }
 
                 $subMenu.attr({
@@ -152,9 +167,8 @@
                 });
             });
 
-            // Set role on all li items - including any injected ones
-            // $('li', this.$menuElm).attr('role', 'presentation');
-            $('li.divider, .dropdown-divider', this.$menuElm).attr('role', 'separator');
+            // Set role on dividers
+            $('.dropdown-divider', this.$menuElm).attr('role', 'separator');
 
             // Touch OFF - Hover mode
             if (!this.settings.isTouch && this.settings.hover) {

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -636,8 +636,12 @@ $dropdown-margin-top:            .125rem !default;
 $dropdown-bg:                    $white !default;
 $dropdown-border-color:          $uibase-300 !default;
 $dropdown-border-width:          $border-width !default;
+$dropdown-border-radius:         $border-radius !default;
 $dropdown-divider-color:         $uibase-300 !default;
 $dropdown-box-shadow:            0 .2rem .3rem rgba(0,0,0,.175) !default;
+
+// Border radius where menu/submenu aligns or 'attaches' to control item.
+$dropdown-attach-border-radius:  0 !default;
 
 $dropdown-link-color:            $uibase-900 !default;
 $dropdown-link-hover-color:      $uibase-900 !default;
@@ -656,8 +660,9 @@ $dropdown-header-font-size:      .875rem !default;
 $dropdown-header-font-weight:    $font-weight-normal !default;
 $dropdown-header-color:          $uibase-400 !default;
 
-$dropdown-caret-color:          $uibase-400 !default;
 $dropdown-caret-width:          .45rem !default;
+$dropdown-caret-color:          $uibase-400 !default;
+$dropdown-caret-active-color:   $active-color !default;
 
 
 // Navs

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -61,7 +61,7 @@
     background-color: $dropdown-bg;
     background-clip: padding-box;
     border: $dropdown-border-width solid $dropdown-border-color;
-    @include border-radius(0 $border-radius $border-radius $border-radius);
+    @include border-radius($dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-border-radius);
     @include box-shadow($dropdown-box-shadow);
 }
 
@@ -123,7 +123,7 @@
         left: 100%;
         //margin-top: -($dropdown-margin-top + $dropdown-padding-y - $border-width);
         margin-top: calc(-#{($dropdown-margin-top + $dropdown-padding-y)} + #{$border-width});
-        @include border-radius(0 $border-radius $border-radius $border-radius);
+        @include border-radius($dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-border-radius);
     }
     > a::after {
         position: absolute;
@@ -138,20 +138,8 @@
         border-bottom: $dropdown-caret-width solid transparent;
         border-left: $dropdown-caret-width solid $dropdown-caret-color;
     }
-    &:hover > a::after {
-        border-left-color: $dropdown-caret-color;
-    }
-
-    &.dropdown-menu-left {
-        > a::after {
-            right: auto;
-            left: .35rem;
-            border-right: $dropdown-caret-width solid $dropdown-caret-color;
-            border-left: 0;
-        }
-        &:hover > a::after {
-            border-right-color: $dropdown-caret-color;
-        }
+    &.active > a::after {
+        border-left-color: $dropdown-caret-active-color;
     }
 }
 
@@ -184,33 +172,6 @@
     }
 }
 
-// Menu positioning
-//
-// Add extra class to `.dropdown-menu` to flip the alignment of the dropdown
-// menu with the parent.
-.dropdown-menu-right {
-    right: 0;
-    left: auto; // Reset the default from `.dropdown-menu`
-    @include border-radius($border-radius 0 $border-radius $border-radius);
-}
-.dropdown-submenu.dropdown-menu-right > .dropdown-menu {
-    right: -100%;
-    left: auto;
-    margin-right: -($border-width * 2);
-    @include border-radius(0 $border-radius $border-radius $border-radius);
-}
-
-.dropdown-menu-left {
-    right: auto;
-    left: 0;
-}
-.dropdown-submenu.dropdown-menu-left > .dropdown-menu {
-    right: auto;
-    left: -100%;
-    margin-left: -($border-width * 2);
-    @include border-radius($border-radius 0 $border-radius $border-radius);
-}
-
 // Dropdown section headers
 .dropdown-header {
     display: block;
@@ -226,8 +187,7 @@
     }
 }
 
-// Dividers (basically an `<hr>`) within the dropdown
-.dropdown-menu .divider,
+// Divider (basically an `<hr>`) within the dropdown
 .dropdown-divider {
     @include nav-divider($dropdown-divider-color);
 }
@@ -242,10 +202,8 @@
     z-index: $zindex-dropdown-backdrop;
 }
 
-
 // Allow for dropdowns to go bottom up (aka, dropup-menu)
 // Just add .dropup after the standard .dropdown class and you're set.
-// TODO: abstract this so that the navbar fixed styles are not placed here?
 .dropup,
 .navbar-fixed-bottom .dropdown {
     // Reverse the caret
@@ -267,7 +225,7 @@
         bottom: 100%;
         margin-top: 0;
         margin-bottom: $dropdown-margin-top;
-        @include border-radius($border-radius $border-radius $border-radius 0);
+        @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
     }
 
     .dropdown-submenu {
@@ -275,55 +233,8 @@
             top: auto;
             bottom: 0;
             margin-top: 0;
-            //margin-bottom: -($dropdown-margin-top + $dropdown-padding-y - $border-width);
             margin-bottom: calc(-#{($dropdown-margin-top + $dropdown-padding-y)} + #{$border-width});
-            @include border-radius($border-radius $border-radius $border-radius 0);
-        }
-    }
-}
-
-// Allow for menus and submenus to go left
-.dropdown-menu-left {
-    .dropdown-menu {
-        right: 0;
-        left: auto;
-        @include border-radius($border-radius 0 $border-radius $border-radius);
-
-        &.dropdown-menu-left {
-            right: auto;
-            left: 0;
-        }
-    }
-
-    //.dropdown-submenu {
-    .dropdown-submenu:not(.dropdown-menu-right) {
-        > a::after {
-            right: auto;
-            left: .35rem;
-            border-right: $dropdown-caret-width solid $dropdown-caret-color;
-            border-left: 0;
-        }
-        &:hover > a::after {
-            border-right-color: $dropdown-caret-color;
-        }
-
-        > .dropdown-menu {
-            right: 100%;
-            left: auto;
-            margin-left: auto;
-            @include border-radius($border-radius 0 $border-radius $border-radius);
-        }
-    }
-}
-
-.dropup.dropdown-menu-left {
-    .dropdown-menu {
-        @include border-radius($border-radius $border-radius 0 $border-radius);
-    }
-
-    .dropdown-submenu {
-        > .dropdown-menu {
-            @include border-radius($border-radius $border-radius 0 $border-radius);
+            @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
         }
     }
 }
@@ -345,34 +256,76 @@
         border-right: $dropdown-caret-width solid $dropdown-caret-color;
         border-bottom: $dropdown-caret-width solid transparent;
     }
-    &:hover > a::before {
-        border-right-color: $dropdown-caret-color;
-    }
+}
 
-    // Back caret alignment and sub-aligment overrides
-    .dropdown-menu-left &,
-    .dropdown-menu-right .dropdown-menu-left & {
-        > a::before {
-            right: .35rem;
-            left: auto;
-            border-right: 0;
-            border-left: $dropdown-caret-width solid $dropdown-caret-color;
-        }
-        &:hover a::before {
-            border-left-color: $dropdown-caret-color;
+// Change back caret direction for left facing menus
+// The `.dropdown-back-left` class is added automatically by the dropdown.js widget
+// This removes the need for overly convoluted CSS rules
+.dropdown-back-left {
+    > a::before {
+        right: .35rem;
+        left: auto;
+        border-right: 0;
+        border-left: $dropdown-caret-width solid $dropdown-caret-color;
+    }
+}
+
+// Allow for menus to go left - aligning to right side of the control
+.dropdown-menu-left {
+    .dropdown-menu {
+        right: 0;
+        left: auto;
+        @include border-radius($dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius);
+    }
+}
+
+// Submenu alignment
+// The `.dropdown-subalign-*` classes are added automatically by the dropdown.js widget
+// This removes the need for overly convoluted CSS rules
+.dropdown-subalign-right {
+    > .dropdown-menu {
+        right: auto;
+        left: 100%;
+        margin-right: -($border-width * 2);
+        margin-left: 0;
+        @include border-radius($dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-border-radius);
+    }
+}
+
+.dropdown-subalign-left {
+    > .dropdown-menu {
+        right: 100%;
+        left: auto;
+        margin-right: 0;
+        margin-left: -($border-width * 2);
+        @include border-radius($dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius);
+    }
+    > a::after {
+        right: auto;
+        left: .35rem;
+        border-right: $dropdown-caret-width solid $dropdown-caret-color;
+        border-left: 0;
+    }
+    &.active > a::after {
+        border-right-color: $dropdown-caret-active-color;
+    }
+}
+
+// Dropup corner overrides
+&.dropup {
+    &.dropdown-menu-left {
+        .dropdown-menu {
+            @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius);
         }
     }
-
-    .dropdown-menu-right &,
-    .dropdown-menu-left .dropdown-menu-right & {
-        > a::before {
-            right: auto;
-            left: .35rem;
-            border-right: $dropdown-caret-width solid $dropdown-caret-color;
-            border-left: 0;
+    .dropdown-subalign-right {
+        > .dropdown-menu {
+            @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
         }
-        &:hover a::before {
-            border-right-color: $dropdown-caret-color;
+    }
+    .dropdown-subalign-left {
+        > .dropdown-menu {
+            @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius);
         }
     }
 }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -2251,7 +2251,7 @@ Anchor variants:<br />
                 <li><a href="#">Something else here</a></li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li><a href="#">Separated link</a></li>
     </ul>
 </div>
@@ -2306,10 +2306,10 @@ Anchor variants:<br />
 <h3>Dropdown - Menu Alignment</h3>
 <div class="clearfix">
     <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_3">
+        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_3" data-cfw-dropdown-backlink=true>
             Default <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul data-cfw-dropdown-target="dropdownTest_3">
+        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_3">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2322,7 +2322,7 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
@@ -2332,11 +2332,11 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
@@ -2351,15 +2351,15 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
-            <li class="divider"></li>
+            <li class="dropdown-divider"></li>
             <li class="disabled"><a href="#">Separated link</a></li>
         </ul>
     </div>
@@ -2368,7 +2368,7 @@ Anchor variants:<br />
         <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_4">
             Drop Up <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul data-cfw-dropdown-target="dropdownTest_4">
+        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_4">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2381,7 +2381,7 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
@@ -2391,11 +2391,11 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
@@ -2410,15 +2410,15 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
-            <li class="divider"></li>
+            <li class="dropdown-divider"></li>
             <li class="disabled"><a href="#">Separated link</a></li>
         </ul>
     </div>
@@ -2427,7 +2427,7 @@ Anchor variants:<br />
         <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_5" data-cfw-dropdown-backlink=true>
             Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul data-cfw-dropdown-target="dropdownTest_5">
+        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_5">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2440,7 +2440,7 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
@@ -2450,11 +2450,11 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
@@ -2469,15 +2469,15 @@ Anchor variants:<br />
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                             <li><a href="#">Something else here</a></li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </li>
-            <li class="divider"></li>
+            <li class="dropdown-divider"></li>
             <li class="disabled"><a href="#">Separated link</a></li>
         </ul>
     </div>
@@ -2488,7 +2488,7 @@ Anchor variants:<br />
     <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub1" data-cfw-dropdown-backlink=true>
         Default<!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul data-cfw-dropdown-target="dropdownSub1">
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub1">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2529,7 +2529,7 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li class="disabled"><a href="#">Separated link</a></li>
     </ul>
 </div>
@@ -2538,7 +2538,7 @@ Anchor variants:<br />
     <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub2" data-cfw-dropdown-backlink=true>
         Drop Right <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul data-cfw-dropdown-target="dropdownSub2">
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub2">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2579,7 +2579,7 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li class="disabled"><a href="#">Separated link</a></li>
     </ul>
 </div>
@@ -2588,7 +2588,7 @@ Anchor variants:<br />
     <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub3" data-cfw-dropdown-backlink=true>
         Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul data-cfw-dropdown-target="dropdownSub3">
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub3">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2629,10 +2629,164 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
         <li class="disabled"><a href="#">Separated link</a></li>
     </ul>
 </div>
+
+<h3>Dropup submenu alignment</h3>
+
+<div class="btn-group dropup">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dup" data-cfw-dropdown-backlink="true">
+        Dropup
+    </button>
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dup">
+        <li class="dropdown-header">Dropdown header</li>
+        <li><a href="#">Action</a></li>
+        <li class="dropdown-menu-left">
+            <a href="#">Left menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-menu-right">
+            <a href="#">Right menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-divider"></li>
+        <li class="disabled"><a href="#">Separated link</a></li>
+    </ul>
+</div>
+
+
+<div class="btn-group dropup dropdown-menu-right">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dupR" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
+        Dropup Right
+    </button>
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dupR">
+        <li class="dropdown-header">Dropdown header</li>
+        <li><a href="#">Action</a></li>
+        <li class="dropdown-menu-left">
+            <a href="#">Left menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-menu-right">
+            <a href="#">Right menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-divider"></li>
+        <li class="disabled"><a href="#">Separated link</a></li>
+    </ul>
+</div>
+
+<div class="btn-group dropup dropdown-menu-left">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dupL" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
+        Dropup Left
+    </button>
+    <ul class="dropdown-menu" data-cfw-dropdown-target="dupL">
+        <li class="dropdown-header">Dropdown header</li>
+        <li><a href="#">Action</a></li>
+        <li class="dropdown-menu-left">
+            <a href="#">Left menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-menu-right">
+            <a href="#">Right menu</a>
+            <ul>
+                <li class="dropdown-menu-left">
+                    <a href="#">Left menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-menu-right">
+                    <a href="#">Right menu</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+            </ul>
+        </li>
+        <li class="dropdown-divider"></li>
+        <li class="disabled"><a href="#">Separated link</a></li>
+    </ul>
+</div>
+
 
 <h3>Caret</h3>
 <p>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -938,7 +938,7 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_0">
                     Action
                 </button>
-                <ul data-cfw-dropdown-target="dropdownTest_0">
+                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_0">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#0-1">Action</a></li>
                     <li>
@@ -951,7 +951,7 @@ $(window).ready(function() {
                                     <li><a href="#0-1-1-0">Action</a></li>
                                     <li><a href="#0-1-1-1">Another action</a></li>
                                     <li><a href="#0-1-1-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#0-1-1-3">Separated link</a></li>
                                 </ul>
                             </li>
@@ -961,11 +961,11 @@ $(window).ready(function() {
                                     <li><a href="#0-1-2-0">Action</a></li>
                                     <li><a href="#0-1-2-1">Another action</a></li>
                                     <li><a href="#0-1-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#0-1-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#0-1-3">Separated link</a></li>
                         </ul>
                     </li>
@@ -981,15 +981,15 @@ $(window).ready(function() {
                                     <li><a href="#0-2-2-0">Action</a></li>
                                     <li><a href="#0-2-2-1">Another action</a></li>
                                     <li><a href="#0-2-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#0-2-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#0-2-3">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#0-3">Separated link</a></li>
                 </ul>
             </div>
@@ -1000,17 +1000,11 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown">
                     <span class="sr-only">Toggle Dropdown</span>
                 </button>
-                <!--
-                <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_1" id="dropdownTest_1">
-                    <span class="sr-only">Toggle Dropdown</span>
-                </button>
-                <ul data-cfw-dropdown-target="dropdownTest_1">
-                -->
                 <ul class="dropdown-menu">
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a></li>
                     <li><a href="#">Something else here</a></li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </div>
@@ -1021,17 +1015,11 @@ $(window).ready(function() {
                 <a href="/foo/" role="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown">
                     <span class="sr-only">Toggle Dropdown</span>
                 </a>
-                <!--
-                <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_1" id="dropdownTest_1">
-                    <span class="sr-only">Toggle Dropdown</span>
-                </button>
-                <ul data-cfw-dropdown-target="dropdownTest_1">
-                -->
                 <ul class="dropdown-menu">
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a></li>
                     <li><a href="#">Something else here</a></li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </div>
@@ -1041,7 +1029,7 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw-dropdown-toggle="dropdownTest_2" id="js_dropdown_2">
                     JS init w/ back
                 </button>
-                <ul data-cfw-dropdown-target="dropdownTest_2" class="slide1">
+                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_2" class="slide1">
                     <li><a href="#2-1">Action</a></li>
                     <li>
                         <a href="#2-1">Another action with a really long entry</a>
@@ -1053,7 +1041,7 @@ $(window).ready(function() {
                                     <li><a href="#2-1-1-0">Action</a></li>
                                     <li><a href="#2-1-1-1">Another action</a></li>
                                     <li><a href="#2-1-1-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#2-1-1-3">Separated link</a></li>
                                 </ul>
                             </li>
@@ -1063,11 +1051,11 @@ $(window).ready(function() {
                                     <li><a href="#2-1-2-0">Action</a></li>
                                     <li><a href="#2-1-2-1">Another action</a></li>
                                     <li><a href="#2-1-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#2-1-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#2-1-3">Separated link</a></li>
                         </ul>
                     </li>
@@ -1083,15 +1071,15 @@ $(window).ready(function() {
                                     <li><a href="#2-2-2-0">Action</a></li>
                                     <li><a href="#2-2-2-1">Another action</a></li>
                                     <li><a href="#2-2-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#2-2-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#2-2-3">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#2-3">Separated link</a></li>
                 </ul>
             </div>
@@ -1108,7 +1096,7 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_3" data-cfw-dropdown-hover=true>
                     Hover Activated
                 </button>
-                <ul data-cfw-dropdown-target="dropdownTest_3">
+                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_3">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#3-1">Action</a></li>
                     <li>
@@ -1121,7 +1109,7 @@ $(window).ready(function() {
                                     <li><a href="#3-1-1-0">Action</a></li>
                                     <li><a href="#3-1-1-1">Another action</a></li>
                                     <li><a href="#3-1-1-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#3-1-1-3">Separated link</a></li>
                                 </ul>
                             </li>
@@ -1131,11 +1119,11 @@ $(window).ready(function() {
                                     <li><a href="#3-1-2-0">Action</a></li>
                                     <li><a href="#3-1-2-1">Another action</a></li>
                                     <li><a href="#3-1-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#3-1-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#3-1-3">Separated link</a></li>
                         </ul>
                     </li>
@@ -1150,15 +1138,15 @@ $(window).ready(function() {
                                     <li><a href="#3-2-2-0">Action</a></li>
                                     <li><a href="#3-2-2-1">Another action</a></li>
                                     <li><a href="#3-2-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#3-2-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#3-2-3">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#3-3">Separated link</a></li>
                 </ul>
             </div>
@@ -1172,7 +1160,7 @@ $(window).ready(function() {
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#">Separated link</a></li>
                 </ul>
             </div>
@@ -1195,7 +1183,7 @@ $(window).ready(function() {
                             <li><a href="#">Something else here</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li><a href="#">Separated link</a></li>
                 </ul>
             </div>
@@ -1213,7 +1201,7 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_4">
                     Drop Up
                 </button>
-                <ul data-cfw-dropdown-target="dropdownTest_4">
+                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_4">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#4-1">Action</a></li>
                     <li>
@@ -1226,7 +1214,7 @@ $(window).ready(function() {
                                     <li><a href="#4-1-1-0">Action</a></li>
                                     <li><a href="#4-1-1-1">Another action</a></li>
                                     <li><a href="#4-1-1-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#4-1-1-3">Separated link</a></li>
                                 </ul>
                             </li>
@@ -1236,11 +1224,11 @@ $(window).ready(function() {
                                     <li><a href="#4-1-2-0">Action</a></li>
                                     <li><a href="#4-1-2-1">Another action</a></li>
                                     <li><a href="#4-1-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#4-1-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#4-1-3">Separated link</a></li>
                         </ul>
                     </li>
@@ -1256,15 +1244,15 @@ $(window).ready(function() {
                                     <li><a href="#4-2-2-0">Action</a></li>
                                     <li><a href="#4-2-2-1">Another action</a></li>
                                     <li><a href="#4-2-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#4-2-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#4-2-3">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#4-3">Separated link</a></li>
                 </ul>
             </div>
@@ -1274,7 +1262,7 @@ $(window).ready(function() {
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_5" data-cfw-dropdown-backlink=true>
                     Drop Left
                 </button>
-                <ul data-cfw-dropdown-target="dropdownTest_5">
+                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_5">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#5-1">Action</a></li>
                     <li>
@@ -1287,7 +1275,7 @@ $(window).ready(function() {
                                     <li><a href="#5-1-1-0">Action</a></li>
                                     <li><a href="#5-1-1-1">Another action</a></li>
                                     <li><a href="#5-1-1-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#5-1-1-3">Separated link</a></li>
                                 </ul>
                             </li>
@@ -1297,11 +1285,11 @@ $(window).ready(function() {
                                     <li><a href="#5-1-2-0">Action</a></li>
                                     <li><a href="#5-1-2-1">Another action</a></li>
                                     <li><a href="#5-1-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#5-1-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#5-1-3">Separated link</a></li>
                         </ul>
                     </li>
@@ -1317,15 +1305,15 @@ $(window).ready(function() {
                                     <li><a href="#5-2-2-0">Action</a></li>
                                     <li><a href="#5-2-2-1">Another action</a></li>
                                     <li><a href="#5-2-2-2">Something else here</a></li>
-                                    <li class="divider"></li>
+                                    <li class="dropdown-divider"></li>
                                     <li><a href="#5-2-2-3">Separated link</a></li>
                                 </ul>
                             </li>
-                            <li class="divider"></li>
+                            <li class="dropdown-divider"></li>
                             <li><a href="#5-2-3">Separated link</a></li>
                         </ul>
                     </li>
-                    <li class="divider"></li>
+                    <li class="dropdown-divider"></li>
                     <li class="disabled"><a href="#5-3">Separated link</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
- Add border radius variable
- Add active caret color variable
- Remove `.divider` use in favor of `.dropdown-divider`
- Update docs with a 'back' link example
- Remove id/toggle/target from dropdown examples
- Clarify a bit about `data-cfw-dropdown-toggle` and `data-cfw-dropdown-target` use
- Move logic for positioning into dropdown.js to allow better control and to simplify CSS