### PR TITLE
v3 - JS - consolidate data parsing into util.js

### DIFF
--- a/docs/assets/js/src/docs.js
+++ b/docs/assets/js/src/docs.js
@@ -72,15 +72,11 @@ function topLinkAffix() {
     var $topLink = $('.topLink');
 
     $topLink.CFW_Affix({
-        offset: {
-            top: function() {
-                // return $('header').outerHeight() + $('.jumbotron-docs').outerHeight();
-                $title = $('.cf-title');
-                return $title.offset().top + $title.outerHeight();
-            },
-            bottom: function() {
-                return $('footer').outerHeight();
-            }
+        offsetTop: function() {
+            return $('.cf-title').offset().top;
+        },
+        offsetBottom: function() {
+            return $('footer').outerHeight();
         }
     });
     $(window).scroll();

--- a/docs/widgets/affix.md
+++ b/docs/widgets/affix.md
@@ -28,7 +28,7 @@ Here's how the affix widget works:
 
 - To start, the widget adds `.affix-top` to indicate the element is in its top-most position. At this point no CSS positioning is required.
 - Scrolling past the element you want affixed should trigger the actual affixing. This is where `.affix` replaces `.affix-top` and sets `position: fixed;` (provided by Bootstrap's CSS).
-- If a bottom offset is defined, scrolling past it should replace `.affix` with `.affix-bottom`. Since offsets are optional, setting one requires you to set the appropriate CSS. In this case, add `position: absolute;` when necessary. The widget uses the data attribute or JavaScript option to determine where to position the element from there.
+- If a `bottom` offset is defined, scrolling past it should replace `.affix` with `.affix-bottom`. Since offsets are optional, setting one requires you to set the appropriate CSS. In this case, add `position: absolute;` when necessary. The widget uses the data attribute or JavaScript option to determine where to position the element from there.
 
 Follow the above steps to set your CSS for either of the usage options below.
 
@@ -37,7 +37,7 @@ Follow the above steps to set your CSS for either of the usage options below.
 To easily add affix behavior to any element, just add `data-cfw="affix"` to the element you want to spy on. Use offsets to define when to toggle the pinning of an element.
 
 {% highlight html %}
-<div data-cfw="affix" data-cfw-affix-offset-top="60" data-cfw-affix-offset-bottom="200">
+<div data-cfw="affix" data-cfw-affix-top="60" data-cfw-affix-bottom="200">
   ...
 </div>
 {% endhighlight %}
@@ -47,18 +47,16 @@ To easily add affix behavior to any element, just add `data-cfw="affix"` to the 
 Call the affix widget via JavaScript:
 {% highlight js %}
 $('#myAffix').CFW_Affix({
-    offset: {
-        top: 100,
-        bottom: function () {
-            return (this.bottom = $('.footer').outerHeight(true));
-        }
+    top: 100,
+    bottom: function() {
+        return ($('.footer').outerHeight(true));
     }
 });
 {% endhighlight %}
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-affix-`, as in `data-cfw-affix-offset-top="200"`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-affix-`, as in `data-cfw-affix-top="200"`.
 
 <div class="table-responsive">
     <table class="table table-bordered table-striped">
@@ -72,10 +70,16 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </thead>
     <tbody>
         <tr>
-            <td>offset</td>
-            <td>number | function | object</td>
+            <td>top</td>
+            <td>number | function</td>
             <td>0</td>
-            <td>Pixels to offset from screen when calculating position of scroll. If a single number is provided, the offset will be applied in both top and bottom directions. To provide a unique, bottom and top offset just provide an object <code>offset: { top: 10 }</code> or <code>offset: { top: 10, bottom: 5 }</code>. Use a function when you need to dynamically calculate an offset.</td>
+            <td>Pixel offset from top of the `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
+        </tr>
+        <tr>
+            <td>bottom</td>
+            <td>number | function</td>
+            <td>0</td>
+            <td>Pixel offset from bottom of `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
         </tr>
         <tr>
             <td>target</td>
@@ -96,7 +100,7 @@ Activates an element to be affixed. Accepts an optional options object.
 
 {% highlight js %}
 $('#myAffix').CFW_Affix({
-    offset: {top: 10}
+    top: 10
 });
 {% endhighlight %}
 

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -198,15 +198,18 @@ Keep popovers in their place with the `viewport` option.
 <script>
     $('.popover-viewport-right').CFW_Popover({
         placement: 'right',
-        viewport: {selector: '#viewport-popover', padding: 2}
+        viewport: '#viewport-popover',
+        padding: 2
     });
     $('.popover-viewport-bottom').CFW_Popover({
         placement: 'bottom',
-        viewport: {selector: '#viewport-popover', padding: 2}
+        viewport: '#viewport-popover',
+        padding: 2
     });
     $('.popover-viewport-drag').CFW_Popover({
         drag: true,
-        viewport: {selector: '#viewport-popover', padding: 2}
+        viewport: '#viewport-popover',
+        padding: 2
     });
 </script>
 {% endexample %}
@@ -335,12 +338,18 @@ function myPopoverAlign(tip, trigger) {
         </tr>
         <tr>
             <td>viewport</td>
-            <td>string | object</td>
-            <td>{ selector: 'body', padding: 0 }</td>
+            <td>string | function</td>
+            <td>'body'</td>
             <td>
-                <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ selector: '#viewport', padding: 0 }</code></p>
+                <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
                 <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the popover instance.</p>
             </td>
+        </tr>
+        <tr>
+            <td>padding</td>
+            <td>integer</td>
+            <td>0</td>
+            <td>Spacing, in pixels, to keep the popover away from the viewport edge.</td>
         </tr>
         <tr>
             <td>html</td>

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -134,11 +134,13 @@ Keep tooltips in their place with the `viewport` option.
 <script>
     $('.tooltip-viewport-right').CFW_Tooltip({
         placement: 'right',
-        viewport: {selector: '#viewport-tooltip', padding: 2}
+        viewport: '#viewport-tooltip',
+        padding: 2
     });
     $('.tooltip-viewport-bottom').CFW_Tooltip({
         placement: 'bottom',
-        viewport: {selector: '#viewport-tooltip', padding: 2}
+        viewport: '#viewport-tooltip',
+        padding: 2
     });
 </script>
 {% endexample %}
@@ -257,12 +259,18 @@ function myTipAlign(tip, trigger) {
         </tr>
         <tr>
             <td>viewport</td>
-            <td>string | object | function</td>
-            <td>{ selector: 'body', padding: 0 }</td>
+            <td>string | function</td>
+            <td>'body'</td>
             <td>
-                <p>Keeps the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code> or <code>{ selector: '#viewport', padding: 0 }</code></p>
+                <p>Keep the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
                 <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the tooltip instance.</p>
             </td>
+        </tr>
+        <tr>
+            <td>padding</td>
+            <td>integer</td>
+            <td>0</td>
+            <td>Spacing, in pixels, to keep the tooltip away from the viewport edge.</td>
         </tr>
         <tr>
             <td>html</td>

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -13,13 +13,14 @@
     var CFW_Widget_Accordion = function(element, options) {
         this.$element = $(element);
 
-        this.settings = $.extend({}, CFW_Widget_Accordion.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('accordion', CFW_Widget_Accordion.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Accordion.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Accordion.DEFAULTS = {
-        active      : false     // [TODO} ???
+        active: false     // [TODO} ???
     };
 
     CFW_Widget_Accordion.prototype = {
@@ -59,14 +60,6 @@
                 }
                 $this.CFW_Collapse('hide');
             });
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwAccordionActive !== 'undefined') { parsedData.active = data.cfwAccordionActive; }
-            return parsedData;
         }
     };
 

--- a/js/affix.js
+++ b/js/affix.js
@@ -16,7 +16,8 @@
         this.unpin = null;
         this.pinnedOffset = null;
 
-        this.settings = $.extend({}, CFW_Widget_Affix.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('affix', CFW_Widget_Affix.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Affix.DEFAULTS, parsedData, options);
 
         this._init();
     };
@@ -24,8 +25,9 @@
     CFW_Widget_Affix.RESET = 'affix affix-top affix-bottom';
 
     CFW_Widget_Affix.DEFAULTS = {
-        offset: 0,
-        target: window
+        target : window,
+        top    : 0,
+        bottom : 0
     };
 
     CFW_Widget_Affix.prototype = {
@@ -81,14 +83,12 @@
             if (!this.$element.is(':visible')) { return; }
 
             var height       = this.$element.height();
-            var offset       = this.settings.offset;
-            var offsetTop    = offset.top;
-            var offsetBottom = offset.bottom;
+            var offsetTop    = this.settings.top;
+            var offsetBottom = this.settings.bottom;
             var scrollHeight =  Math.max($(document).height(), $(document.body).height());
 
-            if (typeof offset != 'object')         { offsetBottom = offsetTop = offset; }
-            if (typeof offsetTop == 'function')    { offsetTop    = offset.top(this.$element); }
-            if (typeof offsetBottom == 'function') { offsetBottom = offset.bottom(this.$element); }
+            if (typeof offsetTop == 'function')    { offsetTop    = offsetTop(this.$element); }
+            if (typeof offsetBottom == 'function') { offsetBottom = offsetBottom(this.$element); }
 
             var affix = this.getState(scrollHeight, height, offsetTop, offsetBottom);
 
@@ -121,17 +121,6 @@
                     top: scrollHeight - height - offsetBottom
                 });
             }
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            parsedData.offset = {};
-            var data = this.$element.data();
-
-            // data.cfwAffixOffset = data.cfwAffixOffset || {};
-            if (typeof data.cfwAffixOffsetBottom !== 'undefined') { parsedData.offset.bottom = data.cfwAffixOffsetBottom; }
-            if (typeof data.cfwAffixOffsetTop !== 'undefined')    { parsedData.offset.top    = data.cfwAffixOffsetTop;    }
-            return parsedData;
         }
     };
 

--- a/js/alert.js
+++ b/js/alert.js
@@ -15,14 +15,16 @@
         this.$parent = null;
         this.inTransition = null;
 
-        this.settings = $.extend({}, CFW_Widget_Alert.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('alert', CFW_Widget_Alert.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Alert.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Alert.DEFAULTS = {
-        animate     : true,     // If alert targets should fade out
-        speed       : 150       // Speed of animation (milliseconds)
+        target  : null,
+        animate : true, // If alert targets should fade out
+        speed   : 150   // Speed of animation (milliseconds)
     };
 
     CFW_Widget_Alert.prototype = {
@@ -93,16 +95,6 @@
             }
 
             this.$parent = $parent;
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwAlertTarget  !== 'undefined') { parsedData.animate = data.cfwAlertTarget;  }
-            if (typeof data.cfwAlertAnimate !== 'undefined') { parsedData.animate = data.cfwAlertAnimate; }
-            if (typeof data.cfwAlertSpeed   !== 'undefined') { parsedData.speed   = data.cfwAlertSpeed;   }
-            return parsedData;
         }
     };
 

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -14,17 +14,19 @@
         this.inTransition = null;
         this.$triggerColl = null;
 
-        this.settings = $.extend({}, CFW_Widget_Collapse.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$triggerElm.CFW_parseData('collapse', CFW_Widget_Collapse.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Collapse.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Collapse.DEFAULTS = {
-        animate     : true,     // If collapse targets should expand and contract
-        speed       : 300,      // Speed of animation (milliseconds)
-        follow      : false,    // If browser focus should move when a collapse toggle is activated
-        horizontal  : false,    // If collapse should transition horizontal (vertical is default)
-        hidden      : true      // Use aria-hidden on target containers by default
+        toggle     : null,
+        animate    : true,  // If collapse targets should expand and contract
+        speed      : 300,   // Speed of animation (milliseconds)
+        follow     : false, // If browser focus should move when a collapse toggle is activated
+        horizontal : false, // If collapse should transition horizontal (vertical is default)
+        hidden     : true   // Use aria-hidden on target containers by default
     };
 
     CFW_Widget_Collapse.prototype = {
@@ -202,20 +204,6 @@
                 this.$triggerColl.get(0).trigger('focus');
             }
             this.$triggerElm.CFW_trigger('afterHide.cfw.collapse');
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$triggerElm.data();
-
-            if (typeof data.cfwCollapseToggle     !== 'undefined') { parsedData.toggle     = data.cfwCollapseToggle;     }
-            if (typeof data.cfwCollapseAnimate    !== 'undefined') { parsedData.animate    = data.cfwCollapseAnimate;    }
-            if (typeof data.cfwCollapseSpeed      !== 'undefined') { parsedData.speed      = data.cfwCollapseSpeed;      }
-            if (typeof data.cfwCollapseFollow     !== 'undefined') { parsedData.follow     = data.cfwCollapseFollow;     }
-            if (typeof data.cfwCollapseHorizontal !== 'undefined') { parsedData.horizontal = data.cfwCollapseHorizontal; }
-            if (typeof data.cfwCollapseHidden     !== 'undefined') { parsedData.hidden     = data.cfwCollapseHidden;     }
-
-            return parsedData;
         }
     };
 

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -20,7 +20,8 @@
 
         this.timerHide = null;
 
-        this.settings = $.extend({}, CFW_Widget_Dropdown.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$triggerElm.CFW_parseData('dropdown', CFW_Widget_Dropdown.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Dropdown.DEFAULTS, parsedData, options);
         this.settings.isTouch = $isTouch;   // Touch enabled-browser flag - override not allowed
 
         this.c = CFW_Widget_Dropdown.CLASSES;
@@ -30,20 +31,20 @@
 
     CFW_Widget_Dropdown.CLASSES = {
         // Class names
-        isMenu          : 'dropdown-menu',
-        hasSubMenu      : 'dropdown-submenu',
-        showSubMenu     : 'show-menu',
-        backdrop        : 'dropdown-backdrop',
-        backLink        : 'dropdown-back'
+        isMenu      : 'dropdown-menu',
+        hasSubMenu  : 'dropdown-submenu',
+        showSubMenu : 'show-menu',
+        backdrop    : 'dropdown-backdrop',
+        backLink    : 'dropdown-back'
     };
 
     CFW_Widget_Dropdown.DEFAULTS = {
-        // Default Settings
-        delay           : 350,          // Delay for hiding menu (milliseconds)
-        hover           : false,        // Enable hover style navigation
-        backlink        : false,        // Insert back links into submenus
-        backtop         : false,        // Should back links start at top level
-        backtext        : 'Back'        // Text for back links
+        toggle   : null,
+        delay    : 350,     // Delay for hiding menu (milliseconds)
+        hover    : false,   // Enable hover style navigation
+        backlink : false,   // Insert back links into submenus
+        backtop  : false,   // Should back links start at top level
+        backtext : 'Back'   // Text for back links
     };
 
     function getParent($node) {
@@ -554,19 +555,6 @@
                 }, $selfRef.settings.delay);
                 return;
             }
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$triggerElm.data();
-
-            if (typeof data.cfwDropdownToggle   !== 'undefined') { parsedData.toggle   = data.cfwDropdownToggle;    }
-            if (typeof data.cfwDropdownDelay    !== 'undefined') { parsedData.delay    = data.cfwDropdownDelay;     }
-            if (typeof data.cfwDropdownHover    !== 'undefined') { parsedData.hover    = data.cfwDropdownHover;     }
-            if (typeof data.cfwDropdownBacklink !== 'undefined') { parsedData.backlink = data.cfwDropdownBacklink;  }
-            if (typeof data.cfwDropdownBacktop  !== 'undefined') { parsedData.backtop  = data.cfwDropdownBacktop;   }
-            if (typeof data.cfwDropdownBacktext !== 'undefined') { parsedData.backtext = data.cfwDropdownBacktext;  }
-            return parsedData;
         }
     };
 

--- a/js/equalize.js
+++ b/js/equalize.js
@@ -15,12 +15,14 @@
         this.$element = $(element);
         this.$window = $(window);
 
-        this.settings = $.extend({}, CFW_Widget_Equalize.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('equalize', CFW_Widget_Equalize.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Equalize.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Equalize.DEFAULTS = {
+        target   : '',
         throttle : 250,     // Throttle speed to limit event firing
         stack    : false,   // Equalize items when stacked
         row      : false,   // Equalize items by row
@@ -227,18 +229,6 @@
                     fn.apply(context, args);
                 }
             };
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwEqualizeTarget   !== 'undefined') { parsedData.target   = data.cfwEqualizeTarget;   }
-            if (typeof data.cfwEqualizeThrottle !== 'undefined') { parsedData.throttle = data.cfwEqualizeThrottle; }
-            if (typeof data.cfwEqualizeStack    !== 'undefined') { parsedData.stack    = data.cfwEqualizeStack;    }
-            if (typeof data.cfwEqualizeRow      !== 'undefined') { parsedData.row      = data.cfwEqualizeRow;      }
-            if (typeof data.cfwEqualizeMinimum  !== 'undefined') { parsedData.minimum  = data.cfwEqualizeMinimum;  }
-            return parsedData;
         }
     };
 

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -15,12 +15,14 @@
         this.id = null;
         this.isLoading = null;
 
-        this.settings = $.extend({}, CFW_Widget_Lazy.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('lazy', CFW_Widget_Lazy.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Lazy.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Lazy.DEFAULTS = {
+        src       : '',
         throttle  : 250,        // Throttle speed to limit event firing
         trigger   : 'scroll resize',   // Events to trigger loading source
         delay     : 0,          // Delay before loading source
@@ -172,23 +174,6 @@
                     fn.apply(context, args);
                 }
             };
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwLazySrc       !== 'undefined') { parsedData.src       = data.cfwLazySrc;       }
-            if (typeof data.cfwLazyThrottle  !== 'undefined') { parsedData.throttle  = data.cfwLazyThrottle;  }
-            if (typeof data.cfwLazyTrigger   !== 'undefined') { parsedData.trigger   = data.cfwLazyTrigger;   }
-            if (typeof data.cfwLazyDelay     !== 'undefined') { parsedData.delay     = data.cfwLazyDelay;     }
-            if (typeof data.cfwLazyEffect    !== 'undefined') { parsedData.effect    = data.cfwLazyEffect;    }
-            if (typeof data.cfwLazySpeed     !== 'undefined') { parsedData.speed     = data.cfwLazySpeed;     }
-            if (typeof data.cfwLazyThreshold !== 'undefined') { parsedData.threshold = data.cfwLazyThreshold; }
-            if (typeof data.cfwLazyContainer !== 'undefined') { parsedData.container = data.cfwLazyContainer; }
-            if (typeof data.cfwLazyInvisible !== 'undefined') { parsedData.invisible = data.cfwLazyInvisible; }
-
-            return parsedData;
         }
     };
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -21,7 +21,8 @@
         this.ignoreBackdropClick = false;
         this.$focusLast = null;
 
-        this.settings = $.extend({}, CFW_Widget_Modal.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$triggerElm.CFW_parseData('modal', CFW_Widget_Modal.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Modal.DEFAULTS, parsedData, options);
         if (this.settings.speed && typeof this.settings.speed == 'number') {
             this.settings.speed = {
                 backdrop: this.settings.speed,
@@ -33,18 +34,17 @@
     };
 
     CFW_Widget_Modal.DEFAULTS = {
-        toggle       : false,       // Target selector
-        animate      : true,        // If modal windows should animate
+        toggle       : false,   // Target selector
+        animate      : true,    // If modal windows should animate
         speed : {
-            backdrop : 150,         // Speed of backdrop animation (milliseconds)
-            modal    : 300          // Speed of modal animation (milliseconds)
+            backdrop : 150,     // Speed of backdrop animation (milliseconds)
+            modal    : 300      // Speed of modal animation (milliseconds)
         },
-        unlink       : false,       // If on hide to remove events and attributes from modal and trigger
-        destroy      : false,       // If on hide to unlink, then remove modal from DOM
-        backdrop     : true,        // Show backdrop, or 'static' for no close on click
-        keyboard     : true,        // Close modal on ESC press
-        show         : false,       // Show modal afer initialize
-        remote       : false        // Remote URL to load one time
+        unlink       : false,   // If on hide to remove events and attributes from modal and trigger
+        destroy      : false,   // If on hide to unlink, then remove modal from DOM
+        backdrop     : true,    // Show backdrop, or 'static' for no close on click
+        keyboard     : true,    // Close modal on ESC press
+        show         : false    // Show modal afer initialize
     };
 
     CFW_Widget_Modal.prototype = {
@@ -439,22 +439,6 @@
                 $selfRef.$targetElm.remove();
             });
             this.unlink();
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$triggerElm.data();
-
-            if (typeof data.cfwModalToggle   !== 'undefined') { parsedData.toggle   = data.cfwModalToggle;  }
-            if (typeof data.cfwModalAnimate  !== 'undefined') { parsedData.animate  = data.cfwModalAnimate;  }
-            if (typeof data.cfwModalSpeed    !== 'undefined') { parsedData.speed    = data.cfwModalSpeed;    }
-            if (typeof data.cfwModalUnlink   !== 'undefined') { parsedData.unlink   = data.cfwModalUnlink;   }
-            if (typeof data.cfwModalDestroy  !== 'undefined') { parsedData.destroy  = data.cfwModalDestroy;  }
-            if (typeof data.cfwModalBackdrop !== 'undefined') { parsedData.backdrop = data.cfwModalBackdrop; }
-            if (typeof data.cfwModalKeyboard !== 'undefined') { parsedData.keyboard = data.cfwModalKeyboard; }
-            if (typeof data.cfwModalShow     !== 'undefined') { parsedData.show     = data.cfwModalShow;     }
-            if (typeof data.cfwModalRemote   !== 'undefined') { parsedData.remote   = data.cfwModalRemote;   }
-            return parsedData;
         }
     };
 

--- a/js/player.js
+++ b/js/player.js
@@ -97,12 +97,14 @@
         this.scriptCurrent = -1;
         this.scriptCues = null;
 
-        this.settings = $.extend({}, CFW_Widget_Player.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('player', CFW_Widget_Player.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Player.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Player.DEFAULTS = {
+        src: '',
         transcript: -1,             // Default transcript off
         transcriptScroll : true,    // Scroll transcript
         transcriptOption : true     // Show transcript options
@@ -1306,18 +1308,6 @@
                     $selfRef.$focus.trigger('focus');
                 }
             }, 10);
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwPlayerSrc              !== 'undefined') { parsedData.src              = data.cfwPlayerSrc;              }
-            if (typeof data.cfwPlayerTranscript       !== 'undefined') { parsedData.transcript       = data.cfwPlayerTranscript;       }
-            if (typeof data.cfwPlayerTranscriptScroll !== 'undefined') { parsedData.transcriptScroll = data.cfwPlayerTranscriptScroll; }
-            if (typeof data.cfwPlayerTranscriptOption !== 'undefined') { parsedData.transcriptOption = data.cfwPlayerTranscriptOption; }
-
-            return parsedData;
         }
     };
 

--- a/js/popover.js
+++ b/js/popover.js
@@ -24,10 +24,9 @@
     };
 
     CFW_Widget_Popover.DEFAULTS = $.extend({}, $.fn.CFW_Tooltip.Constructor.DEFAULTS, {
-        placement   : 'top',        // Where to locate tooltip (top/bottom/left/right/auto)
-        trigger     : 'click',      // How tooltip is triggered (click/hover/focus/manual)
+        placement   : 'top',        // Where to locate popover (top/bottom/left/right/auto)
+        trigger     : 'click',      // How popover is triggered (click/hover/focus/manual)
         content     : '',           // Content text/html to be inserted
-        closetext   : '<span aria-hidden="true">&times;</span>', // Text for close links
         drag        : false,        // If the popover should be draggable
         dragtext    : '<span aria-hidden="true">+</span>', // Text for drag handle
         dragsrtext  : 'Drag',       // Screen reader text for drag handle
@@ -256,22 +255,6 @@
             this.$arrow = this.$targetElm.find('.arrow, .popover-arrow');
         }
         return this.$arrow;
-    };
-
-    CFW_Widget_Popover.prototype._parseDataAttrExt = function() {
-        var parsedData = {};
-        var $e = this.$triggerElm;
-
-        var string = this.type;
-        var dataType = string.charAt(0).toUpperCase() + string.slice(1);
-
-        if (typeof $e.data('cfw' + dataType + 'Content')    !== 'undefined') { parsedData.content    = $e.data('cfw' + dataType + 'Content');    }
-        if (typeof $e.data('cfw' + dataType + 'Drag')       !== 'undefined') { parsedData.drag       = $e.data('cfw' + dataType + 'Drag');       }
-        if (typeof $e.data('cfw' + dataType + 'Dragtext')   !== 'undefined') { parsedData.dragtext   = $e.data('cfw' + dataType + 'Dragtext');   }
-        if (typeof $e.data('cfw' + dataType + 'Dragsrtext') !== 'undefined') { parsedData.dragsrtext = $e.data('cfw' + dataType + 'Dragsrtext'); }
-        if (typeof $e.data('cfw' + dataType + 'Dragstep')   !== 'undefined') { parsedData.dragstep   = $e.data('cfw' + dataType + 'Dragstep');   }
-
-        return parsedData;
     };
 
     function Plugin(option) {

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -17,12 +17,14 @@
         this.activeTarget = null;
         this.scrollHeight = 0;
 
-        this.settings = $.extend({}, CFW_Widget_Scrollspy.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$scrollElement.CFW_parseData('scrollspy', CFW_Widget_Scrollspy.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Scrollspy.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Scrollspy.DEFAULTS = {
+        target: null,
         offset: 10
     };
 
@@ -133,15 +135,6 @@
             $(this.selector)
                 .parentsUntil(this.settings.target, '.active')
                 .removeClass('active');
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$scrollElement.data();
-
-            if (typeof data.cfwScrollspyTarget !== 'undefined') { parsedData.target = data.cfwScrollspyTarget; }
-            if (typeof data.cfwScrollspyOffset !== 'undefined') { parsedData.offset = data.cfwScrollspyOffset; }
-            return parsedData;
         }
     };
 

--- a/js/slider.js
+++ b/js/slider.js
@@ -35,7 +35,8 @@
         this.val0 = 0;
         this.val1 = 0;
 
-        this.settings = $.extend({}, CFW_Widget_Slider.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('slider', CFW_Widget_Slider.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Slider.DEFAULTS, parsedData, options);
 
         this.inDrag = null;
         this.startPos = null;
@@ -46,16 +47,16 @@
     };
 
     CFW_Widget_Slider.DEFAULTS = {
-        min : null,             // min value
-        max : null,             // max value
-        step: 1,                // small step increment
-        chunk: null,            // large step increment (will be auto determined if not defined)
-        enabled : true,         // true - enabled / false - disabled
-        vertical : false,       // alternate orientation
-        reversed : false,       // show thumbs in opposite order
+        min : null,         // min value
+        max : null,         // max value
+        step : 1,           // small step increment
+        chunk : null,       // large step increment (will be auto determined if not defined)
+        enabled : true,     // true - enabled / false - disabled
+        vertical : false,   // alternate orientation
+        reversed : false    // show thumbs in opposite order
 
         // TODO
-        tooltip : 'show'        // 'show,hide,always'
+        // tooltip : 'show'        // 'show,hide,always'
     };
 
     CFW_Widget_Slider.prototype = {
@@ -492,21 +493,6 @@
                 $node = this.$sliderThumbMin;
             }
             return $node;
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-            if (typeof data.cfwSliderMin        !== 'undefined') { parsedData.min       = data.cfwSliderMin;        }
-            if (typeof data.cfwSliderMax        !== 'undefined') { parsedData.max       = data.cfwSliderMax;        }
-            if (typeof data.cfwSliderStep       !== 'undefined') { parsedData.step      = data.cfwSliderStep;       }
-            if (typeof data.cfwSliderChunk      !== 'undefined') { parsedData.chunk     = data.cfwSliderChunk;      }
-            if (typeof data.cfwSliderVertical   !== 'undefined') { parsedData.vertical  = data.cfwSliderVertical;   }
-            if (typeof data.cfwSliderReversed   !== 'undefined') { parsedData.reversed  = data.cfwSliderReversed;   }
-            if (typeof data.cfwSliderEnabled    !== 'undefined') { parsedData.enabled   = data.cfwSliderEnabled;    }
-
-            if (typeof data.cfwSliderTooltip    !== 'undefined') { parsedData.tooltip   = data.cfwSliderTooltip;    }
-            return parsedData;
         }
     };
 

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -21,7 +21,8 @@
         this.currTab = null;
         this.currIndex = 0;
 
-        this.settings = $.extend({}, CFW_Widget_Slideshow.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('slideshow', CFW_Widget_Slideshow.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Slideshow.DEFAULTS, parsedData, options);
 
         this._init();
     };
@@ -119,14 +120,6 @@
 
         _findIndex : function(node) {
             return $.inArray(node, this.$tabs);
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            // var data = this.$element.data();
-
-            // if (typeof data.cfwSlideshowActive !== 'undefined') { parsedData.active = data.cfwSlideshowActive; }
-            return parsedData;
         }
     };
 

--- a/js/tab-responsive.js
+++ b/js/tab-responsive.js
@@ -14,7 +14,8 @@
     var CFW_Widget_TabResponsive = function(element, options) {
         this.$element = $(element);
 
-        this.settings = $.extend({}, CFW_Widget_TabResponsive.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$element.CFW_parseData('tabresponsive', CFW_Widget_TabResponsive.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_TabResponsive.DEFAULTS, parsedData, options);
 
         this.$tabFirst = this.$element.find('[data-cfw="tab"]').eq(0);
         this.$navElm = this.$tabFirst.closest('ul:not(.dropdown-menu)');
@@ -24,7 +25,7 @@
     };
 
     CFW_Widget_TabResponsive.DEFAULTS = {
-        active      : false     // Open the collase for the default active tab
+        active: false   // Open the collapse for the default active tab
     };
 
     CFW_Widget_TabResponsive.prototype = {
@@ -135,14 +136,6 @@
                     $triggerElm.CFW_Tab('show');
                 }
             });
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$element.data();
-
-            if (typeof data.cfwTabresponsiveActive !== 'undefined') { parsedData.active = data.cfwTabresponsiveActive; }
-            return parsedData;
         }
     };
 

--- a/js/tab.js
+++ b/js/tab.js
@@ -13,15 +13,17 @@
         this.$navElm = null;
         this.$targetElm = null;
 
-        this.settings = $.extend({}, CFW_Widget_Tab.DEFAULTS, this._parseDataAttr(), options);
+        var parsedData = this.$triggerElm.CFW_parseData('tab', CFW_Widget_Tab.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Tab.DEFAULTS, parsedData, options);
 
         this._init();
     };
 
     CFW_Widget_Tab.DEFAULTS = {
-        animate     : true,     // If tabs should be allowed fade in and out
-        speed       : 150,      // Speed of animation in milliseconds
-        hidden      : true      // Use aria-hidden on target containers by default
+        target  : null,
+        animate : true, // If tabs should be allowed fade in and out
+        speed   : 150,  // Speed of animation in milliseconds
+        hidden  : true  // Use aria-hidden on target containers by default
     };
 
     CFW_Widget_Tab.prototype = {
@@ -246,17 +248,6 @@
             }
 
             $prevActive.removeClass('in');
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var data = this.$triggerElm.data();
-
-            if (typeof data.cfwTabTarget  !== 'undefined') { parsedData.target  = data.cfwTabTarget;  }
-            if (typeof data.cfwTabAnimate !== 'undefined') { parsedData.animate = data.cfwTabAnimate; }
-            if (typeof data.cfwTabSpeed   !== 'undefined') { parsedData.speed   = data.cfwTabSpeed;   }
-            if (typeof data.cfwTabHidden  !== 'undefined') { parsedData.hidden  = data.cfwTabHidden;  }
-            return parsedData;
         }
     };
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -43,14 +43,13 @@
             hide        : 250               // Delay for hiding tooltip (milliseconds)
         },
         container       : false,            // Where to place tooltip if moving is needed
-        viewport: {                         // Viewport to constrain tooltip within
-            selector: 'body',
-            padding: 0
-        },
+        viewport        : 'body',           // Viewport to constrain tooltip within
+        padding         : 0,                // Padding from viewport edge
         html            : false,            // Use HTML or text insertion mode
         closetext       : '<span aria-hidden="true">&times;</span>', // Text for close links
         closesrtext     : 'Close',          // Screen reader text for close links
         title           : '',               // Title text/html to be inserted
+        activate        : false,            // Auto show after init
         unlink          : false,            // If on hide to remove events and attributes from tooltip and trigger
         destroy         : false,            // If on hide to unlink, then remove tooltip from DOM
         template        : '<div class="tooltip"><div class="tooltip-inner"></div><div class="tooltip-arrow"></div></div>'
@@ -110,7 +109,8 @@
         },
 
         getSettings : function(options) {
-            var settings = $.extend({}, this.getDefaults(), this._parseDataAttr(), this._parseDataAttrExt(), options);
+            var parsedData = this.$triggerElm.CFW_parseData(this.type, this.getDefaults());
+            var settings = $.extend({}, this.getDefaults(), parsedData, options);
             if (settings.delay && typeof settings.delay == 'number') {
                 settings.delay = {
                     show: settings.delay,
@@ -763,7 +763,7 @@
             var delta = { top: 0, left: 0 };
             if (!this.$viewport) return delta;
 
-            var viewportPadding = this.settings.viewport && this.settings.viewport.padding || 0;
+            var viewportPadding = this.settings.padding;
             // var viewportDimensions = this._getPosition(this.$viewport);
             var viewportDimensions = this.getViewportBounds(this.$viewport);
 
@@ -887,38 +887,6 @@
                 return (isTabIndexNaN || tabIndex >= 0) && $selfRef._focusable(this, !isTabIndexNaN);
             });
             return items;
-        },
-
-        _parseDataAttr : function() {
-            var parsedData = {};
-            var $e = this.$triggerElm;
-
-            var string = this.type;
-            var dataType = string.charAt(0).toUpperCase() + string.slice(1);
-
-            if (typeof $e.data('cfw' + dataType + 'Toggle')      !== 'undefined') { parsedData.toggle      = $e.data('cfw' + dataType + 'Toggle');      }
-            if (typeof $e.data('cfw' + dataType + 'Trigger')     !== 'undefined') { parsedData.trigger     = $e.data('cfw' + dataType + 'Trigger');     }
-            if (typeof $e.data('cfw' + dataType + 'Placement')   !== 'undefined') { parsedData.placement   = $e.data('cfw' + dataType + 'Placement');   }
-            if (typeof $e.data('cfw' + dataType + 'Follow')      !== 'undefined') { parsedData.follow      = $e.data('cfw' + dataType + 'Follow');      }
-            if (typeof $e.data('cfw' + dataType + 'Animate')     !== 'undefined') { parsedData.animate     = $e.data('cfw' + dataType + 'Animate');     }
-            if (typeof $e.data('cfw' + dataType + 'Speed')       !== 'undefined') { parsedData.speed       = $e.data('cfw' + dataType + 'Speed');       }
-            if (typeof $e.data('cfw' + dataType + 'Delay')       !== 'undefined') { parsedData.delay       = $e.data('cfw' + dataType + 'Delay');       }
-            if (typeof $e.data('cfw' + dataType + 'DelayShow')   !== 'undefined') { parsedData.delay.show  = $e.data('cfw' + dataType + 'DelayShow');   }
-            if (typeof $e.data('cfw' + dataType + 'DelayHide')   !== 'undefined') { parsedData.delay.hide  = $e.data('cfw' + dataType + 'DelayHide');   }
-            if (typeof $e.data('cfw' + dataType + 'Container')   !== 'undefined') { parsedData.container   = $e.data('cfw' + dataType + 'Container');   }
-            if (typeof $e.data('cfw' + dataType + 'Viewport')    !== 'undefined') { parsedData.viewport    = $e.data('cfw' + dataType + 'Viewport');    }
-            if (typeof $e.data('cfw' + dataType + 'Html')        !== 'undefined') { parsedData.html        = $e.data('cfw' + dataType + 'Html');        }
-            if (typeof $e.data('cfw' + dataType + 'Closetext')   !== 'undefined') { parsedData.closetext   = $e.data('cfw' + dataType + 'Closetext');   }
-            if (typeof $e.data('cfw' + dataType + 'Closesrtext') !== 'undefined') { parsedData.closesrtext = $e.data('cfw' + dataType + 'Closesrtext'); }
-            if (typeof $e.data('cfw' + dataType + 'Title')       !== 'undefined') { parsedData.title       = $e.data('cfw' + dataType + 'Title');       }
-            if (typeof $e.data('cfw' + dataType + 'Unlink')      !== 'undefined') { parsedData.unlink      = $e.data('cfw' + dataType + 'Unlink');      }
-            if (typeof $e.data('cfw' + dataType + 'Destroy')     !== 'undefined') { parsedData.destroy     = $e.data('cfw' + dataType + 'Destroy');     }
-            if (typeof $e.data('cfw' + dataType + 'Activate')    !== 'undefined') { parsedData.activate    = $e.data('cfw' + dataType + 'Activate');    }
-            return parsedData;
-        },
-
-        _parseDataAttrExt : function() {
-            return;
         }
     };
 

--- a/js/util.js
+++ b/js/util.js
@@ -8,6 +8,10 @@
 (function($) {
     'use strict';
 
+    String.prototype.capitalize = function() {
+        return this.charAt(0).toUpperCase() + this.slice(1);
+    };
+
     function CFW_transitionEnd() {
         if (window.QUnit) {
             return false;
@@ -81,6 +85,23 @@
             return false;
         }
         return true;
+    };
+
+    $.fn.CFW_parseData = function(name, object) {
+        var parsedData = {};
+        var $node = $(this);
+        var data = $node.data();
+        name = name.capitalize();
+
+        for (var prop in object) {
+            if (object.hasOwnProperty(prop)) {
+                var propName = prop.capitalize();
+                if (typeof data['cfw' + name + propName] !== 'undefined') {
+                    parsedData[prop] = data['cfw' + name + propName];
+                }
+            }
+        }
+        return parsedData;
     };
 
 })(jQuery);

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -39,15 +39,10 @@ $(window).ready(function() {
     });
     var $sideBar = $('.sidebar');
     $sideBar.CFW_Affix({
-        offset: {
-            top: function () {
-                var offsetTop      = $sideBar.offset().top;
-                var sideBarMargin  = parseInt($sideBar.children(0).css('margin-top'), 10)
-                var navOuterHeight = $('.topnav').height();
-                return (this.top = offsetTop - navOuterHeight);
-            },
-            bottom: 0
-        }
+        offsetTop:
+            function() {
+                return $('.topnav').height();
+            }
     });
 });
 

--- a/test/js/unit/affix.js
+++ b/test/js/unit/affix.js
@@ -37,7 +37,7 @@ $(function() {
         $(templateHTML).appendTo(document.body);
 
         $('#affixTarget').CFW_Affix({
-            offset: $('#affixTarget ul').position()
+            top: $('#affixTarget ul').position().top
         });
 
         $('#affixTarget')
@@ -72,7 +72,8 @@ $(function() {
 
         $('#affixTopTarget')
             .CFW_Affix({
-                offset: { top: 120, bottom: 0 }
+                top: 120,
+                bottom: 0
             })
             .on('affixed-top.cfw.affix', function() {
                 assert.ok($('#affixTopTarget').hasClass('affix-top'), 'affix-top class applied');

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -609,10 +609,8 @@ $(function() {
             .appendTo($container)
             .CFW_Tooltip({
                 placement: 'right',
-                viewport: {
-                    selector: 'body',
-                    padding: 12
-                }
+                viewport: 'body',
+                padding: 12
             });
 
         $target.CFW_Tooltip('show');
@@ -637,10 +635,8 @@ $(function() {
             .appendTo($container)
             .CFW_Tooltip({
                 placement: 'right',
-                viewport: {
-                    selector: 'body',
-                    padding: 12
-                }
+                viewport: 'body',
+                padding: 12
             });
 
         $target.CFW_Tooltip('show');
@@ -667,10 +663,8 @@ $(function() {
             .appendTo($container)
             .CFW_Tooltip({
                 placement: 'bottom',
-                viewport: {
-                    selector: 'body',
-                    padding: 12
-                }
+                viewport: 'body',
+                padding: 12
             });
 
         $target.CFW_Tooltip('show');
@@ -696,10 +690,8 @@ $(function() {
             .appendTo($container)
             .CFW_Tooltip({
                 placement: 'bottom',
-                viewport: {
-                    selector: 'body',
-                    padding: 12
-                }
+                viewport: 'body',
+                padding: 12
             });
 
         $target.CFW_Tooltip('show');


### PR DESCRIPTION
Have the data property parsing based on the `DEFAULT` settings properties for each widget.

The idea is to iterate over each default property and check for a matching data attribute on the trigger/calling element without having to do an explicit check.

Reworked some of the settings a bit, and will probably have more to do later, but those were not a main concern in this first pass.

Result was a trim of ~12Kb in the concatenated code, and 7Kb in the minified version.