### PR TITLE
v3 - rework repsonsive embeds

### DIFF
--- a/docs/assets/scss/_player.scss
+++ b/docs/assets/scss/_player.scss
@@ -253,10 +253,10 @@
     height: auto !important;
 }
 
-.player-unstarted .video-responsive:hover {
+.player-unstarted .embed-responsive:hover {
     cursor: pointer;
 }
-.player-unstarted .video-responsive:after {
+.player-unstarted .embed-responsive:after {
     display: inline-block;
     position: absolute;
     top: 50%;
@@ -277,7 +277,7 @@
     opacity: 0.75;
     pointer-events: none;
 }
-.player-unstarted .video-responsive:hover:after {
+.player-unstarted .embed-responsive:hover:after {
     filter: alpha(opacity=100);
     opacity: 1;
 }

--- a/docs/utilities/responsive-embeds.md
+++ b/docs/utilities/responsive-embeds.md
@@ -16,7 +16,7 @@ Rules are directly applied to `<iframe>`, `<embed>`, `<video>`, and `<object>` e
 </div>
 {% endexample %}
 
-Aspect ratios can be customized with modifier classes.
+By default the aspect ratio is set to 16:9, this can be customized by overriding the `$embed-ratio` variable by copying it into your `/scss/_custom.scss` file.  Also, the aspect ratios can be customized with the included modifier classes.
 
 {% highlight html %}
 <!-- 21:9 aspect ratio -->
@@ -37,16 +37,5 @@ Aspect ratios can be customized with modifier classes.
 <!-- 1:1 aspect ratio -->
 <div class="embed-responsive embed-responsive-1x1">
   <iframe class="embed-responsive-item" src="..."></iframe>
-</div>
-{% endhighlight %}
-
-## Special Case: Video
-
-As a quick alternative, using the class `.video-responsive` uses the same settings as `.embed-responsive` but sets a default aspect ratio of 16:9.
-
-{% highlight html %}
-<!-- 16:9 aspect ratio -->
-<div class="video-responsive">
-  <video>...</video>
 </div>
 {% endhighlight %}

--- a/docs/widgets/player.md
+++ b/docs/widgets/player.md
@@ -125,7 +125,7 @@ Available seek and volume sliders.
 <p><small>Source: <a href="https://videos.pexels.com/videos/tourists-looking-at-niagara-falls-333">Tourists Looking at Niagara Falls</a></small></p>
 
 <div data-cfw="player" class="video-wrapper">
-    <div class="video-responsive">
+    <div class="embed-responsive">
         <video poster="{{ site.baseurl }}/assets/video/niagara_falls.jpg" controls>
             <source src="{{ site.baseurl }}/assets/video/niagara_falls.mp4" type="video/mp4" />
             <track src="{{ site.baseurl }}/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
@@ -177,7 +177,7 @@ Add an interactive transcript to your video using the `transcript` control.  The
 <p><small>Source: <a href="https://videos.pexels.com/videos/tourists-looking-at-niagara-falls-333">Tourists Looking at Niagara Falls</a></small></p>
 
 <div data-cfw="player" data-cfw-player-transcript="0" class="video-wrapper">
-    <div class="video-responsive">
+    <div class="embed-responsive">
         <video poster="{{ site.baseurl }}/assets/video/niagara_falls.jpg" controls>
             <source src="{{ site.baseurl }}/assets/video/niagara_falls.mp4" type="video/mp4" />
             <track src="{{ site.baseurl }}/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" />

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -9,7 +9,6 @@
 @import "mixins/breakpoints";
 @import "mixins/hover";
 @import "mixins/images";
-@import "mixins/embeds";
 @import "mixins/focus-ring";
 @import "mixins/reset-filter";
 @import "mixins/screen-reader";

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -405,6 +405,11 @@ $thumbnail-border-radius:       $border-radius !default;
 $thumbnail-box-shadow:          0 .0625rem .125rem rgba(0,0,0,.075) !default;
 
 
+// Responsive embed
+// =====
+$embed-ratio: percentage(9 / 16) !default;
+
+
 // Code
 // =====
 $code-font-size:            87.5% !default;

--- a/scss/component/_embed-responsive.scss
+++ b/scss/component/_embed-responsive.scss
@@ -1,12 +1,16 @@
-//scss-lint:disable VendorPrefix ImportantRule
-
-// Credit: Nicolas Gallagher and SUIT CSS.
+//scss-lint:disable VendorPrefix
 .embed-responsive {
     position: relative;
     display: block;
-    height: 0;
+    width: 100%;
     padding: 0;
     overflow: hidden;
+
+    &::before {
+        display: block;
+        padding-top: $embed-ratio;
+        content: "";
+    }
 
     .embed-responsive-item,
     iframe,
@@ -23,76 +27,40 @@
     }
 }
 
-// Special use-case: default video to 16x9
-.video-responsive {
-    position: relative;
-    display: block;
-    height: 0;
-    padding: 0;
-    padding-bottom: percentage(9 / 16);
-    overflow: hidden;
+.embed-responsive-21x9 {
+    &::before {
+        padding-top: percentage(9 / 21);
+    }
+}
 
-    .video-responsive-item,
+.embed-responsive-16x9 {
+    &::before {
+        padding-top: percentage(9 / 16);
+    }
+}
+
+.embed-responsive-4x3 {
+    &::before {
+        padding-top: percentage(3 / 4);
+    }
+}
+
+.embed-responsive-1x1 {
+    &::before {
+        padding-top: percentage(1 / 1);
+    }
+}
+
+// Fullscreen video
+:fullscreen .embed-responsive {
+    position: initial;
+}
+:-ms-fullscreen .embed-responsive {
+    .embed-responsive-item,
     iframe,
     embed,
     object,
     video {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        border: 0;
+        position: -ms-device-fixed;
     }
-}
-
-.embed-responsive-21x9 {
-    padding-bottom: percentage(9 / 21);
-}
-
-.embed-responsive-16x9 {
-    padding-bottom: percentage(9 / 16);
-}
-
-.embed-responsive-4x3 {
-    padding-bottom: percentage(3 / 4);
-}
-
-.embed-responsive-1x1 {
-    padding-bottom: percentage(1 / 1);
-}
-
-//Fullscreen video
-// Each vendor prefix needs to be seperate!
-
-:-moz-full-screen .video-responsive,
-:-moz-full-screen .embed-responsive {
-    position: initial;
-}
-:-webkit-full-screen .video-responsive,
-:-webkit-full-screen .embed-responsive {
-    position: initial;
-}
-:-ms-fullscreen .video-responsive,
-:-ms-fullscreen .embed-responsive {
-    position: initial;
-}
-:fullscreen .video-responsive,
-:fullscreen .embed-responsive {
-    position: initial;
-}
-
-:-moz-full-screen video {
-    @include video-fullscreen();
-}
-:-webkit-full-screen video {
-    @include video-fullscreen();
-}
-:-ms-fullscreen video {
-    position: -ms-device-fixed !important;
-    @include video-fullscreen();
-}
-:fullscreen video {
-    @include video-fullscreen();
 }

--- a/scss/mixins/_embeds.scss
+++ b/scss/mixins/_embeds.scss
@@ -1,8 +1,0 @@
-//scss-lint:disable ImportantRule
-
-@mixin video-fullscreen() {
-    width: 100% !important;
-    max-width: 100%;
-    height: 100% !important;
-    max-height: 100%;
-}

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -302,10 +302,10 @@ body {
     height: auto !important;
 }
 
-.player-unstarted .video-responsive:hover {
+.player-unstarted .embed-responsive:hover {
     cursor: pointer;
 }
-.player-unstarted .video-responsive:after {
+.player-unstarted .embed-responsive:after {
     display: inline-block;
     position: absolute;
     top: 50%;
@@ -326,7 +326,7 @@ body {
     opacity: 0.75;
     pointer-events: none;
 }
-.player-unstarted .video-responsive:hover:after {
+.player-unstarted .embed-responsive:hover:after {
     filter: alpha(opacity=100);
     opacity: 1;
 }
@@ -447,7 +447,7 @@ body {
 
 <h2 class="h4">Niagara Falls</h2>
 <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
-    <div class="video-responsive">
+    <div class="embed-responsive">
         <video poster="../assets/video/niagara_falls.jpg" controls>
             <source src="../assets/video/niagara_falls.mp4" type="video/mp4" />
             <track src="../assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
@@ -499,7 +499,7 @@ body {
 
 <h2 class="h4">Niagara Falls</h2>
 <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
-    <div class="video-responsive">
+    <div class="embed-responsive">
         <video poster="../assets/video/niagara_falls.jpg" controls preload="none">
             <source src="../assets/video/niagara_falls.mp4">
             <track src="../assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
@@ -544,7 +544,7 @@ body {
 <h2 class="h4">Transcript testing</h2>
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" data-cfw-player-transcript="2" role="region" aria-label="video player">
-        <div class="video-responsive">
+        <div class="embed-responsive">
             <video poster="../assets/video/niagara_falls.jpg" controls preload="none">
                 <source src="../assets/video/niagara_falls.mp4">
                 <track src="../assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
@@ -588,7 +588,7 @@ body {
 <h2 class="h4">Transcript as toggle</h2>
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player" data-cfw-player-transcript-option="false" data-cfw-player-transcript=0>
-        <div class="video-responsive">
+        <div class="embed-responsive">
             <video poster="../assets/video/niagara_falls.jpg" controls>
                 <source src="../assets/video/niagara_falls.mp4" type="video/mp4" />
                 <track src="../assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
@@ -634,7 +634,7 @@ body {
 <h2 class="h4">Niagara Falls</h2>
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
-        <div class="video-responsive">
+        <div class="embed-responsive">
             <video poster="../assets/video/niagara_falls.jpg" controls>
                 <source src="../assets/video/niagara_falls.mp4">
                 <track src="../assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
@@ -679,7 +679,7 @@ body {
 <h2 class="h4">Transcript + Caption testing</h2>
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" data-cfw-player-transcript="1" role="region" aria-label="video player">
-        <div class="video-responsive">
+        <div class="embed-responsive">
             <video poster="../assets/video/niagara_falls.jpg" controls preload="none">
                 <source src="../assets/video/niagara_falls.mp4">
                 <track src="../assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" default />

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1649,27 +1649,9 @@ Anchor variants:<br />
   </div>
 </progress>
 
-<h3>Video responsive</h3>
-<div class="video-sample">
-    <div class="video-responsive">
-        <video poster="../assets/video/niagara_falls.jpg" controls>
-            <source src="../assets/video/niagara_falls.mp4" type="video/mp4" />
-            <track src="../assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
-            <p>HTML5 video not supported</p>
-        </video>
-    </div>
-</div>
-<!--
-<div class="video-sample">
-    <div class="video-responsive">
-        <iframe width="420" height="315" src="https://www.youtube.com/embed/MbGkL06EU90" frameborder="0" allowfullscreen></iframe>
-    </div>
-</div>
--->
-
 <h3>Embed responsive</h3>
 <div class="video-sample">
-    <div class="embed-responsive embed-responsive-16x9">
+    <div class="embed-responsive">
         <video poster="../assets/video/niagara_falls.jpg" controls>
             <source src="../assets/video/niagara_falls.mp4" type="video/mp4" />
             <track src="../assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
@@ -1677,13 +1659,17 @@ Anchor variants:<br />
         </video>
     </div>
 </div>
-<!--
-<div class="video-sample">
-    <div class="embed-responsive embed-responsive-16x9">
-        <iframe width="420" height="315" src="https://www.youtube.com/embed/MbGkL06EU90" frameborder="0" allowfullscreen></iframe>
+
+<h3>Embed responsive - in flex element</h3>
+<div class="video-sample" style="display: flex;">
+    <div class="embed-responsive">
+        <video poster="../assets/video/niagara_falls.jpg" controls>
+            <source src="../assets/video/niagara_falls.mp4" type="video/mp4" />
+            <track src="../assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
+            <p>HTML5 video not supported</p>
+        </video>
     </div>
 </div>
--->
 
 <h3>List group</h3>
 <ul class="list-group">


### PR DESCRIPTION
Fix responsive embeds to layout correctly when contained within a flexbox container.

Also reduce some of the fullscreen styles.  They were also only targeting a `<video>` element, and should be a bit more broad.  By resetting the `position` of the `.embed-responsive' container, all seems to be well.

Changed to let Autoprefixer do the lifting too.

Killed off the custom `.video-responsive` since that aspect ratio is now the default (and configurable) ratio.