### PR TITLE
v3 - Widget:Button - improve accessibility and add initialization

### DIFF
--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -17,29 +17,30 @@ Do more with buttons. Control button states or create groups of buttons for more
 
 ### Toggle State
 
-Add `data-cfw="button"` to toggle a button's `active` state. If you're pre-toggling a button, you must manually add the `.active` class and `aria-pressed="true"` to the `<button>`.
+Add `data-cfw="button"` to toggle a button's `active` and `aria-pressed` states. If you're pre-toggling a button, you must manually add the `.active` class to the `<button>`, the `aria-pressed="true"` will be added automatically by the widget.
 
 {% example html %}
-<button type="button" data-cfw="button" class="btn btn-primary">Single toggle</button>
+<button type="button" data-cfw="button" class="btn btn-info">Single toggle</button>
+<button type="button" data-cfw="button" class="btn btn-info active">Pre-selected toggle</button>
 {% endexample %}
 
 ### Checkbox and Radio Buttons
 
-Our `.button` styles can be applied to other elements, such as `<label>`s, to provide checkbox or radio style button toggling. Add `data-toggle="buttons"` to a `.btn-group` containing those modified buttons to enable toggling in their respective styles.
+Our `.btn` styles can be applied to other elements, such as `<label>`s, to provide checkbox or radio style button toggling. Add `data-toggle="buttons"` to a `.btn-group` containing those modified buttons to enable toggling in their respective styles.
 
-The checked state for these buttons is **only updated via `click` event** on the button. If you use another method to update the input---e.g., with `<input type="reset">` or by manually applying the input's `checked` property---you'll need to toggle `.active` on the `<label>` manually.
+The checked state for these buttons is **only updated via `click` event** on the button. If you use another method to update the input---e.g., with `<input type="reset">` or by manually applying the input's `checked` property---you'll need to toggle `.active` **and** `aria-pressed` on the `<label>` manually.
 
-Note that pre-checked buttons require you to manually add the `.active` class to the input's `<label>`.
+Note that pre-checked buttons will automatically add the `.active` class  and `aria-pressed` attribute to the input's `<label>` when initialized by the Button widget.
 
 {% example html %}
 <div class="btn-group" data-cfw="buttons">
-    <label class="btn btn-primary active">
+    <label class="btn btn-info">
         <input type="checkbox" checked>Checkbox 1 (pre-checked)
     </label>
-    <label class="btn btn-primary">
+    <label class="btn btn-info">
         <input type="checkbox">Checkbox 2
     </label>
-    <label class="btn btn-primary">
+    <label class="btn btn-info">
         <input type="checkbox">Checkbox 3
     </label>
 </div>
@@ -47,13 +48,13 @@ Note that pre-checked buttons require you to manually add the `.active` class to
 
 {% example html %}
 <div class="btn-group" data-cfw="buttons">
-    <label class="btn btn-primary active">
-        <input type="radio" name="options" checked> Radio 1 (preselected)
+    <label class="btn btn-info">
+        <input type="radio" name="options" checked> Radio 1 (pre-selected)
     </label>
-    <label class="btn btn-primary">
+    <label class="btn btn-info">
         <input type="radio" name="options"> Radio 2
     </label>
-    <label class="btn btn-primary">
+    <label class="btn btn-info">
         <input type="radio" name="options"> Radio 3
     </label>
 </div>
@@ -66,4 +67,26 @@ Note that pre-checked buttons require you to manually add the `.active` class to
 #### `.CFW_Button('toggle')`
 {:.no_toc}
 
-Toggles push state. Gives the button the appearance that it has been activated.
+Toggles push state. Changes the button the appearance and `aria-pressed` state to indicate that it has been activated or deactivated.
+
+## Accessibility
+
+### Widget Initialization
+If used on a group of buttons using the `data-toggle="buttons"`, the Button widget will initialize individually on each descendant `.btn` element.
+
+Upon initialization, the Button widget will automatically apply the visual `.active` class and the `aria-pressed` attribute in the following manner.
+1. Check to see if the button item contains an `<input>`:
+    - Update the `.active` state based on the state of the `checked` property.  The class will be added if the property is present, or removed if not present.
+2. If the button item does not contain an `<input>`, the visual active state will not be modified.
+3. Finally, `aria-pressed="true"` is set if the button item has the `.active` class, or set to `aria-pressed="false"` if the class is not set.
+
+### Toggle
+Somewhat similar to the initialization phase, the property, class, and attributes are set the same order.
+1. Check to see if the button item contains an `<input>`:
+    - If the button item is in a set of `type="radio"` elements, unset/deactivate the currently active radio input.
+    - Activate the state of the `checked` property for the toggled item.
+2. Toggle the state of the visual `.active` class by adding or removing.
+3. Finally, `aria-pressed="true"` is set if the button item has the `.active` class, or set to `aria-pressed="false"` if the class is not set.
+
+### Visual Focus
+For button items that contain an `<input>` element, the focus needs to be placed on the `<input>` itself so interaction is possible.  To assist in visual cues, a visual `.focus` class is added to the `.btn` element when the descendant `<input>` receives focus, and removed upon loss of focus.

--- a/js/button.js
+++ b/js/button.js
@@ -10,38 +10,78 @@
 
     var CFW_Widget_Button = function(element) {
         this.$element = $(element);
+        this.$parent = this.$element.closest('[data-cfw="buttons"]');
+
+        this._init();
     };
 
     CFW_Widget_Button.prototype = {
+        _init : function() {
+            var $selfRef = this;
+
+            var $input = this.$element.find('input').first();
+            if ($input.length) {
+                if ($input.prop('checked')) {
+                    this.$element.addClass('active');
+                } else {
+                    this.$element.removeClass('active');
+                }
+            }
+            this.$element.attr('aria-pressed', this.$element.hasClass('active'));
+
+            // Event handlers
+            this.$element
+                .on('click.cfw.button', function(e) {
+                    var $btn = $(this);
+
+                    $selfRef.toggle();
+
+                    if (!$(e.target).is('input')) {
+                        // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
+                        e.preventDefault();
+                        // The target component still receive the focus
+                        if ($btn.is('input,button')) {
+                            $btn.trigger('focus');
+                        } else {
+                            $btn.find('input:visible,button:visible').first().trigger('focus');
+                        }
+                    }
+                });
+            if ($input.length) {
+                this.$element.on('focusin.cfw.button focusout.cfw.button', function(e) {
+                    $(this).toggleClass('focus', /^focus(in)?$/.test(e.type));
+                });
+            }
+        },
 
         toggle : function() {
             var changed = true;
-            var $parent = this.$element.closest('[data-cfw="buttons"]');
 
-            if ($parent.length) {
+            if (this.$parent.length) {
                 var $input = this.$element.find('input');
-                if ($input.prop('type') == 'radio') {
-                    if ($input.prop('checked')) {
-                        changed = false;
+                if ($input.length) {
+                    if ($input.prop('type') == 'radio') {
+                        if ($input.prop('checked') && this.$element.hasClass('active')) {
+                            changed = false;
+                        } else {
+                            this.$parent.find('.active')
+                                .removeClass('active')
+                                .attr('aria-pressed', false);
+                        }
                     }
-                    $parent.find('.active').removeClass('active');
-                    this.$element.addClass('active');
-                } else if ($input.prop('type') == 'checkbox') {
-                    if (($input.prop('checked')) !== this.$element.hasClass('active')) {
-                        changed = false;
+
+                    if (changed) {
+                        $input.prop('checked', !this.$element.hasClass('active'));
+                        $input.trigger('change');
                     }
-                    this.$element.toggleClass('active');
                 }
-                $input.prop('checked', this.$element.hasClass('active'));
-                if (changed) {
-                    $input.trigger('change');
-                }
-            } else {
+            }
+
+            if (changed) {
                 this.$element.attr('aria-pressed', !this.$element.hasClass('active'));
                 this.$element.toggleClass('active');
             }
         }
-
     };
 
     function Plugin(option) {
@@ -50,41 +90,21 @@
             var data = $this.data('cfw.button');
             var options = typeof option === 'object' && option;
 
-            if (!data) {
-                $this.data('cfw.button', (data = new CFW_Widget_Button(this, options)));
+            // Check to see if group
+            if ($this.is('[data-cfw="buttons"]')) {
+                // Pass through to buttons
+                $this.find('.btn').CFW_Button(option);
+            } else {
+                // Operate on independent buttons
+                if (!data) {
+                    $this.data('cfw.button', (data = new CFW_Widget_Button(this, options)));
+                }
+                if (option == 'toggle') data.toggle();
             }
-            data.toggle();
         });
     }
 
     $.fn.CFW_Button = Plugin;
     $.fn.CFW_Button.Constructor = CFW_Widget_Button;
-
-    // API
-    // ===
-    $(document)
-        .on('click.cfw.button', '[data-cfw^="button"]', function(e) {
-            var $btn = $(e.target).closest('.btn');
-
-            Plugin.call($btn, 'toggle');
-
-            if (!($(e.target).is('input[type="radio"], input[type="checkbox"]'))) {
-                // Prevent double click on radios, and the double selections (so cancellation) on checkboxes
-                e.preventDefault();
-                // The target component still receive the focus
-                if ($btn.is('input,button')) {
-                    $btn.trigger('focus');
-                } else {
-                    $btn.find('input:visible,button:visible').first().trigger('focus');
-                }
-            }
-
-            if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) {
-                e.preventDefault();
-            }
-        })
-        .on('focus.cfw.button blur.cfw.button', '[data-cfw^="button"]', function(e) {
-            $(e.target).closest('.btn').toggleClass('focus', /^focus(in)?$/.test(e.type));
-        });
 
 })(jQuery);

--- a/js/common.js
+++ b/js/common.js
@@ -12,6 +12,9 @@
         var $scope = $(this);
         if (!$scope) { $scope = $(document.body); }
 
+        $('[data-cfw^="button"]', $scope).each(function() {
+            $(this).CFW_Button();
+        });
         $('[data-cfw="collapse"]', $scope).each(function() {
             $(this).CFW_Collapse();
         });

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -334,6 +334,8 @@ $(window).ready(function() {
             <strong>Toggle State:</strong>
             <br />
             <button type="button" data-cfw="button" class="btn btn-info">Single toggle</button>
+            &nbsp;
+            <button type="button" data-cfw="button" class="btn btn-info active">Single toggle</button>
             <br />
             <br />
 
@@ -342,22 +344,27 @@ $(window).ready(function() {
                     <strong>Checkbox:</strong>
                     <br />
                     <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-info active">
+                        <label class="btn btn-info" id="btnTog1">
                             <input type="checkbox" checked /> Check 1
                         </label>
-                        <label class="btn btn-info">
+                        <label class="btn btn-info" id="btnTog2">
                             <input type="checkbox" /> Check 2
                         </label>
-                        <label class="btn btn-info">
+                        <label class="btn btn-info" id="btnTog3">
                             <input type="checkbox" /> Check 3
                         </label>
                     </div>
+                    <br />
+                    <a href="#" onclick="$('#btnTog1').CFW_Button('toggle'); return false;">Toggle 1</a>
+                    <a href="#" onclick="$('#btnTog2').CFW_Button('toggle'); return false;">Toggle 2</a>
+                    <a href="#" onclick="$('#btnTog3').CFW_Button('toggle'); return false;">Toggle 3</a>
+
                 </div>
                 <div class="col-sm-6">
                     <strong>Radio:</strong>
                     <br />
                     <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-info active">
+                        <label class="btn btn-info">
                             <input type="radio" name="options" checked /> Radio 1
                         </label>
                         <label class="btn btn-info">
@@ -366,6 +373,15 @@ $(window).ready(function() {
                         <label class="btn btn-info">
                             <input type="radio" name="options" /> Radio 3
                         </label>
+                    </div>
+                </div>
+                <div class="col-sm-6">
+                    <strong>Buttons:</strong>
+                    <br />
+                    <div class="btn-group" data-cfw="buttons">
+                        <button class="btn" type="button">One</button>
+                        <button class="btn active" type="button">Two</button>
+                        <button class="btn" type="button">Three</button>
                     </div>
                 </div>
             </div>

--- a/test/js/unit/button.js
+++ b/test/js/unit/button.js
@@ -16,6 +16,131 @@ $(function() {
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
 
+    QUnit.test('should set active if btn child is checked radio', function(assert) {
+        assert.expect(2);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary">'
+            + '<input type="radio" id="radio1" autocomplete="off" checked>Radio'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        var $btn = $('#btn1');
+        assert.ok(!$btn.hasClass('active'), 'btn does not have active class');
+        $group.CFW_Button();
+        assert.ok($btn.hasClass('active'), 'btn has active class');
+    });
+
+    QUnit.test('should set aria-pressed=true if btn child is checked radio', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary">'
+            + '<input type="radio" id="radio1" autocomplete="off" checked>Radio'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'true');
+    });
+
+    QUnit.test('should set aria-pressed=false if btn child is unchecked radio', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary">'
+            + '<input type="radio" id="radio1" autocomplete="off">Radio'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'false');
+    });
+
+    QUnit.test('should remove active if btn child is unchecked radio', function(assert) {
+        assert.expect(2);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary active">'
+            + '<input type="radio" id="radio1" autocomplete="off">Radio'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        var $btn = $('#btn1');
+        assert.ok($btn.hasClass('active'), 'btn has active class');
+        $group.CFW_Button();
+        assert.ok(!$btn.hasClass('active'), 'btn does not have active class');
+    });
+
+    QUnit.test('should set active if btn child is checked checkbox', function(assert) {
+        assert.expect(2);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary">'
+            + '<input type="checkbox" id="checkbox1" autocomplete="off" checked>Checkbox'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        var $btn = $('#btn1');
+        assert.ok(!$btn.hasClass('active'), 'btn does not have active class');
+        $group.CFW_Button();
+        assert.ok($btn.hasClass('active'), 'btn has active class');
+    });
+
+    QUnit.test('should set aria-pressed=true if btn child is checked checkbox', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary">'
+            + '<input type="checkbox" id="checkbox1" autocomplete="off" checked>Checkbox'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'true');
+    });
+
+    QUnit.test('should set aria-pressed=false if btn child is unchecked checkbox', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary active">'
+            + '<input type="checkbox" id="checkbox1" autocomplete="off">Checkbox'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'false');
+    });
+
+    QUnit.test('should remove active if btn child is unchecked checkbox', function(assert) {
+        assert.expect(2);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<label id="btn1" class="btn btn-primary active">'
+            + '<input type="checkbox" id="checkbox1" autocomplete="off">Checkbox'
+            + '</label>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        var $btn = $('#btn1');
+        assert.ok($btn.hasClass('active'), 'btn has active class');
+        $group.CFW_Button();
+        assert.ok(!$btn.hasClass('active'), 'btn does not have active class');
+    });
+
+    QUnit.test('should set aria-pressed=true if active btn in container', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<button type="button" id="btn1" class="btn active">Button</button>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'true');
+    });
+
+    QUnit.test('should set aria-pressed=false inactive btn in container', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
+            + '<button type="button" id="btn1" class="btn">Button</button>'
+            + '</div>';
+        var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'false');
+    });
+
+
     QUnit.test('should toggle active', function(assert) {
         assert.expect(2);
         var $btn = $('<button class="btn" data-cfw="button">test</button>');
@@ -24,12 +149,24 @@ $(function() {
         assert.ok($btn.hasClass('active'), 'btn has class active');
     });
 
+    QUnit.test('should toggle aria-pressed on buttons in container', function(assert) {
+        assert.expect(1);
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">' +
+            '<button id="btn1" class="btn" type="button">One</button>' +
+            '<button id="btn2" class="btn" type="button">Two</button>' +
+            '</div>';
+        $('#qunit-fixture').append(groupHTML);
+        $('#btn1').CFW_Button('toggle');
+        assert.strictEqual($('#btn1').attr('aria-pressed'), 'true');
+    });
+
     QUnit.test('should toggle active when btn children are clicked', function(assert) {
         assert.expect(2);
         var $btn = $('<button class="btn" data-cfw="button">test</button>');
         var $inner = $('<i/>');
         $btn.append($inner)
-            .appendTo('#qunit-fixture');
+            .appendTo('#qunit-fixture')
+            .CFW_Button();
         assert.ok(!$btn.hasClass('active'), 'btn does not have active class');
         $inner.trigger('click');
         assert.ok($btn.hasClass('active'), 'btn has class active');
@@ -48,7 +185,8 @@ $(function() {
         var $btn = $('<button class="btn" data-cfw="button" aria-pressed="false">test</button>');
         var $inner = $('<i/>');
         $btn.append($inner)
-            .appendTo('#qunit-fixture');
+            .appendTo('#qunit-fixture')
+            .CFW_Button();
         assert.strictEqual($btn.attr('aria-pressed'), 'false', 'btn aria-pressed state is false');
         $inner.trigger('click');
         assert.strictEqual($btn.attr('aria-pressed'), 'true', 'btn aria-pressed state is true');
@@ -58,12 +196,13 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var groupHTML = '<div class="btn-group" data-toggle="buttons">'
+        var groupHTML = '<div class="btn-group" data-cfw="buttons">'
             + '<label class="btn btn-primary">'
             + '<input type="radio" id="radio" autocomplete="off">Radio'
             + '</label>'
             + '</div>';
         var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
 
         $group.find('input').on('change', function(e) {
             e.preventDefault();
@@ -88,6 +227,7 @@ $(function() {
             + '</label>'
             + '</div>';
         var $group = $(groupHTML).appendTo('#qunit-fixture');
+        $group.CFW_Button();
 
         var $btn1 = $group.children().eq(0);
         var $btn2 = $group.children().eq(1);


### PR DESCRIPTION
Change Button widget to no longer use event delegation as the mode of operation.

Switch over to use the Figuration standard of running an initialization process to add the accessibility supports as required.  Additional unit tests added.

Updated the docs to explain the accessibility supports.