### PR TITLE
v3 - JS - alter transition support to use CSS transition-duration values

### DIFF
--- a/docs/widgets/alert.md
+++ b/docs/widgets/alert.md
@@ -87,12 +87,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>true</td>
             <td>If alert targets should fade out.</td>
         </tr>
-        <tr>
-            <td>speed</td>
-            <td>integer</td>
-            <td>150</td>
-            <td>Speed of animation (milliseconds) - corresponds the animation speed specified in CSS.</td>
-        </tr>
     </tbody>
     </table>
 </div> <!-- /.table-responsive -->

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -106,12 +106,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If collapse targets should expand and contract.</td>
         </tr>
         <tr>
-            <td>speed</td>
-            <td>integer</td>
-            <td>350</td>
-            <td>Speed of animation (milliseconds) - corresponds the animation speed specified in CSS.</td>
-        </tr>
-        <tr>
             <td>follow</td>
             <td>boolean</td>
             <td>false</td>

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -335,16 +335,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If modal targets should fade and slide in.</td>
         </tr>
         <tr>
-            <td>speed</td>
-            <td>number| object</td>
-            <td>backdrop:150, modal:300</td>
-            <td>
-                <p>Speed of animations for fading backdrop and sliding the modal dialog (ms).</p>
-                <p>If a number is supplied, speed is applied to both fade/slide.  These numbers need to correspsond to the CSS animation settings.</p>
-                Object structure is: `speed: { backdrop: 150, modal: 300 }`
-            </td>
-        </tr>
-        <tr>
             <td>unlink</td>
             <td>boolean</td>
             <td>false</td>

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -272,12 +272,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If popover items should fade in and out.</td>
         </tr>
         <tr>
-            <td>speed</td>
-            <td>integer</td>
-            <td>150</td>
-            <td>Speed of animation (milliseconds) - corresponds the animation speed specified in CSS.</td>
-        </tr>
-        <tr>
             <td>follow</td>
             <td>boolean</td>
             <td>false</td>

--- a/docs/widgets/tab.md
+++ b/docs/widgets/tab.md
@@ -129,12 +129,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If the tab pane target should fade in and out.</td>
         </tr>
         <tr>
-            <td>speed</td>
-            <td>integer</td>
-            <td>350</td>
-            <td>Speed of animation (milliseconds) - corresponds the animation speed specified in CSS.</td>
-        </tr>
-        <tr>
             <td>hidden</td>
             <td>boolean</td>
             <td>true</td>

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -193,12 +193,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If tooltip items should fade in and out.</td>
         </tr>
         <tr>
-            <td>speed</td>
-            <td>integer</td>
-            <td>150</td>
-            <td>Speed of animation (milliseconds) - corresponds the animation speed specified in CSS.</td>
-        </tr>
-        <tr>
             <td>follow</td>
             <td>boolean</td>
             <td>false</td>

--- a/js/alert.js
+++ b/js/alert.js
@@ -23,8 +23,7 @@
 
     CFW_Widget_Alert.DEFAULTS = {
         target  : null,
-        animate : true, // If alert targets should fade out
-        speed   : 150   // Speed of animation (milliseconds)
+        animate : true  // If alert targets should fade out
     };
 
     CFW_Widget_Alert.prototype = {
@@ -71,14 +70,7 @@
 
             this.$parent.removeClass('in');
 
-            if ($.support.transitionEnd && this.$parent.hasClass('fade')) {
-                this.$parent
-                    .one('cfwTransitionEnd', $.proxy(removeElement, this))
-                    .CFW_emulateTransitionEnd(this.settings.speed);
-                return;
-            }
-
-            removeElement();
+            this.$parent.CFW_transition(null, removeElement);
         },
 
         findParent : function() {

--- a/js/tab.js
+++ b/js/tab.js
@@ -22,7 +22,6 @@
     CFW_Widget_Tab.DEFAULTS = {
         target  : null,
         animate : true, // If tabs should be allowed fade in and out
-        speed   : 150,  // Speed of animation in milliseconds
         hidden  : true  // Use aria-hidden on target containers by default
     };
 
@@ -168,7 +167,6 @@
         },
 
         fadeEnable : function() {
-            if (!$.support.transitionEnd) { return; }
             this.$targetElm.addClass('fade');
             if (this.$targetElm.hasClass('active')) {
                 this.$targetElm.addClass('in');
@@ -210,29 +208,29 @@
             nextTab.CFW_Tab('show').trigger('focus');
         },
 
-        _activateTab : function(node, container, isPanel, $previous) {
+        _activateTab : function($node, container, isPanel, $previous) {
             var $selfRef = this;
             var $prevActive = container.find('> .active');
-            var doTransition = isPanel && $.support.transitionEnd && this.settings.animate;
+            var doTransition = isPanel && this.settings.animate;
 
             function displayTab() {
                 $prevActive.removeClass('active');
 
-                node.addClass('active');
+                $node.addClass('active');
 
                 if (isPanel) {
                     $prevActive.attr('aria-hidden', 'true');
-                    node.attr('aria-hidden', 'false');
+                    $node.attr('aria-hidden', 'false');
                 }
 
                 if (doTransition) {
-                    node[0].offsetWidth; // Reflow for transition
-                    node.addClass('in');
+                    $node[0].offsetWidth; // Reflow for transition
+                    $node.addClass('in');
                 } else {
                     if (isPanel) {
                         $selfRef.settings.animate = false;
                     }
-                    node.removeClass('fade');
+                    $node.removeClass('fade');
                 }
 
                 if (isPanel) {
@@ -240,12 +238,7 @@
                 }
             }
 
-            if (doTransition) {
-                node.one('cfwTransitionEnd', displayTab)
-                    .CFW_emulateTransitionEnd(this.settings.speed);
-            } else {
-                displayTab();
-            }
+            $node.CFW_transition(null, displayTab);
 
             $prevActive.removeClass('in');
         }

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -37,7 +37,6 @@
         trigger         : 'hover focus',    // How tooltip is triggered (click/hover/focus/manual)
         follow          : false,            // If the browser focus should follow active tooltip
         animate         : true,             // Should the tooltip fade in and out
-        speed           : 150,              // Speed of animation (milliseconds)
         delay : {
             show        : 0,                // Delay for showing tooltip (milliseconda)
             hide        : 250               // Delay for hiding tooltip (milliseconds)
@@ -424,12 +423,7 @@
                     });
             }
 
-            if ($.support.transitionEnd && this.$targetElm.hasClass('fade')) {
-                this.$targetElm.one('cfwTransitionEnd', $.proxy(this._showComplete, this))
-                    .CFW_emulateTransitionEnd(this.settings.speed);
-            } else {
-                this._showComplete();
-            }
+            this.$targetElm.CFW_transition(null, $.proxy(this._showComplete, this));
         },
 
         hide : function(force) {
@@ -466,12 +460,7 @@
             }
             $(document).off('.cfw.' + this.type + '.tabmove');
 
-            if ($.support.transitionEnd && this.$targetElm.hasClass('fade')) {
-                this.$targetElm.one('cfwTransitionEnd', $.proxy(this._hideComplete, this))
-                    .CFW_emulateTransitionEnd(this.settings.speed);
-            } else {
-                this._hideComplete();
-            }
+            this.$targetElm.CFW_transition(null, $.proxy(this._hideComplete, this));
 
             this.hoverState = null;
         },

--- a/test/js/unit/alert.js
+++ b/test/js/unit/alert.js
@@ -16,27 +16,60 @@ $(function() {
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
 
-    QUnit.test('should fade element out on clicking .close', function(assert) {
+    QUnit.test('should fade element out on clicking .close (no transition)', function(assert) {
         assert.expect(1);
         var alertHTML = '<div class="alert alert-danger">'
             + '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>'
             + '<p><strong>Danger!</strong> There is definitaly some error now.</p>'
             + '</div>';
-        var $alert = $(alertHTML).CFW_Alert().appendTo($('#qunit-fixture'));
+        var $alert = $(alertHTML).css('transition', 'none').CFW_Alert().appendTo($('#qunit-fixture'));
         $alert.find('.close').trigger('click');
         assert.strictEqual($alert.hasClass('in'), false, 'remove .in class on .close click');
     });
 
-    QUnit.test('should remove element when clicking .close', function(assert) {
+    QUnit.test('should fade element out on clicking .close (with transition)', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var alertHTML = '<div class="alert alert-danger">'
+            + '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>'
+            + '<p><strong>Danger!</strong> There is definitaly some error now.</p>'
+            + '</div>';
+        var $alert = $(alertHTML).css('transition', '.05s').CFW_Alert().appendTo($('#qunit-fixture'));
+        $alert
+            .one('afterClose.cfw.alert', function() {
+                assert.strictEqual($alert.hasClass('in'), false, 'remove .in class on .close click');
+                done();
+            })
+            .find('.close').trigger('click');
+    });
+
+    QUnit.test('should remove element when clicking .close (no transition)', function(assert) {
         assert.expect(2);
         var alertHTML = '<div class="alert alert-danger">'
             + '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>'
             + '<p><strong>Danger!</strong> There is definitaly some error now.</p>'
             + '</div>';
-        var $alert = $(alertHTML).appendTo('#qunit-fixture').CFW_Alert();
+        var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture').CFW_Alert();
         assert.notEqual($('#qunit-fixture').find('.alert').length, 0, 'element added to dom');
         $alert.find('.close').trigger('click');
         assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'element removed from dom');
+    });
+
+    QUnit.test('should remove element when clicking .close (with transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var alertHTML = '<div class="alert alert-danger">'
+            + '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>'
+            + '<p><strong>Danger!</strong> There is definitaly some error now.</p>'
+            + '</div>';
+        var $alert = $(alertHTML).css('transition', '.05s').appendTo('#qunit-fixture').CFW_Alert();
+        assert.notEqual($('#qunit-fixture').find('.alert').length, 0, 'element added to dom');
+        $alert
+            .one('afterClose.cfw.alert', function() {
+                assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'element removed from dom');
+                done();
+            })
+            .find('.close').trigger('click');
     });
 
     QUnit.test('should not fire afterClose when beforeClose is prevented', function(assert) {

--- a/test/js/unit/collapse.js
+++ b/test/js/unit/collapse.js
@@ -16,23 +16,65 @@ $(function() {
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
 
-    QUnit.test('should show a collapsed element', function(assert) {
+    QUnit.test('should show a collapsed element (no transition)', function(assert) {
         assert.expect(2);
         var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
+        var $target = $('<div id="test" class="collapse" />').css('transition', 'none').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
         $trigger.CFW_Collapse('show');
         assert.ok($target.hasClass('in'), 'has class "in"');
         assert.ok(!/height/i.test($target.attr('style')), 'has height reset');
     });
 
-    QUnit.test('should hide a collapsed element', function(assert) {
-        assert.expect(1);
+    QUnit.test('should show a collapsed element (with transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
         var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $target = $('<div id="test" />').appendTo('#qunit-fixture');
+        var $target = $('<div id="test" class="collapse" />').css('transition', '.05s').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
-        $trigger.CFW_Collapse('hide');
-        assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+        $trigger
+            .one('afterShow.cfw.collapse', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                assert.ok(!/height/i.test($target.attr('style')), 'has height reset');
+                done();
+            });
+        $trigger.CFW_Collapse('show');
+    });
+
+    QUnit.test('should hide a collapsed element (no transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $target = $('<div id="test" class="collapse" />').css('transition', 'none').appendTo('#qunit-fixture');
+        $trigger.CFW_Collapse();
+        $trigger
+            .one('afterShow.cfw.collapse', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                $trigger.CFW_Collapse('hide');
+            })
+            .one('afterHide.cfw.collapse', function() {
+                assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+                done();
+            })
+            .CFW_Collapse('show');
+    });
+
+    QUnit.test('should hide a collapsed element (with transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $target = $('<div id="test" class="collapse" />').css('transition', '.05s').appendTo('#qunit-fixture');
+        $trigger.CFW_Collapse();
+        $trigger
+            .one('afterShow.cfw.collapse', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                $trigger.CFW_Collapse('hide');
+            })
+            .one('afterHide.cfw.collapse', function() {
+                assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+                done();
+            })
+            .CFW_Collapse('show');
     });
 
     QUnit.test('should not fire afterShow when beforeShow is prevented', function(assert) {
@@ -43,12 +85,12 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('beforeShow.cfw.collapse', function(e) {
+            .one('beforeShow.cfw.collapse', function(e) {
                 e.preventDefault();
                 assert.ok(true, 'beforeShow event fired');
                 done();
             })
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok(false, 'afterShow event fired');
             });
         $trigger.CFW_Collapse();
@@ -63,10 +105,10 @@ $(function() {
         var $target = $('<div id="test" class="collapse" style="height: 0px" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('beforeShow.cfw.collapse', function() {
+            .one('beforeShow.cfw.collapse', function() {
                 assert.strictEqual($target.get(0).style.height, '0px', 'height is 0px');
             })
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.strictEqual($target.get(0).style.height, '', 'height is auto');
                 done();
             });
@@ -82,7 +124,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok($target.hasClass('in'), 'target has in class');
                 done();
             });
@@ -108,7 +150,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.ok(!$target.hasClass('in'), 'target does not have in class');
                 done();
             });
@@ -126,7 +168,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok($trigger0.hasClass('open'), 'trigger0 has open class');
                 assert.ok($trigger1.hasClass('open'), 'trigger1 has open class');
                 done();
@@ -146,7 +188,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.ok(!$trigger0.hasClass('open'), 'trigger0 does not have open class');
                 assert.ok(!$trigger1.hasClass('open'), 'trigger1 does not have open class');
                 done();
@@ -165,7 +207,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.ok(false);
             });
 
@@ -182,7 +224,7 @@ $(function() {
         /* var $target =  */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok(true, 'show a previously-uninitialized hidden collapse when the "show" method is called');
             });
 
@@ -199,7 +241,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok(false);
             });
 
@@ -216,7 +258,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.ok(true, 'hiding a previously-uninitialized shown collapse when the "hide" method is called');
             });
 
@@ -233,7 +275,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse" aria-hidden="true" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.notOk($target.is('[aria-hidden]'), 'aria-hidden attribute removed');
                 done();
             });
@@ -250,7 +292,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.strictEqual($target.attr('aria-hidden'), 'true', 'aria-hidden on target is "true"');
                 done();
             });
@@ -268,7 +310,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.strictEqual($trigger0.attr('aria-expanded'), 'true', 'aria-expanded on trigger0 is "true"');
                 assert.strictEqual($trigger1.attr('aria-expanded'), 'true', 'aria-expanded on trigger1 is "true"');
                 done();
@@ -288,7 +330,7 @@ $(function() {
         /* var $target = */ $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger0
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.strictEqual($trigger0.attr('aria-expanded'), 'false', 'aria-expanded on trigger0 is "true"');
                 assert.strictEqual($trigger1.attr('aria-expanded'), 'false', 'aria-expanded on trigger1 is "true"');
                 done();
@@ -307,7 +349,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterHide.cfw.collapse', function() {
+            .one('afterHide.cfw.collapse', function() {
                 assert.ok(!$target.hasClass('in'));
                 done();
             });
@@ -324,7 +366,7 @@ $(function() {
         var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
-            .on('afterShow.cfw.collapse', function() {
+            .one('afterShow.cfw.collapse', function() {
                 assert.ok($target.hasClass('in'));
                 done();
             });

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -52,12 +52,64 @@ $(function() {
         $trigger.CFW_Modal('show');
     });
 
-    QUnit.test('should hide modal when hide is called', function(assert) {
+    QUnit.test('should show modal when show is called (no transition)', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal" />').css('transition', 'none').appendTo('#qunit-fixture');
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.ok($target.is(':visible'), 'modal visible');
+                done();
+            });
+        $trigger.CFW_Modal();
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('should show modal when show is called (with transition)', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal" />').css('transition', '.05s').appendTo('#qunit-fixture');
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.ok($target.is(':visible'), 'modal visible');
+                done();
+            });
+        $trigger.CFW_Modal();
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('should hide modal when hide is called (no transition)', function(assert) {
         assert.expect(2);
         var done = assert.async();
 
         var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
-        var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal" />').css('transition', 'none').appendTo('#qunit-fixture');
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.ok($target.is(':visible'), 'modal visible');
+                $trigger.CFW_Modal('hide');
+            })
+            .on('afterHide.cfw.modal', function() {
+                assert.ok(!$target.is(':visible'), 'modal hidden');
+                done();
+            });
+        $trigger.CFW_Modal();
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('should hide modal when hide is called (with transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal" />').css('transition', '.05s').appendTo('#qunit-fixture');
 
         $target
             .on('afterShow.cfw.modal', function() {


### PR DESCRIPTION
Instead of having potentially mismatched values in the CSS and JS for transition duration, have the transition emulator check the value itself. This way the transition durations can be modified purely in the CSS and the widgets will adapt automatically.

Also adding some unit tests to make sure these work in transition and non-transition modes.

Modified widgets:
- Alert
- Collapse
- Modal
- Tab
- Tooltip (and Popover by extension)

 