### PR TITLE
V3 - JS first pass updates

### DIFF
--- a/docs/widgets/accordion.md
+++ b/docs/widgets/accordion.md
@@ -22,7 +22,10 @@ Accordion requires the following:
 * ToC goes here
 {:toc}
 
-## Example
+## Examples
+
+### Basic Example
+
 A simple accordion.
 
 {% example html %}
@@ -38,6 +41,45 @@ A simple accordion.
     <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion2">Collapse Toggle #3</a></h4>
     <div class="collapse" data-cfw-collapse-target="accordion2">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
+    </div>
+</div>
+{% endexample %}
+
+### Using Cards
+
+Here some cards are used to add a bit of layout.
+
+{% example html %}
+<div data-cfw="accordion">
+    <div class="card mb-0">
+        <div class="card-header">
+            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card0">Collapse Toggle #1</a></h4>
+        </div>
+        <div class="collapse" data-cfw-collapse-target="card0">
+            <div class="card-block">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
+            </div>
+        </div>
+    </div>
+    <div class="card mb-0">
+        <div class="card-header">
+            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card1">Collapse Toggle #2</a></h4>
+        </div>
+        <div class="collapse" data-cfw-collapse-target="card1">
+            <div class="card-block">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
+            </div>
+        </div>
+    </div>
+    <div class="card mb-0">
+        <div class="card-header">
+            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card2">Collapse Toggle #3</a></h4>
+        </div>
+        <div class="collapse" data-cfw-collapse-target="card2">
+            <div class="card-block">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
+            </div>
+        </div>
     </div>
 </div>
 {% endexample %}
@@ -63,11 +105,12 @@ $('#myAccordion').CFW_Accordion();
 #### `.CFW_Accordion()`
 {:.no_toc}
 
-Activates the an accordion element.
+Activates the element as an accordion listener.
 
-{% highlight js %}
-$('#myAccordion').CFW_Accordion();
-{% endhighlight %}
+#### `.CFW_Accordion('dispose')`
+{:.no_toc}
+
+Removes the accordion listener and data from the element. Falls back to non-associated, or individual, collapse controls.
 
 ### Events
 
@@ -85,7 +128,7 @@ You can also get the collapse events as indicated in the [Collapse widget]({{ si
     </thead>
     <tbody>
         <tr>
-            <td>init.cfw.accordion</td>
+            <td><code>init.cfw.accordion</code></td>
             <td>This event fires after the accordion item is initialized.</td>
         </tr>
     </tbody>

--- a/docs/widgets/affix.md
+++ b/docs/widgets/affix.md
@@ -113,6 +113,10 @@ Recalculates the state of the affix based on the dimensions, position, and scrol
 $('#myAffix').CFW_Affix('checkPosition');
 {% endhighlight %}
 
+#### `.CFW_Affix('dispose')`
+{:.no_toc}
+
+Disables the affix functionality and removes any `.affix`, `.affix-top`, or `.affix-bottom` from the designated element.
 
 ### Events
 

--- a/docs/widgets/alert.md
+++ b/docs/widgets/alert.md
@@ -96,7 +96,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 #### `.CFW_Alert(options)`
 {:.no_toc}
 
-Activates the alert as a closable element. Accepts an optional options `object`.
+Activates the alert as a closable element by listening for click events on descendant elements which have the `data-cfw-dismiss="alert"` attribute. (Not necessary when using the Figuration widget API is enabled.) Accepts an optional options `object`.
 
 {% highlight js %}
 $('#myAlert').CFW_Alert({
@@ -108,6 +108,11 @@ $('#myAlert').CFW_Alert({
 {:.no_toc}
 
 Closes an alert.
+
+#### `.CFW_Alert('dipose')`
+{:.no_toc}
+
+Removes the click event listener from an alert. This will not disable a dismiss item if the Figuration widget API is enabled.
 
 ### Events
 

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -60,18 +60,59 @@ Note that pre-checked buttons will automatically add the `.active` class  and `a
 </div>
 {% endexample %}
 
+### Grouped Buttons
+
+You couls also use `.btn`s inside a `.btn-group` for interface controls.
+
+{% example html %}
+<div class="btn-group" data-cfw="buttons">
+    <button class="btn" type="button">One</button>
+    <button class="btn active" type="button">Two</button>
+    <button class="btn" type="button">Three</button>
+</div>
+{% endexample %}
+
 ## Usage
 
+### Via Data Attributes
+
+See the above examples to determine the appropriate data attribute for your use case.
+
+Typically, use `data-cfw="button"` on a single button for toggle, and 'data-cfw="buttons"` on a ancestor element for grouped buttons.
+
+### Via JavaScript
+
+Enable manually with:
+
+{% highlight js %}
+$('#myCollapse').CFW_Button();
+{% endhighlight %}
+
+### Options
+
+None.
+
 ### Methods
+
+#### `.CFW_Button()`
+{:.no_toc}
+
+Activate a single or group of buttons to act as toggles.
 
 #### `.CFW_Button('toggle')`
 {:.no_toc}
 
 Toggles push state. Changes the button the appearance and `aria-pressed` state to indicate that it has been activated or deactivated.
 
+#### `.CFW_Button('dispose')`
+{:.no_toc}
+
+Removes the toggle functionality for a single or group of buttons.  This will leave the button or group of buttons in their current state.
+
 ## Accessibility
 
 ### Widget Initialization
+
 If used on a group of buttons using the `data-toggle="buttons"`, the Button widget will initialize individually on each descendant `.btn` element.
 
 Upon initialization, the Button widget will automatically apply the visual `.active` class and the `aria-pressed` attribute in the following manner.

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -128,12 +128,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>false</td>
             <td>Use a horizontal transition instead of the default vertical transition.</td>
         </tr>
-        <tr>
-            <td>hidden</td>
-            <td>boolean</td>
-            <td>true</td>
-            <td>Use the <code>aria-hidden</code> attribute on the target container to indicate visibility status to screen readers.</td>
-        </tr>
     </tbody>
     </table>
 </div> <!-- /.table-responsive -->

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -5,7 +5,7 @@ subtitle: collapse.js
 group: widgets
 ---
 
-Get base styles and flexible support for collapsible components like accordions and navigation.
+Get base styles and flexible support for toggling content on your page.
 
 ## Contents
 {:.no_toc}
@@ -29,7 +29,7 @@ Click the buttons below to show and hide another element via class changes.
 
 ### Multiple Triggers
 
-You can assign multiple triggers to control one collapse target, but you need to use the `data-cfw-collapse-toggle` and matching `data-cfw-collapse-target` attributes so that the toggle and target states are all synchronised.
+You can assign multiple triggers to control one collapse target, but you either need to use the `data-cfw-collapse-toggle` and matching `data-cfw-collapse-target` attributes, or matching `href` attributes with the associated `id`, so that the toggle and target states are all synchronised.
 
 {% example html %}
 <a href="#" role="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-toggle="multi-collapse">Trigger 1 <span class="caret"></span></a>
@@ -38,6 +38,17 @@ You can assign multiple triggers to control one collapse target, but you need to
     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
 </div>
 {% endexample %}
+
+Using `id` and matching `href` attributes.
+
+{% example html %}
+<a href="#href-collapse" role="button" class="btn btn-outline-primary" data-cfw="collapse">ID Trigger 1 <span class="caret"></span></a>
+<a href="#href-collapse" role="button" class="btn btn-outline-primary" data-cfw="collapse">ID Trigger 2 <span class="caret"></span></a>
+<div id="href-collapse">
+    <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
+</div>
+{% endexample %}
+
 
 ### Horizonal
 
@@ -154,6 +165,12 @@ Shows a collapsible element.
 {:.no_toc}
 
 Hides a collapsible element.
+
+#### `.CFW_Collapse('dispose')`
+{:.no_toc}
+
+Disables the collapse control functionality for a given element, leaving the collapse target is its current state.
+
 
 ### Events
 

--- a/docs/widgets/drag.md
+++ b/docs/widgets/drag.md
@@ -64,7 +64,7 @@ Options can be passed via JavaScript.
 
 Activates the equalizer widget. Accepts an optional options `object`.
 
-#### `.CFW_Drag('destroy')`
+#### `.CFW_Drag('dispose')`
 {:.no_toc}
 
 Disables the drag functionality.

--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -5,7 +5,7 @@ subtitle: dropdown.js
 group: widgets
 ---
 
-Add dropdown menus to nearly anything with this widget, including buttons, navbars, tabs, and pills.
+Add a context menu or list of links to a control item.  Support for nested lists is included automatically.  There is also an expand on hover option, even though we recommend that you use the default click to toggle mode for consitent usability across devices.
 
 {% callout warning %}
 #### Incompatible Widgets
@@ -36,7 +36,7 @@ Here is a static example showing the dropdown layout and content pieces.
         <ul class="dropdown-menu">
             <li class="dropdown-header">Sample Header</li>
             <li><a href="#">Action</a></li>
-            <li class="disabled"><a href="#">Disabled action</a></li>
+            <li><a href="#" class="disabled">Disabled action</a></li>
             <li class="dropdown-submenu open">
                 <a href="#">Something else here</a>
                 <ul class="dropdown-menu">
@@ -166,12 +166,12 @@ Separate groups of related menu items with a divider.
 
 ### Disabled Menu Items
 
-Add `.disabled` to the `li` item in the dropdown to **style them as disabled**.
+Add `.disabled` to the `a` item in the dropdown to **style them as disabled**.
 
 {% example html %}
 <ul class="dropdown-menu">
   <li><a href="#">Regular link</a></li>
-  <li class="disabled"><a href="#">Disabled link</a></li>
+  <li><a href="#" class="disabled">Disabled link</a></li>
   <li><a href="#">Another link</a></li>
 </ul>
 {% endexample %}
@@ -189,7 +189,7 @@ Add `.active` to the `li` item in the dropdown to show a visual emphasis.
 {% example html %}
 <ul class="dropdown-menu">
   <li><a href="#">Regular link</a></li>
-  <li class="active"><a href="#">Active link</a></li>
+  <li><a href="#" class="active">Active link</a></li>
   <li><a href="#">Another link</a></li>
 </ul>
 {% endexample %}
@@ -221,7 +221,7 @@ Using the [`backlink` option](#options), you can have 'back' menu items automati
             </ul>
         </li>
         <li class="dropdown-divider"></li>
-        <li class="disabled"><a href="#">Disabled item</a></li>
+        <li><a href="#" class="disabled">Disabled item</a></li>
     </ul>
 </div>
 {% endexample %}
@@ -289,7 +289,7 @@ Add `.dropdown-menu-left` to a `.dropdown-menu` to right align the dropdown menu
             </ul>
         </li>
         <li class="dropdown-divider"></li>
-        <li class="disabled"><a href="#">Disabled link</a></li>
+        <li><a href="#" class="disabled">Disabled link</a></li>
     </ul>
 </div>
 {% endexample %}
@@ -345,7 +345,7 @@ The menu alignment class of `.dropdown-menu-left` will also work with submenu it
             </ul>
         </li>
         <li class="dropdown-divider"></li>
-        <li class="disabled"><a href="#">Separated link</a></li>
+        <li><a href="#" class="disabled">Separated link</a></li>
     </ul>
 </div>
 {% endexample %}
@@ -465,6 +465,11 @@ Shows the root menu element.
 {:.no_toc}
 
 Hides the root menu element.
+
+#### `.CFW_Dropdown('dispose')`
+{:.no_toc}
+
+Hides the root menu element and disconnect all the event listeners and data from the menu items and the trigger element.
 
 ### Events
 

--- a/docs/widgets/equalize.md
+++ b/docs/widgets/equalize.md
@@ -237,6 +237,11 @@ $('#myContainer').CFW_Equalize({
 
 Update the container heights. This will also bubble up the DOM to equalize any ancestor equalize widgets in the case of nesting.
 
+#### `.CFW_Equalize('dispose')`
+{:.no_toc}
+
+Remove the data and global event listener for a given instance of equalize.  This does not alter any nested child equalize instances.
+
 ### Events
 
 Event callbacks happen on the parent equalize element.

--- a/docs/widgets/lazy.md
+++ b/docs/widgets/lazy.md
@@ -80,7 +80,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>throttle</td>
             <td>integer</td>
             <td>250</td>
-            <td>Timeout rate (milliseconds) for the throttle function helps to decrease unnecessary function calls through scroll or resize events.</td>
+            <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll or resize events.</td>
         </tr>
         <tr>
             <td>trigger</td>

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -340,10 +340,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>If the `unlink` method should be called when the modal is hidden.  This leaves the modal behind in the DOM.</td>
         </tr>
         <tr>
-            <td>destroy</td>
+            <td>dispose</td>
             <td>boolean</td>
             <td>false</td>
-            <td>If the `destroy` method should be called when the modal is hidden. This will remove the modal from the DOM.</td>
+            <td>If the `dispose` method should be called when the modal is hidden. This will remove the modal from the DOM.</td>
         </tr>
         <tr>
             <td>backdrop</td>
@@ -402,7 +402,7 @@ Hides a modal dialog.
 
 Hides the modal, removes events and attributes from both trigger and modal.
 
-#### `.CFW_Modal('destroy')`
+#### `.CFW_Modal('dispose')`
 {:.no_toc}
 
 Calls the `unlink` method, and then removes the modal from the DOM.
@@ -457,7 +457,7 @@ Event callbacks happen on the target `<div class="modal">` element.
             <td>This event is fired when a modal item has been unlinked from its trigger item and the data-api removed. This event can occur after the `afterHide` event when invoked from the `unlink` method, or before if set to automatically unlink.</td>
         </tr>
         <tr>
-            <td>destroy.cfw.modal</td>
+            <td>dispose.cfw.modal</td>
             <td>This event is fired immediately before the modal item is removed from the DOM.</td>
         </tr>
     </tbody>
@@ -482,7 +482,7 @@ A quick example:<br />
         <ul>
             <li><code>$('#myModal').CFW_Modal('hide');</code></li>
             <li>or <code>$('#myModal').CFW_Modal('unlink');</code></li>
-            <li>or <code>$('#myModal').CFW_Modal('destroy');</code></li>
+            <li>or <code>$('#myModal').CFW_Modal('dispose');</code></li>
         </ul>
     </li>
     <li>Update/create the modal object and insert into DOM.</li>

--- a/docs/widgets/overview.md
+++ b/docs/widgets/overview.md
@@ -112,7 +112,14 @@ $('#myModal').on('beforeShow.cfw.modal', function(e) {
 {% endhighlight %}
 
 ## No Fallbacks
+
 Figuration's widgets don't fallback or degrade gracefully when JavaScript is disabled. If you care about the user experience in this case, use `<noscript>` to explain the situation (and how to re-enable JavaScript) to your users, and/or add your own custom fallbacks.
+
+## Dipose Methods
+
+Every widget has a `dispose` method that should remove any event listeners and data, as well as nullify any constructed JavaScript variables associated with a given widget.  Certain widgets will also remove their dynamically created content or controls from the DOM.
+
+While most likely not needed in everyday use, there may be specific circumstances when this might be useful.  For example, if you are doing large amounts of dynamic content, in order to help with memory garbage collection, it might be beneficial to call the `dispose` on a widget before you remove the content from the DOM.
 
 ## Accessibility
 

--- a/docs/widgets/player.md
+++ b/docs/widgets/player.md
@@ -500,6 +500,11 @@ Change the caption/subtitle track.  `trackID` is the 0-indexed array of track it
 
 Change the transcript track.  `trackID` is the 0-indexed array of track items defined in the `<video>` element. Setting `trackID` to `-1` will turn off the transcript.
 
+#### `.CFW_Player('dispose')`
+{:.no_toc}
+
+Remove any associated transcript, sliders, dropdowns, data, and event listeners created by the player widget.
+
 ### Events
 
 Event callbacks happen on the `<audio>`/`<video>` element, but will bubble up through the DOM and can be captured on the `data-cfw="player"` wrapping container if needed.

--- a/docs/widgets/scrollspy.md
+++ b/docs/widgets/scrollspy.md
@@ -49,7 +49,6 @@ Scroll the area below the navbar and watch the active class change. The dropdown
     </div>
 </div> <!-- /.cf-example -->
 
-
 ## Usage
 
 ### Requires Relative Positioning
@@ -59,7 +58,7 @@ No matter the implementation method, scrollspy requires the use of `position: re
 {% callout danger %}
 #### Resolvable ID targets required
 
-Navbar links must have resolvable id targets. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`.
+Navigation links must have resolvable id targets. For example, a `<a href="#home">home</a>` must correspond to something in the DOM like `<div id="home"></div>`. Using a `data-target` attribute is also matched, in the example case the attribute would be `data-target="#home"`.
 {% endcallout %}
 
 {% callout info %}
@@ -70,7 +69,7 @@ Target elements that are not [`:visible` according to jQuery](https://api.jquery
 
 ### Via Data Attributes
 
-To easily add scrollspy behavior to your topbar navigation, add `data-cfw="scrollspy"` to the element you want to spy on (most typically this would be the `<body>`). Then add the `data-cfw-scrollspy-target` attribute with the ID or class of the parent element of any `.nav` component.
+To easily add scrollspy behavior to a navigation section, add `data-cfw="scrollspy"` to the element you want to spy on (most typically this would be the `<body>`). Then add the `data-cfw-scrollspy-target` attribute with the ID or class of any `<ul>`, `<ol>`, or `<nav>`, that use [Figuration nav component]({{ site.baseurl }}/components/navs/) markup, containing the subset of navigation links.
 
 {% highlight css %}
 body {
@@ -119,6 +118,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>10</td>
             <td>Pixels to offset from top when calculating position of scroll.</td>
         </tr>
+        <tr>
+            <td>throttle</td>
+            <td>integer</td>
+            <td>100</td>
+            <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll event.</td>
+        </tr>
     </tbody>
     </table>
 </div> <!-- /.table-responsive -->
@@ -146,6 +151,11 @@ $('[data-cfw="scrollspy"]').each(function() {
     var $spy = $(this).CFW_Scrollspy('refresh');
 });
 {% endhighlight %}
+
+#### `.CFW_Scrollspy('dispose')`
+{:.no_toc}
+
+Removes the associated event listener for the given scrollspy element, leaving the target navigation in its current state.
 
 ### Events
 

--- a/docs/widgets/slider.md
+++ b/docs/widgets/slider.md
@@ -249,6 +249,11 @@ Enable the slider.
 
 Disable the slider.
 
+#### `.CFW_Slider('dispose')`
+{:.no_toc}
+
+Detach the listen events and data for the slider, and remove the slider controls from the DOM.
+
 ### Events
 
 Event callbacks happen on the created slider element.

--- a/docs/widgets/slideshow.md
+++ b/docs/widgets/slideshow.md
@@ -22,30 +22,140 @@ Sideshow requires the following:
 * ToC goes here
 {:toc}
 
-## Example
+## Examples
 
-This example uses the [pagination componenent]({{ site.baseurl }}/components/pagination/), but it will also work with [tab]({{ site.baseurl }}/components/navs/#tabs) or [pill]({{ site.baseurl }}/components/navs/#pills) style navigation.
+### Using Tabs
+
+The slideshow works well with [tab navigation]({{ site.baseurl }}/components/navs/#tabs).
+
+<div class="cf-example">
+    <ul class="nav nav-tabs" data-cfw="slideshow">
+        <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+        <li class="nav-item"><a href="#tab-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
+        <li class="nav-item"><a href="#tab-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
+        <li class="nav-item"><a href="#tab-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
+        <li class="nav-item"><a href="#tab-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
+        <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    </ul>
+    <div class="tab-content">
+        <div class="tab-pane" id="tab-slide0">
+            <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+        </div>
+        <div class="tab-pane" id="tab-slide1">
+            <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit.</p>
+        </div>
+        <div class="tab-pane" id="tab-slide2">
+            <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+        </div>
+        <div class="tab-pane" id="tab-slide3">
+            <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+        </div>
+    </div>
+</div>
+
+{% highlight html %}
+<ul class="nav nav-tabs" data-cfw="slideshow">
+    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+    <li class="nav-item"><a href="#tab-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
+    <li class="nav-item"><a href="#tab-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
+    <li class="nav-item"><a href="#tab-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
+    <li class="nav-item"><a href="#tab-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
+    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+</ul>
+<div class="tab-content">
+    <div class="tab-pane" id="tab-slide0">
+        ...
+    </div>
+    <div class="tab-pane" id="tab-slide1">
+        ...
+    </div>
+    <div class="tab-pane" id="tab-slide2">
+        ...
+    </div>
+    <div class="tab-pane" id="tab-slide3">
+        ...
+    </div>
+</div>
+{% endhighlight %}
+
+### Using Pills
+
+The slideshow also works with [pill navigation]({{ site.baseurl }}/components/navs/#pills).
+
+<div class="cf-example">
+    <nav class="nav nav-pills" data-cfw="slideshow">
+        <a href="#" class="nav-item nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
+        <a href="#pill-slide0" class="nav-item nav-link" data-cfw="tab">Slide 1</a>
+        <a href="#pill-slide1" class="nav-item nav-link" data-cfw="tab">Slide 2</a>
+        <a href="#pill-slide2" class="nav-item nav-link" data-cfw="tab">Slide 3</a>
+        <a href="#pill-slide3" class="nav-item nav-link" data-cfw="tab">Slide 4</a>
+        <a href="#" class="nav-item nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
+    </nav>
+    <div class="tab-content">
+        <div class="tab-pane" id="pill-slide0">
+            <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+        </div>
+        <div class="tab-pane" id="pill-slide1">
+            <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit.</p>
+        </div>
+        <div class="tab-pane" id="pill-slide2">
+            <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+        </div>
+        <div class="tab-pane" id="pill-slide3">
+            <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+        </div>
+    </div>
+</div>
+
+{% highlight html %}
+<nav class="nav nav-pills" data-cfw="slideshow">
+    <a href="#" class="nav-item nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
+    <a href="#pill-slide0" class="nav-item nav-link" data-cfw="tab">Slide 1</a>
+    <a href="#pill-slide1" class="nav-item nav-link" data-cfw="tab">Slide 2</a>
+    <a href="#pill-slide2" class="nav-item nav-link" data-cfw="tab">Slide 3</a>
+    <a href="#pill-slide3" class="nav-item nav-link" data-cfw="tab">Slide 4</a>
+    <a href="#" class="nav-item nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
+</nav>
+<div class="tab-content">
+    <div class="tab-pane" id="pill-slide0">
+        ...
+    </div>
+    <div class="tab-pane" id="pill-slide1">
+        ...
+    </div>
+    <div class="tab-pane" id="pill-slide2">
+        ...
+    </div>
+    <div class="tab-pane" id="pill-slide3">
+        ...
+    </div>
+</div>
+{% endhighlight %}
+
+### Using Pagination
+
+You can even use the [pagination componenent]({{ site.baseurl }}/components/pagination/).
 
 <div class="cf-example">
     <ul class="pagination" data-cfw="slideshow">
         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-        <li class="page-item"><a href="#slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
-        <li class="page-item"><a href="#slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
-        <li class="page-item"><a href="#slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
-        <li class="page-item"><a href="#slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
+        <li class="page-item"><a href="#page-slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
+        <li class="page-item"><a href="#page-slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
+        <li class="page-item"><a href="#page-slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
+        <li class="page-item"><a href="#page-slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
     </ul>
     <div class="tab-content">
-        <div class="tab-pane" id="slide0">
+        <div class="tab-pane" id="page-slide0">
             <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
         </div>
-        <div class="tab-pane" id="slide1">
-            <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
+        <div class="tab-pane" id="page-slide1">
+            <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit.</p>
         </div>
-        <div class="tab-pane" id="slide2">
+        <div class="tab-pane" id="page-slide2">
             <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
         </div>
-        <div class="tab-pane" id="slide3">
+        <div class="tab-pane" id="page-slide3">
             <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
         </div>
     </div>
@@ -53,24 +163,78 @@ This example uses the [pagination componenent]({{ site.baseurl }}/components/pag
 
 {% highlight html %}
 <ul class="pagination" data-cfw="slideshow">
-    <li><a href="#" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-    <li><a href="#slide0" data-cfw="tab">Slide 1</a></li>
-    <li><a href="#slide1" data-cfw="tab">Slide 2</a></li>
-    <li><a href="#slide2" data-cfw="tab">Slide 3</a></li>
-    <li><a href="#slide3" data-cfw="tab">Slide 4</a></li>
-    <li><a href="#" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+    <li class="page-item"><a href="#page-slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
+    <li class="page-item"><a href="#page-slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
+    <li class="page-item"><a href="#page-slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
+    <li class="page-item"><a href="#page-slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
+    <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
 </ul>
 <div class="tab-content">
-    <div class="tab-pane" id="slide0">
+    <div class="tab-pane" id="page-slide0">
         ...
     </div>
-    <div class="tab-pane" id="slide1">
+    <div class="tab-pane" id="page-slide1">
         ...
     </div>
-    <div class="tab-pane" id="slide2">
+    <div class="tab-pane" id="page-slide2">
         ...
     </div>
-    <div class="tab-pane" id="slide3">
+    <div class="tab-pane" id="page-slide3">
+        ...
+    </div>
+</div>
+{% endhighlight %}
+
+### Disabled Tabs
+
+If there is a tab that is disabled, the previous and next navigation items will skip over the disabled item.
+
+<div class="cf-example">
+    <ul class="nav nav-tabs" data-cfw="slideshow">
+        <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+        <li class="nav-item"><a href="#ex-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
+        <li class="nav-item"><a href="#ex-slide1" class="nav-link disabled" data-cfw="tab">Slide 2</a></li>
+        <li class="nav-item"><a href="#ex-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
+        <li class="nav-item"><a href="#ex-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
+        <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    </ul>
+    <div class="tab-content">
+        <div class="tab-pane" id="ex-slide0">
+            <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+        </div>
+        <div class="tab-pane" id="ex-slide1">
+            <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit.</p>
+        </div>
+        <div class="tab-pane" id="ex-slide2">
+            <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+        </div>
+        <div class="tab-pane" id="ex-slide3">
+            <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+        </div>
+    </div>
+</div>
+
+{% highlight html %}
+<ul class="nav nav-tabs" data-cfw="slideshow">
+    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+    <li class="nav-item"><a href="#ex-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
+    <li class="nav-item"><a href="#ex-slide1" class="nav-link disabled" data-cfw="tab">Slide 2</a></li>
+    <li class="nav-item"><a href="#ex-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
+    <li class="nav-item"><a href="#ex-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
+    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+</ul>
+<div class="tab-content">
+    <div class="tab-pane" id="ex-slide0">
+        ...
+    </div>
+    <div class="tab-pane" id="ex-slide1">
+        ...
+    </div>
+    <div class="tab-pane" id="ex-slide2">
+        ...
+    </div>
+    <div class="tab-pane" id="ex-slide3">
         ...
     </div>
 </div>
@@ -124,6 +288,20 @@ Shows the previous slide, unless the first slide is current.
 
 Shows the next slide, unless the last slide is current.
 
+#### `.CFW_Slideshow('update')`
+{:.no_toc}
+
+Update the state of the navigation controls. Useful if there is a change to the tabs.
+
+#### `.CFW_Slideshow('dispose')`
+{:.no_toc}
+
+Disable the slideshow navigation controls and listeners.  This will leave the tab widget controls active.
+
+### Options
+
+None.
+
 ### Events
 
 Event callbacks happen on the slideshow element.
@@ -150,6 +328,10 @@ You can also get the tab events as indicated in the [Tab widget]({{ site.baseurl
         <tr>
             <td>next.cfw.slideshow</td>
             <td>This event fires before the call to activate the next slide.</td>
+        </tr>
+        <tr>
+            <td>update.cfw.slideshow</td>
+            <td>This event fires after the state of the navigation controls is updated.</td>
         </tr>
     </tbody>
     </table>

--- a/docs/widgets/tab-responsive.md
+++ b/docs/widgets/tab-responsive.md
@@ -129,6 +129,9 @@ $('#myTabResponsive').CFW_TabResponsive();
 
 ### Options
 
+None.
+
+{% comment %}
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tabResponsive`, as in `data-cfw-tabResponsive-active=true`.
 
 <div class="table-responsive">
@@ -151,6 +154,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </tbody>
     </table>
 </div> <!-- /.table-responsive -->
+{% endcomment %}
 
 ### Methods
 

--- a/docs/widgets/tab-responsive.md
+++ b/docs/widgets/tab-responsive.md
@@ -23,10 +23,6 @@ Sideshow requires the following:
 * ToC goes here
 {:toc}
 
-## Overview
-
-Tab-Responsive, removes and disables the use of `aria-hidden` attributes on the tab and collapse target items for accessibility, otherwise all content inside a Tab-Responsive widget would be hidden to screen readers.
-
 ## Example
 
 This example uses a breakpoint of 62em/992px.  Larger widths will see the tab style navigation, smaller widths will see a simple accordion using headers as the collapse triggers.  If you change the browser width between the two sides of the breakpoint, you will see the active tab becomes the active collapse, and vice-versa.

--- a/docs/widgets/tab.md
+++ b/docs/widgets/tab.md
@@ -128,12 +128,6 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
             <td>true</td>
             <td>If the tab pane target should fade in and out.</td>
         </tr>
-        <tr>
-            <td>hidden</td>
-            <td>boolean</td>
-            <td>true</td>
-            <td>Use the <code>aria-hidden</code> attribute on the target container to indicate visibility status to screen readers.</td>
-        </tr>
     </tbody>
     </table>
 </div> <!-- /.table-responsive -->

--- a/docs/widgets/tab.md
+++ b/docs/widgets/tab.md
@@ -187,11 +187,11 @@ When showing a new tab, the events fire in the following order:
             <td>This event fires on tab show after a tab has been shown. Use <code>event.target</code> and <code>event.relatedTarget</code> to target the active tab and the previous active tab (if available) respectively.</td>
         </tr>
         <tr>
-            <td>beforeHhide.cfw.tab</td>
+            <td>beforeHide.cfw.tab</td>
             <td>This event fires when a new tab is to be shown (and thus the previous active tab is to be hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the current active tab and the new soon-to-be-active tab, respectively.</td>
         </tr>
         <tr>
-            <td>afterHhide.cfw.tab</td>
+            <td>afterHide.cfw.tab</td>
             <td>This event fires after a new tab is shown (and thus the previous active tab is hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the previous active tab and the new active tab, respectively.</td>
         </tr>
     </tbody>

--- a/docs/widgets/tab.md
+++ b/docs/widgets/tab.md
@@ -150,6 +150,11 @@ $('#myTab a').CFW_Tab({
 
 Shows the `tab-pane` for a given tab, and hides all sibling `tab-pane` items.
 
+#### `.CFW_Tab('dispose')`
+{:.no_toc}
+
+Will disable the listen events for the given tab, but leave it otherwise unchanged.
+
 ### Events
 Event callbacks happen on the toggle/trigger element.
 

--- a/js/accordion.js
+++ b/js/accordion.js
@@ -8,58 +8,51 @@
 (function($) {
     'use strict';
 
-    if ($.fn.CFW_Collapse === undefined) throw new Error('CFW_Accordion requires collapse.js');
+    if ($.fn.CFW_Collapse === undefined) throw new Error('CFW_Accordion requires CFW_Collapse');
 
-    var CFW_Widget_Accordion = function(element, options) {
+    var CFW_Widget_Accordion = function(element) {
         this.$element = $(element);
-
-        var parsedData = this.$element.CFW_parseData('accordion', CFW_Widget_Accordion.DEFAULTS);
-        this.settings = $.extend({}, CFW_Widget_Accordion.DEFAULTS, parsedData, options);
-
         this._init();
-    };
-
-    CFW_Widget_Accordion.DEFAULTS = {
-        active: false     // [TODO} ???
     };
 
     CFW_Widget_Accordion.prototype = {
         _init : function() {
             var $selfRef = this;
 
-            this.$element.attr('data-cfw', 'accordion');
-
-            this.$element.on('beforeShow.cfw.collapse', function(e) {
-                if (e.isDefaultPrevented()) { return; }
-                $selfRef.updateCollapse(e);
-            });
-
-            this.$element.CFW_trigger('init.cfw.accordion');
+            this.$element
+                .attr('data-cfw', 'accordion')
+                .on('beforeShow.cfw.collapse', function(e) {
+                    if (e.isDefaultPrevented()) { return; }
+                    $selfRef._update(e);
+                })
+                .CFW_trigger('init.cfw.accordion');
         },
 
-        updateCollapse : function(e) {
-            var hasActive = false;
-            var $activeCollapse = $(e.target);
+        _update : function(e) {
+            var inTransition = false;
+            var $current = $(e.target);
             var $collapse = this.$element.find('[data-cfw="collapse"]');
 
             $collapse.each(function() {
                 if ($(this).data('cfw.collapse').inTransition === 1) {
-                    hasActive = true;
+                    inTransition = true;
                 }
             });
 
-            if (hasActive) {
+            if (inTransition) {
                 e.preventDefault();
                 return;
             }
 
-            $collapse.each(function() {
-                var $this = $(this);
-                if ($this.is($activeCollapse)) {
-                    return;
-                }
-                $this.CFW_Collapse('hide');
-            });
+            $collapse.not($current).CFW_Collapse('hide');
+        },
+
+        dispose : function() {
+            this.$element
+                .off('.cfw.collapse')
+                .removeData('cfw.accordion');
+
+            this.$element = null;
         }
     };
 
@@ -67,11 +60,9 @@
         var args = [].splice.call(arguments, 1);
         return this.each(function() {
             var $this = $(this);
-            var data = $this.data('cfw.Accordion');
-            var options = typeof option === 'object' && option;
-
+            var data = $this.data('cfw.accordion');
             if (!data) {
-                $this.data('cfw.Accordion', (data = new CFW_Widget_Accordion(this, options)));
+                $this.data('cfw.accordion', (data = new CFW_Widget_Accordion(this)));
             }
             if (typeof option === 'string') {
                 data[option].apply(data, args);

--- a/js/affix.js
+++ b/js/affix.js
@@ -66,7 +66,6 @@
             return false;
         },
 
-
         getPinnedOffset : function() {
             if (this.pinnedOffset) { return this.pinnedOffset; }
             this.$element.removeClass(CFW_Widget_Affix.RESET).addClass('affix');
@@ -121,6 +120,21 @@
                     top: scrollHeight - height - offsetBottom
                 });
             }
+        },
+
+        dispose : function() {
+            this.$element
+                .off('.cfw.affix')
+                .removeClass(CFW_Widget_Affix.RESET)
+                .removeData('cfw.affix');
+
+            this.$element = null;
+            this.$window = null;
+            this.$target = null;
+            this.affixed = null;
+            this.unpin = null;
+            this.pinnedOffset = null;
+            this.settings = null;
         }
     };
 

--- a/js/alert.js
+++ b/js/alert.js
@@ -37,14 +37,13 @@
                 this.$parent.addClass('fade in');
             }
 
-            this.$parent.on('click.cfw.alert', dismiss, function() {
-                $selfRef.close();
-            });
-
-            this.$parent.data('cfw.alert', this);
-            this.$parent.find(dismiss).data('cfw.alert', this);
-
-            this.$parent.CFW_trigger('init.cfw.alert');
+            this.$parent
+                .on('click.cfw.alert', dismiss, function() {
+                    $selfRef.close();
+                })
+                .data('cfw.alert', this)
+                .find(dismiss).data('cfw.alert', this)
+                .CFW_trigger('init.cfw.alert');
         },
 
         close : function(e) {
@@ -62,15 +61,16 @@
 
             function removeElement() {
                 // Detach from parent, fire event then clean up data
-                $selfRef.$parent.detach();
-                $selfRef.inTransition = 0;
-                $selfRef.$parent.CFW_trigger('afterClose.cfw.alert');
+                $selfRef.$parent
+                    .detach()
+                    .CFW_trigger('afterClose.cfw.alert');
                 $selfRef.$parent.remove();
+                $selfRef.inTransition = 0;
             }
 
-            this.$parent.removeClass('in');
-
-            this.$parent.CFW_transition(null, removeElement);
+            this.$parent
+                .removeClass('in')
+                .CFW_transition(null, removeElement);
         },
 
         findParent : function() {
@@ -87,6 +87,16 @@
             }
 
             this.$parent = $parent;
+        },
+
+        dispose : function() {
+            this.$parent.off('.cfw.alert');
+            this.$element.removeData('cfw.alert');
+
+            this.$element = null;
+            this.$parent = null;
+            this.inTransition = null;
+            this.settings = null;
         }
     };
 
@@ -111,8 +121,9 @@
 
     // API
     // ===
-    $(document).on('click.cfw.alert', dismiss, function() {
-        $(this).CFW_Alert('close');
-    });
-
+    if (typeof CFW_API === 'undefined' || CFW_API !== false) {
+        $(document).on('click.cfw.alert', dismiss, function() {
+            $(this).CFW_Alert('close');
+        });
+    }
 })(jQuery);

--- a/js/button.js
+++ b/js/button.js
@@ -71,20 +71,31 @@
                     }
 
                     if (changed) {
-                        $input.prop('checked', !this.$element.hasClass('active'));
-                        $input.trigger('change');
+                        $input.prop('checked', !this.$element.hasClass('active'))
+                            .trigger('change');
                     }
                 }
             }
 
             if (changed) {
-                this.$element.attr('aria-pressed', !this.$element.hasClass('active'));
-                this.$element.toggleClass('active');
+                this.$element
+                    .attr('aria-pressed', !this.$element.hasClass('active'))
+                    .toggleClass('active');
             }
+        },
+
+        dispose : function() {
+            this.$element
+                .off('.cfw.button')
+                .removeData('cfw.button');
+
+            this.$element = null;
+            this.$parent = null;
         }
     };
 
     function Plugin(option) {
+        var args = [].splice.call(arguments, 1);
         return this.each(function() {
             var $this = $(this);
             var data = $this.data('cfw.button');
@@ -99,7 +110,9 @@
                 if (!data) {
                     $this.data('cfw.button', (data = new CFW_Widget_Button(this, options)));
                 }
-                if (option == 'toggle') data.toggle();
+                if (typeof option === 'string') {
+                    data[option].apply(data, args);
+                }
             }
         });
     }

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -123,7 +123,11 @@
 
             this.inTransition = true;
             this.$triggers.addClass('open');
-            this.$target.removeClass('collapse').addClass('collapsing')[dimension](0);
+
+            this.$target.removeClass('collapse')[dimension](0);
+            if (this.settings.animate) {
+                this.$target.addClass('collapsing');
+            }
 
             var scrollSize = $.camelCase(['scroll', dimension].join('-'));
 
@@ -171,7 +175,10 @@
                 var $this = $(this);
                 $this[dimension]($this[dimension]())[0].offsetHeight;
             });
-            this.$target.addClass('collapsing').removeClass('collapse in');
+            this.$target.removeClass('collapse in');
+            if (this.settings.animate) {
+                this.$target.addClass('collapsing');
+            }
 
             // Determine/unset dimension size for each target (triggers the transition)
             function start() {
@@ -190,6 +197,14 @@
 
             // Bind transition callback to first target
             this.$target.eq(0).CFW_transition(start, complete);
+        },
+
+        animDisable : function() {
+            this.settings.animate = false;
+        },
+
+        animEnable: function() {
+            this.settings.animate = true;
         },
 
         dispose : function() {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -24,8 +24,7 @@
         toggle     : null,
         animate    : true,  // If collapse targets should expand and contract
         follow     : false, // If browser focus should move when a collapse toggle is activated
-        horizontal : false, // If collapse should transition horizontal (vertical is default)
-        hidden     : true   // Use aria-hidden on target containers by default
+        horizontal : false  // If collapse should transition horizontal (vertical is default)
     };
 
     CFW_Widget_Collapse.prototype = {
@@ -83,9 +82,6 @@
                 this.$target.addClass('collapse in')[dimension]('');
             } else {
                 this.$triggers.attr('aria-expanded', 'false');
-                if (this.settings.hidden) {
-                    this.$target.attr('aria-hidden', 'true');
-                }
             }
 
             // Bind click handler
@@ -140,7 +136,7 @@
 
             function complete() {
                 $selfRef.$triggers.attr('aria-expanded', 'true');
-                $selfRef.$target.removeClass('collapsing').addClass('collapse in').removeAttr('aria-hidden')[dimension]('');
+                $selfRef.$target.removeClass('collapsing').addClass('collapse in')[dimension]('');
                 $selfRef.inTransition = false;
                 if (follow) {
                     $selfRef.$target.attr('tabindex', '-1').get(0).trigger('focus');
@@ -185,9 +181,6 @@
             function complete() {
                 $selfRef.$triggers.attr('aria-expanded', 'false');
                 $selfRef.$target.removeClass('collapsing in').addClass('collapse');
-                if ($selfRef.settings.hidden){
-                    $selfRef.$target.attr('aria-hidden', 'true');
-                }
                 $selfRef.inTransition = false;
                 if (follow) {
                     $selfRef.$element.trigger('focus');
@@ -197,11 +190,6 @@
 
             // Bind transition callback to first target
             this.$target.eq(0).CFW_transition(start, complete);
-        },
-
-        hiddenDisable : function() {
-            this.$target.removeAttr('aria-hidden');
-            this.settings.hidden = false;
         },
 
         dispose : function() {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -9,12 +9,12 @@
     'use strict';
 
     var CFW_Widget_Collapse = function(element, options) {
-        this.$triggerElm = $(element);
-        this.$targetElm = null;
-        this.inTransition = null;
-        this.$triggerColl = null;
+        this.$element = $(element);
+        this.$target = null;
+        this.$triggers = null;
+        this.inTransition = false;
 
-        var parsedData = this.$triggerElm.CFW_parseData('collapse', CFW_Widget_Collapse.DEFAULTS);
+        var parsedData = this.$element.CFW_parseData('collapse', CFW_Widget_Collapse.DEFAULTS);
         this.settings = $.extend({}, CFW_Widget_Collapse.DEFAULTS, parsedData, options);
 
         this._init();
@@ -35,67 +35,68 @@
             var collapseID = this.settings.toggle;
 
             // Find target by id/css selector
-            var $targetElm = $(this.settings.toggle);
-            if (!$targetElm.length) {
+            var $target = $(this.settings.toggle);
+            if (!$target.length) {
                 // Get target (box) items
-                $targetElm = $('[data-cfw-collapse-target="' + collapseID + '"]');
+                $target = $('[data-cfw-collapse-target="' + collapseID + '"]');
             }
-            if (!$targetElm.length) {
-                collapseID = this.$triggerElm.attr('href');
-                $targetElm = $(collapseID);
+            if (!$target.length) {
+                collapseID = this.$element.attr('href');
+                $target = $(collapseID);
             }
-            if (!$targetElm.length) { return false; }
+            if (!$target.length) { return false; }
             if ((collapseID === undefined) || (collapseID.length <= 0)) { return false; }
-            this.$targetElm = $targetElm;
+            this.$target = $target;
 
-            this.$triggerElm.attr({
+            this.$element.attr({
                 'data-cfw': 'collapse',
                 'data-cfw-collapse-toggle': collapseID
             });
 
             // Build trigger collection
-            this.$triggerColl = $('[data-cfw="collapse"][data-cfw-collapse-toggle="' + collapseID + '"]');
+            this.$triggers = $('[data-cfw="collapse"][data-cfw-collapse-toggle="' + collapseID + '"],' +
+                '[data-cfw="collapse"][href="' + collapseID + '"]');
 
             // Check for presence of trigger id - set if not present
-            // var triggerID = this.$triggerElm.CFW_getID('cfw-collapse');
+            // var triggerID = this.$element.CFW_getID('cfw-collapse');
 
             // Add collpase class(es)
-            this.$targetElm.addClass('collapse');
+            this.$target.addClass('collapse');
             if (this.settings.horizontal) {
-                this.$targetElm.addClass('width');
+                this.$target.addClass('width');
             }
 
             // A button can control multiple boxes so we need to id each on box individually
             var targetList = '';
 
-            this.$targetElm.each(function() {
+            this.$target.each(function() {
                 var tempID = $(this).CFW_getID('cfw-collapse');
                 targetList += (tempID + ' ');
             });
             // Set ARIA on trigger
-            this.$triggerColl.attr('aria-controls', $.trim(targetList));
+            this.$triggers.attr('aria-controls', $.trim(targetList));
 
             // Determine default state
             var dimension = this.dimension();
-            if (this.$triggerColl.hasClass('open')) {
-                this.$triggerColl.attr('aria-expanded', 'true');
-                this.$targetElm.addClass('collapse in')[dimension]('');
+            if (this.$triggers.hasClass('open')) {
+                this.$triggers.attr('aria-expanded', 'true');
+                this.$target.addClass('collapse in')[dimension]('');
             } else {
-                this.$triggerColl.attr('aria-expanded', 'false');
+                this.$triggers.attr('aria-expanded', 'false');
                 if (this.settings.hidden) {
-                    this.$targetElm.attr('aria-hidden', 'true');
+                    this.$target.attr('aria-hidden', 'true');
                 }
             }
 
             // Bind click handler
-            this.$triggerElm.on('click.cfw.collapse.toggle', $.proxy(this.toggle, this));
-
-            this.$triggerElm.CFW_trigger('init.cfw.collapse');
+            this.$element
+                .on('click.cfw.collapse.toggle', $.proxy(this.toggle, this))
+                .CFW_trigger('init.cfw.collapse');
         },
 
         toggle : function(e) {
             if (e) { e.preventDefault(); }
-            if (this.$triggerElm.hasClass('open') || this.$targetElm.hasClass('in')) {
+            if (this.$element.hasClass('open') || this.$target.hasClass('in')) {
                 this.hide();
             } else {
                 this.show();
@@ -103,7 +104,7 @@
         },
 
         dimension : function() {
-            var hasWidth = this.$targetElm.hasClass('width');
+            var hasWidth = this.$target.hasClass('width');
             if (hasWidth || this.settings.horizontal) {
                 return 'width';
             }
@@ -113,96 +114,106 @@
         show : function(follow) {
             var $selfRef = this;
             if (follow === null) { follow = this.settings.follow; }
-            this.settings.showFollow = follow;
 
             // Bail if transition in progress
-            if (this.inTransition || this.$targetElm.hasClass('in')) { return; }
+            if (this.inTransition || this.$target.hasClass('in')) { return; }
 
             // Start open transition
-            if (!this.$triggerElm.CFW_trigger('beforeShow.cfw.collapse')) {
+            if (!this.$element.CFW_trigger('beforeShow.cfw.collapse')) {
                 return;
             }
 
             var dimension = this.dimension();
 
-            this.inTransition = 1;
-            this.$triggerColl.addClass('open');
-            this.$targetElm.removeClass('collapse').addClass('collapsing')[dimension](0);
+            this.inTransition = true;
+            this.$triggers.addClass('open');
+            this.$target.removeClass('collapse').addClass('collapsing')[dimension](0);
 
             var scrollSize = $.camelCase(['scroll', dimension].join('-'));
 
             // Determine/set dimension size for each target (triggers the transition)
             function start() {
-                $selfRef.$targetElm.each(function() {
+                $selfRef.$target.each(function() {
                     $(this)[dimension]($(this)[0][scrollSize]);
                 });
             }
+
+            function complete() {
+                $selfRef.$triggers.attr('aria-expanded', 'true');
+                $selfRef.$target.removeClass('collapsing').addClass('collapse in').removeAttr('aria-hidden')[dimension]('');
+                $selfRef.inTransition = false;
+                if (follow) {
+                    $selfRef.$target.attr('tabindex', '-1').get(0).trigger('focus');
+                }
+                $selfRef.$element.CFW_trigger('afterShow.cfw.collapse');
+            }
+
             // Bind transition callback to first target
-            this.$targetElm.eq(0).CFW_transition(start, $.proxy(this._showComplete, this));
+            this.$target.eq(0).CFW_transition(start, complete);
         },
 
         hide : function(follow) {
             var $selfRef = this;
 
             if (follow === null) { follow = this.settings.follow; }
-            this.settings.hideFollow = follow;
 
             // Bail if transition in progress
-            if (this.inTransition || !this.$targetElm.hasClass('in')) { return; }
+            if (this.inTransition || !this.$target.hasClass('in')) { return; }
 
             // Start close transition
-            if (!this.$triggerElm.CFW_trigger('beforeHide.cfw.collapse')) {
+            if (!this.$element.CFW_trigger('beforeHide.cfw.collapse')) {
                 return;
             }
 
             var dimension = this.dimension();
 
-            this.inTransition = 1;
-            this.$triggerColl.removeClass('open');
+            this.inTransition = true;
+            this.$triggers.removeClass('open');
 
             // Set dimension size and reflow before class changes for Chrome/Webkit or no animation occurs
-            this.$targetElm.each(function() {
+            this.$target.each(function() {
                 var $this = $(this);
                 $this[dimension]($this[dimension]())[0].offsetHeight;
             });
-            this.$targetElm.addClass('collapsing').removeClass('collapse in');
+            this.$target.addClass('collapsing').removeClass('collapse in');
 
             // Determine/unset dimension size for each target (triggers the transition)
             function start() {
-                $selfRef.$targetElm[dimension]('');
+                $selfRef.$target[dimension]('');
             }
-            // Bind transition callback to first target
-            this.$targetElm.eq(0).CFW_transition(start, $.proxy(this._hideComplete, this));
 
+            function complete() {
+                $selfRef.$triggers.attr('aria-expanded', 'false');
+                $selfRef.$target.removeClass('collapsing in').addClass('collapse');
+                if ($selfRef.settings.hidden){
+                    $selfRef.$target.attr('aria-hidden', 'true');
+                }
+                $selfRef.inTransition = false;
+                if (follow) {
+                    $selfRef.$element.trigger('focus');
+                }
+                $selfRef.$element.CFW_trigger('afterHide.cfw.collapse');
+            }
+
+            // Bind transition callback to first target
+            this.$target.eq(0).CFW_transition(start, complete);
         },
 
         hiddenDisable : function() {
-            this.$targetElm.removeAttr('aria-hidden');
+            this.$target.removeAttr('aria-hidden');
             this.settings.hidden = false;
         },
 
-        _showComplete : function() {
-            var dimension = this.dimension();
-            this.$triggerColl.attr('aria-expanded', 'true');
-            this.$targetElm.removeClass('collapsing').addClass('collapse in').removeAttr('aria-hidden')[dimension]('');
-            this.inTransition = 0;
-            if (this.settings.showFollow) {
-                this.$targetElm.attr('tabindex', '-1').get(0).trigger('focus');
-            }
-            this.$triggerElm.CFW_trigger('afterShow.cfw.collapse');
-        },
+        dispose : function() {
+            this.$element
+                .off('.cfw.collapse')
+                .removeData('cfw.collapse');
 
-        _hideComplete : function() {
-            this.$triggerColl.attr('aria-expanded', 'false');
-            this.$targetElm.removeClass('collapsing in').addClass('collapse');
-            if (this.settings.hidden){
-                this.$targetElm.attr('aria-hidden', 'true');
-            }
-            this.inTransition = 0;
-            if (this.settings.hideFollow) {
-                this.$triggerColl.get(0).trigger('focus');
-            }
-            this.$triggerElm.CFW_trigger('afterHide.cfw.collapse');
+            this.$element = null;
+            this.$target = null;
+            this.$triggers = null;
+            this.inTransition = null;
+            this.settings = null;
         }
     };
 

--- a/js/common.js
+++ b/js/common.js
@@ -12,6 +12,9 @@
         var $scope = $(this);
         if (!$scope) { $scope = $(document.body); }
 
+        $('[data-cfw-dismisss="alert"]', $scope).each(function() {
+            $(this).CFW_Alert();
+        });
         $('[data-cfw^="button"]', $scope).each(function() {
             $(this).CFW_Button();
         });

--- a/js/drag.js
+++ b/js/drag.js
@@ -9,7 +9,6 @@
     'use strict';
 
     var CFW_Widget_Drag = function(element, options) {
-        this.element = element;
         this.$element = $(element);
         this.dragging = false;
         this.dragdata = {};
@@ -31,29 +30,34 @@
             this.$element.CFW_trigger('init.cfw.drag');
         },
 
-        destroy : function() {
-            this.dragging = false;
-            this.dragdata = null;
+        dispose : function() {
+            this._dragStartOff();
             this.$element
                 .off('.cfw.drag')
                 .removeData('cfw.drag');
-            if (this.detachEvent) {
-                this.detachEvent('ondragstart', this.__dontstart);
+
+            this.$element = null;
+            this.dragging = null;
+            this.dragdata = null;
+            this.settings = null;
+
+            if (this.$element[0].detachEvent) {
+                this.$element[0].detachEvent('ondragstart', this._dontStart);
             }
         },
 
         _dragStartOn : function() {
             this.$element.on('mousedown.cfw.dragstart touchstart.cfw.dragstart MSPointerDown.cfw.dragstart', $.proxy(this._dragStart, this));
+            // prevent image dragging in IE...
+            if (this.$element[0].attachEvent) {
+                this.$element[0].attachEvent('ondragstart', this._dontStart);
+            }
         },
 
         _dragStartOff : function(e) {
-            e.preventDefault();
+            if (e) e.preventDefault();
             $(document).off('.cfw.dragin');
             this.$element.off('.cfw.dragstart');
-            // prevent image dragging in IE...
-            if (this.element.attachEvent) {
-                this.element.attachEvent('ondragstart', this.__dontstart);
-            }
         },
 
         _dragStart : function(e) {
@@ -150,7 +154,7 @@
             return p;
         },
 
-        __dontstart : function() {
+        _dontStart : function() {
             return false;
         }
     };
@@ -162,7 +166,7 @@
             var data = $this.data('cfw.drag');
             var options = typeof option === 'object' && option;
 
-            if (!data && /destroy/.test(option)) {
+            if (!data && /dispose/.test(option)) {
                 return false;
             }
             if (!data) {

--- a/js/drag.js
+++ b/js/drag.js
@@ -31,6 +31,9 @@
         },
 
         dispose : function() {
+            if (this.$element[0].detachEvent) {
+                this.$element[0].detachEvent('ondragstart', this._dontStart);
+            }
             this._dragStartOff();
             this.$element
                 .off('.cfw.drag')
@@ -40,10 +43,6 @@
             this.dragging = null;
             this.dragdata = null;
             this.settings = null;
-
-            if (this.$element[0].detachEvent) {
-                this.$element[0].detachEvent('ondragstart', this._dontStart);
-            }
         },
 
         _dragStartOn : function() {

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -11,9 +11,8 @@
     var CFW_Widget_Lazy = function(element, options) {
         this.$element = $(element);
         this.$window = $(window);
-        this.eventTypes = null;
-        this.id = null;
-        this.isLoading = null;
+        this.instance = null;
+        this.inTransition = null;
 
         var parsedData = this.$element.CFW_parseData('lazy', CFW_Widget_Lazy.DEFAULTS);
         this.settings = $.extend({}, CFW_Widget_Lazy.DEFAULTS, parsedData, options);
@@ -30,7 +29,7 @@
         speed     : 0,          // Speed of effect (milliseconds)
         threshold : 0,          // Amount of pixels below viewport to triger show
         container : window,     // Where to watch for events
-        invisible : false,       // Load sources that are not :visible
+        invisible : false,      // Load sources that are not :visible
         placeholder: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
     };
 
@@ -48,17 +47,17 @@
                 }
             }
 
-            this.id = this.$element.CFW_getID('cfw-lazy');
+            this.instance = this.$element.CFW_getID('cfw-lazy');
 
             // Bind events
-            this.eventTypes = this.settings.trigger.split(' ');
-            for (var i = this.eventTypes.length; i--;) {
-                var eventType = this.eventTypes[i];
+            var eventTypes = this.settings.trigger.split(' ');
+            for (var i = eventTypes.length; i--;) {
+                var eventType = eventTypes[i];
                 if (eventType == 'scroll' || eventType == 'resize') {
-                    $(this.settings.container).on(eventType + '.cfw.lazy.' + this.id, $().CFW_throttle($.proxy(this._handleTrigger, this), this.settings.throttle));
+                    $(this.settings.container).on(eventType + '.cfw.lazy.' + this.instance, $().CFW_throttle($.proxy(this._handleTrigger, this), this.settings.throttle));
                     checkInitViewport = true;
                 } else {
-                    $(this.$element).on(eventType + '.cfw.lazy.' + this.id, $.proxy(this.show, this));
+                    $(this.$element).on(eventType + '.cfw.lazy', $.proxy(this.show, this));
                 }
             }
 
@@ -76,7 +75,7 @@
 
         belowFold : function() {
             var fold;
-            if (this.settings.container === undefined || this.settings.container === window) {
+            if (this.settings.container === window) {
                 fold = (window.innerHeight ? window.innerHeight : this.$window.height()) + this.$window.scrollTop();
             } else {
                 fold = $(this.settings.container).offset().top + $(this.settings.container).height();
@@ -86,7 +85,7 @@
 
         afterRight : function() {
             var fold;
-            if (this.settings.container === undefined || this.settings.container === window) {
+            if (this.settings.container === window) {
                 fold = this.$window.width() + this.$window.scrollLeft();
             } else {
                 fold = $(this.settings.container).offset().left + $(this.settings.container).width();
@@ -96,7 +95,7 @@
 
         aboveTop : function() {
             var fold;
-            if (this.settings.container === undefined || this.settings.container === window) {
+            if (this.settings.container === window) {
                 fold = this.$window.scrollTop();
             } else {
                 fold = $(this.settings.container).offset().top;
@@ -106,7 +105,7 @@
 
         beforeLeft: function() {
             var fold;
-            if (this.settings.container === undefined || this.settings.container === window) {
+            if (this.settings.container === window) {
                 fold = this.$window.scrollLeft();
             } else {
                 fold = $(this.settings.container).offset().left;
@@ -123,25 +122,21 @@
             this.$element[this.settings.effect](this.settings.speed);
 
             setTimeout(function() {
+console.log($selfRef.$element);
                 $selfRef.$element.CFW_trigger('afterShow.cfw.lazy');
+                $selfRef.dispose();
             }, this.settings.speed);
-
-            // Unbind events and unset data
-            $(this.settings.container).off('.cfw.lazy.' + this.id);
-            this.$element.off('.cfw.lazy.' + this.id)
-                .removeData('cfw.lazy')
-                .removeAttr('data-cfw');
         },
 
         show : function() {
             var $selfRef = this;
-            if (this.isLoading) { return; }
+            if (this.inTransition) { return; }
 
             if (!this.$element.CFW_trigger('beforeShow.cfw.lazy')) {
                 return;
             }
 
-            this.isLoading = true;
+            this.inTransition = true;
 
             setTimeout(function() {
                 $selfRef.loadSrc();
@@ -149,7 +144,24 @@
         },
 
         _handleTrigger : function() {
-            if (this.inViewport()) { this.show(); }
+            // Handle delayed event calls by checking for null
+            if (this.$element !== null) {
+                if (this.inViewport()) { this.show(); }
+            }
+        },
+
+        dispose : function() {
+            $(this.settings.container).off('.cfw.lazy.' + this.instance);
+            this.$element.off('.cfw.lazy')
+                .removeData('cfw.lazy')
+                .removeAttr('data-cfw');
+
+            this.$element = null;
+            this.$window = null;
+            this.instance = null;
+            this.inTransition = null;
+            this.settings = null;
+
         }
     };
 

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -122,7 +122,6 @@
             this.$element[this.settings.effect](this.settings.speed);
 
             setTimeout(function() {
-console.log($selfRef.$element);
                 $selfRef.$element.CFW_trigger('afterShow.cfw.lazy');
                 $selfRef.dispose();
             }, this.settings.speed);

--- a/js/player.js
+++ b/js/player.js
@@ -1308,6 +1308,56 @@
                     $selfRef.$focus.trigger('focus');
                 }
             }, 10);
+        },
+
+        dispose : function() {
+            clearTimeout(this.activityTimer);
+            if (this.$scriptElm) {
+                $('.player-scripttxt-seekpoint', this.$scriptElm).off();
+                this.$scriptElm.remove();
+            }
+            if (this.$sliderSeek) {
+                this.$sliderSeek.CFW_Slider('dispose');
+            }
+            if (this.$volSeek) {
+                this.$volSeek.CFW_Slider('dispose');
+            }
+            if ($.hasData(this.$player.find('[data-cfw-player="caption"]'))) {
+                this.$player.find('[data-cfw-player="caption"]').CFW_Dropdown('dispose');
+            }
+            if ($.hasData(this.$player.find('[data-cfw-player="transcript"]'))) {
+                this.$player.find('[data-cfw-player="transcript"]').CFW_Dropdown('dispose');
+            }
+            this.$player.off();
+            this.$media.off();
+
+            this.$element
+                .off()
+                .removeData('cfw.player');
+
+            this.$element = null;
+            this.type = null;
+            this.$media = null;
+            this.media = null;
+            this.$player = null;
+            this.$focus = null;
+            this.$sliderSeek = null;
+            this.$volSeek = null;
+            this.activity = null;
+            this.over = null;
+            this.userActive = null;
+            this.activityTimer = null;
+            this.mouseActivity = null;
+            this.scrubPlay = null;
+            this.played = null;
+            this.status = null;
+            this.support = null;
+            this.trackValid = null;
+            this.trackCurrent = null;
+            this.$scriptElm = null;
+            this.scriptCurrent = null;
+            this.scriptCues = null;
+            this.settings = null;
         }
     };
 
@@ -1330,15 +1380,4 @@
     $.fn.CFW_Player = Plugin;
     $.fn.CFW_Player.Constructor = CFW_Widget_Player;
 
-    /*
-    // API
-    // ===
-    $(window).ready(function() {
-        if (typeof CFW_API === 'undefined' || CFW_API !== false) {
-            $('[data-cfw="player"]').each(function() {
-                $(this).CFW_Player();
-            });
-        }
-    });
-    */
 })(jQuery);

--- a/js/popover.js
+++ b/js/popover.js
@@ -15,10 +15,6 @@
         this.docAdded = false;
         this.keyTimer = null;
         this.keyDelay = 750;
-        this.flags = {
-            keyShift: false,
-            keyTab : false
-        };
 
         this._init('popover', element, options);
     };
@@ -264,7 +260,7 @@
             var data = $this.data('cfw.popover');
             var options = typeof option === 'object' && option;
 
-            if (!data && /unlink|destroy|hide/.test(option)) {
+            if (!data && /unlink|dispose|hide/.test(option)) {
                 return false;
             }
             if (!data) {

--- a/js/popover.js
+++ b/js/popover.js
@@ -8,7 +8,7 @@
 (function($) {
     'use strict';
 
-    if ($.fn.CFW_Tooltip === undefined) throw new Error('CFW_Popover requires tooltip.js');
+    if ($.fn.CFW_Tooltip === undefined) throw new Error('CFW_Popover requires CFW_Tooltip');
 
     var CFW_Widget_Popover = function(element, options) {
         this.dragAdded = false;

--- a/js/popover.js
+++ b/js/popover.js
@@ -48,7 +48,7 @@
     };
 
     CFW_Widget_Popover.prototype.setContent = function() {
-        var $tip = this.$targetElm;
+        var $tip = this.$target;
         var $title = $tip.find('.popover-title');
         var $content = $tip.find('.popover-content');
 
@@ -72,19 +72,19 @@
         // Use '.popover-title' for labelledby
         if ($title.length) {
             var labelledby = $title.eq(0).CFW_getID('cfw-popover');
-            this.$targetElm.attr('aria-labelledby', labelledby);
+            this.$target.attr('aria-labelledby', labelledby);
         }
 
         if (this.settings.drag && !this.dragAdded) {
-            if (this.$targetElm.find('[data-cfw-drag="' + this.type + '"]').length <= 0) {
+            if (this.$target.find('[data-cfw-drag="' + this.type + '"]').length <= 0) {
                 var $drag = $('<span role="button" tabindex="0" class="drag" data-cfw-drag="' + this.type +  '" aria-label="' + this.settings.dragsrtext + '">' + this.settings.dragtext + '</span>');
-                $drag.insertAfter(this.$targetElm.find('.close').eq(0));
+                $drag.insertAfter(this.$target.find('.close').eq(0));
                 this.dragAdded = true;
             }
         }
 
-        if (this.$targetElm.find('[data-cfw-drag="' + this.type + '"]').length) {
-            this.$targetElm.addClass('draggable');
+        if (this.$target.find('[data-cfw-drag="' + this.type + '"]').length) {
+            this.$target.addClass('draggable');
             // Force settings
             this.settings.trigger = 'click';
             this.settings.container = 'body';
@@ -96,22 +96,22 @@
 
         if (!$title.html()) { $title.hide(); }
 
-        if ((this.$targetElm.attr('role') == 'dialog') && (!this.docAdded)) {
+        if ((this.$target.attr('role') == 'dialog') && (!this.docAdded)) {
             // Inject a role="document" container
-            var $children = this.$targetElm.children().not(this.$arrow);
+            var $children = this.$target.children().not(this.$arrow);
             var docDiv = document.createElement('div');
             docDiv.setAttribute('role', 'document');
             $children.wrapAll(docDiv);
             // Make sure arrow is at end of popover for roles to work properly with screen readers
             this._arrow();
-            this.$arrow.appendTo(this.$targetElm);
+            this.$arrow.appendTo(this.$target);
             this.docAdded = true;
         }
     };
 
     CFW_Widget_Popover.prototype.getContent = function() {
         var content;
-        var $e = this.$triggerElm;
+        var $e = this.$element;
         var s = this.settings;
 
         content = (typeof s.content == 'function' ? s.content.call($e[0]) :  s.content);
@@ -126,9 +126,9 @@
         var dragOpt = { handle: '[data-cfw-drag="' + this.type + '"]' };
 
         // Unset any previous drag events
-        this.$targetElm.off('.cfw.drag');
+        this.$target.off('.cfw.drag');
 
-        this.$targetElm.on('dragStart.cfw.drag', function() {
+        this.$target.on('dragStart.cfw.drag', function() {
             var $viewport;
             if ($selfRef.$viewport) {
                 $viewport = $selfRef.$viewport;
@@ -141,7 +141,7 @@
             limit.right = limit.left + $viewport.outerWidth() - $(this).outerWidth();
 
             $selfRef._updateZ();
-            $selfRef.$triggerElm.CFW_trigger('dragStart.cfw.' + $selfRef.type);
+            $selfRef.$element.CFW_trigger('dragStart.cfw.' + $selfRef.type);
         })
         .on('drag.cfw.drag', function(e) {
             var viewportPadding = 0;
@@ -155,14 +155,14 @@
             });
         })
         .on('dragEnd.cfw.drag', function() {
-            $selfRef.$triggerElm.CFW_trigger('dragEnd.cfw.' + $selfRef.type);
+            $selfRef.$element.CFW_trigger('dragEnd.cfw.' + $selfRef.type);
         })
         .on('keydown.cfw.' + this.type + '.drag', '[data-cfw-drag="' + this.type + '"]', function(e) {
             if (/(37|38|39|40)/.test(e.which)) {
                 if (e) { e.stopPropagation(); }
 
                 if (!$selfRef.keyTimer) {
-                    $selfRef.$triggerElm.CFW_trigger('dragStart.cfw.' + $selfRef.type);
+                    $selfRef.$element.CFW_trigger('dragStart.cfw.' + $selfRef.type);
                 }
 
                 clearTimeout($selfRef.keyTimer);
@@ -176,7 +176,7 @@
                     $viewport = $(document.body);
                 }
 
-                var $node = $selfRef.$targetElm;
+                var $node = $selfRef.$target;
                 var step = $selfRef.settings.dragstep;
                 limit = $viewport.offset();
                 limit.bottom = limit.top + $viewport.outerHeight() - $node.outerHeight();
@@ -201,7 +201,7 @@
                 });
 
                 $selfRef.keyTimer = setTimeout(function() {
-                    $selfRef.$triggerElm.CFW_trigger('dragEnd.cfw.' + $selfRef.type);
+                    $selfRef.$element.CFW_trigger('dragEnd.cfw.' + $selfRef.type);
                     $selfRef.keyTimer = null;
                 }, $selfRef.keyDelay);
 
@@ -210,27 +210,27 @@
             }
         });
 
-        this.$targetElm.CFW_Drag(dragOpt);
+        this.$target.CFW_Drag(dragOpt);
     };
 
-    CFW_Widget_Popover.prototype.hide = function() {
+    CFW_Widget_Popover.prototype.hide = function(force) {
         // Fire key drag end if needed
         if (this.keyTimer) {
-            this.$triggerElm.CFW_trigger('dragEnd.cfw.' + this.type);
+            this.$element.CFW_trigger('dragEnd.cfw.' + this.type);
             clearTimeout(this.keyTimer);
         }
         // Call tooltip hide
-        $.fn.CFW_Tooltip.Constructor.prototype.hide.apply(this);
+        $.fn.CFW_Tooltip.Constructor.prototype.hide.call(this, force);
     };
 
     CFW_Widget_Popover.prototype._removeDynamicTip = function() {
-        this.$targetElm.detach();
+        this.$target.detach();
         this.dynamicTip = false;
         this.closeAdded = false;
         this.dragAdded = false;
         this.docAdded = false;
         this.$arrow = false;
-        this.$targetElm = null;
+        this.$target = null;
     };
 
     CFW_Widget_Popover.prototype._updateZ = function() {
@@ -245,16 +245,23 @@
             }
         });
         // Only increase if highest is not current popover
-        if (this.$targetElm[0] !== $zObj[0]) {
-            this.$targetElm.css('z-index', ++zMax);
+        if (this.$target[0] !== $zObj[0]) {
+            this.$target.css('z-index', ++zMax);
         }
     };
 
     CFW_Widget_Popover.prototype._arrow = function() {
         if (!this.$arrow) {
-            this.$arrow = this.$targetElm.find('.arrow, .popover-arrow');
+            this.$arrow = this.$target.find('.arrow, .popover-arrow');
         }
         return this.$arrow;
+    };
+
+    CFW_Widget_Popover.prototype._disposeExt = function() {
+        this.dragAdded = null;
+        this.docAdded = null;
+        this.keyTimer = null;
+        this.keyDelay = null;
     };
 
     function Plugin(option) {

--- a/js/popover.js
+++ b/js/popover.js
@@ -15,6 +15,10 @@
         this.docAdded = false;
         this.keyTimer = null;
         this.keyDelay = 750;
+        this.flags = {
+            keyShift: false,
+            keyTab : false
+        };
 
         this._init('popover', element, options);
     };

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -9,8 +9,9 @@
     'use strict';
 
     var CFW_Widget_Scrollspy = function(element, options) {
-        this.$body  = $('body');
-        this.$scrollElement = $(element).is('body') ? $(window) : $(element);
+        this.$body = $('body');
+        this.$element = $(element);
+        this.$scrollElement = this.$element.is('body') ? $(window) : this.$element;
         this.selector = null;
         this.offsets = [];
         this.targets = [];
@@ -25,15 +26,14 @@
 
     CFW_Widget_Scrollspy.DEFAULTS = {
         target: null,
-        offset: 10
+        offset: 10,
+        throttle: 100
     };
 
     CFW_Widget_Scrollspy.prototype = {
         _init : function() {
-            var process  = $.proxy(this.process, this);
-
-            this.$scrollElement.on('scroll.bs.scrollspy', process);
-            this.selector = (this.settings.target || '') + ' .nav li > a';
+            this.$scrollElement.on('scroll.cfw.scrollspy', $().CFW_throttle($.proxy(this.process, this), this.settings.throttle));
+            this.selector = (this.settings.target || '') + ' a';
             this.$scrollElement.CFW_trigger('init.cfw.scrollspy');
 
             this.refresh();
@@ -60,7 +60,6 @@
 
             this.$body
                 .find(this.selector)
-                // .filter(':visible')
                 .map(function() {
                     var $el   = $(this);
                     var href  = $el.data('target') || $el.attr('href');
@@ -138,6 +137,21 @@
             $(this.selector)
                 .filter('.active')
                 .removeClass('active');
+        },
+
+        dispose : function() {
+            this.$scrollElement.off('.cfw.scrollspy');
+            this.$element.removeData('cfw.scrollspy');
+
+            this.$body = null;
+            this.$element = null;
+            this.$scrollElement = null;
+            this.selector = null;
+            this.offsets = null;
+            this.targets = null;
+            this.activeTarget = null;
+            this.scrollHeight = null;
+            this.settings = null;
         }
     };
 
@@ -145,11 +159,11 @@
         var args = [].splice.call(arguments, 1);
         return this.each(function() {
             var $this = $(this);
-            var data = $this.data('cfw.Scrollspy');
+            var data = $this.data('cfw.scrollspy');
             var options = typeof option === 'object' && option;
 
             if (!data) {
-                $this.data('cfw.Scrollspy', (data = new CFW_Widget_Scrollspy(this, options)));
+                $this.data('cfw.scrollspy', (data = new CFW_Widget_Scrollspy(this, options)));
             }
             if (typeof option === 'string') {
                 data[option].apply(data, args);

--- a/js/slider.js
+++ b/js/slider.js
@@ -14,16 +14,16 @@
         this.$element = $(element);
 
         this.$slider = null;
-        this.$sliderTrack = null;
-        this.$sliderTrackSelection = null;
-        this.$sliderThumbMin = null;
-        this.$sliderThumbMax = null;
+        this.$track = null;
+        this.$selection = null;
+        this.$thumbMin = null;
+        this.$thumbMax = null;
 
         this.$inputMin = null;
-        this.inputMinLabelTxt = '';
+        this.labelMinTxt = '';
 
         this.$inputMax = null;
-        this.inputMaxLabelTxt = '';
+        this.labelMaxTxt = '';
 
         this.ordinal = false;
         this.range = false;
@@ -54,7 +54,6 @@
 
     CFW_Widget_Slider.prototype = {
         _init : function() {
-
             var inputs = this._initInputs();
             if (inputs === false) { return; }
 
@@ -112,47 +111,47 @@
             // var sliderID = this.$slider.CFW_getID('cfw-slider');
 
             /* Track elements */
-            var sliderTrack = document.createElement('div');
-            this.$sliderTrack = $(sliderTrack).addClass('slider-track');
-            var sliderTrackSelection = document.createElement('div');
-            this.$sliderTrackSelection = $(sliderTrackSelection).addClass('slider-selection');
+            var track = document.createElement('div');
+            this.$track = $(track).addClass('slider-track');
+            var selection = document.createElement('div');
+            this.$selection = $(selection).addClass('slider-selection');
 
             /* Thumb/handle elements */
             var $labelMin = this._getLabel(this.$inputMin);
-            var inputMinLabelID = $labelMin.CFW_getID('cfw-slider');
-            this.inputMinLabelTxt = $labelMin.text();
+            var labelMinID = $labelMin.CFW_getID('cfw-slider');
+            this.labelMinTxt = $labelMin.text();
 
-            var sliderThumbMin = document.createElement('div');
-            this.$sliderThumbMin = $(sliderThumbMin).addClass('slider-thumb slider-thumb-min')
+            var thumbMin = document.createElement('div');
+            this.$thumbMin = $(thumbMin).addClass('slider-thumb slider-thumb-min')
                 .attr({
                     'role': 'slider',
                     'tabindex': -1,
-                    'aria-labelledby': inputMinLabelID
+                    'aria-labelledby': labelMinID
                 });
 
             if (this.range) {
                 var $labelMax = this._getLabel(this.$inputMax);
-                var inputMaxLabelID = $labelMax.CFW_getID('cfw-slider');
-                this.inputMaxLabelTxt = $labelMax.text();
+                var labelMaxID = $labelMax.CFW_getID('cfw-slider');
+                this.labelMaxTxt = $labelMax.text();
 
-                var sliderThumbMax = document.createElement('div');
-                this.$sliderThumbMax = $(sliderThumbMax).addClass('slider-thumb slider-thumb-max')
+                var thumbMax = document.createElement('div');
+                this.$thumbMax = $(thumbMax).addClass('slider-thumb slider-thumb-max')
                     .attr({
                         'role': 'slider',
                         'tabindex': -1,
-                        'aria-labelledby': inputMaxLabelID
+                        'aria-labelledby': labelMaxID
                     });
 
-                this.$sliderThumbMin.attr('aria-controls', this.$sliderThumbMax.CFW_getID('cfw-slider'));
-                this.$sliderThumbMax.attr('aria-controls', this.$sliderThumbMin.CFW_getID('cfw-slider'));
+                this.$thumbMin.attr('aria-controls', this.$thumbMax.CFW_getID('cfw-slider'));
+                this.$thumbMax.attr('aria-controls', this.$thumbMin.CFW_getID('cfw-slider'));
             }
 
             // Attach elements together and insert
-            this.$sliderTrack.append(this.$sliderTrackSelection);
-            this.$sliderTrack.append(this.$sliderThumbMin);
-            if (this.range) { this.$sliderTrack.append(this.$sliderThumbMax); }
+            this.$track.append(this.$selection);
+            this.$track.append(this.$thumbMin);
+            if (this.range) { this.$track.append(this.$thumbMax); }
 
-            this.$slider.append(this.$sliderTrack);
+            this.$slider.append(this.$track);
 
             this.$element.append(this.$slider);
         },
@@ -160,19 +159,19 @@
         updateValues : function() {
             this.val0 = (this.ordinal) ? this.$inputMin[0].selectedIndex : parseFloat(this.$inputMin.val());
             if (!this.range) {
-                this.$sliderThumbMin.attr({
+                this.$thumbMin.attr({
                     'aria-valuemin': this.settings.min,
                     'aria-valuemax': this.settings.max,
                     'aria-valuenow': this.val0
                 });
             } else {
                 this.val1 = (this.ordinal) ? this.$inputMax[0].selectedIndex : parseFloat(this.$inputMax.val());
-                this.$sliderThumbMin.attr({
+                this.$thumbMin.attr({
                     'aria-valuemin': this.settings.min,
                     'aria-valuemax': this.val1,
                     'aria-valuenow': this.val0
                 });
-                this.$sliderThumbMax.attr({
+                this.$thumbMax.attr({
                     'aria-valuemin': this.val0,
                     'aria-valuemax': this.settings.max,
                     'aria-valuenow': this.val1
@@ -189,18 +188,18 @@
             var selStart;
 
             // Reset visuals
-            this.$sliderTrackSelection.css({
+            this.$selection.css({
                 'top': '',
                 'left': '',
                 'width': '',
                 'height': ''
             });
-            this.$sliderThumbMin.css({
+            this.$thumbMin.css({
                 'top': '',
                 'left': ''
             });
             if (this.range) {
-                this.$sliderThumbMax.css({
+                this.$thumbMax.css({
                     'top': '',
                     'left': ''
                 });
@@ -230,19 +229,19 @@
             var pos = (this.settings.vertical) ? 'top' : 'left';
             var dim = (this.settings.vertical) ? 'height' : 'width';
 
-            this.$sliderTrackSelection.css(pos, selStart + '%').css(dim, pctSize + '%');
+            this.$selection.css(pos, selStart + '%').css(dim, pctSize + '%');
             if (!this.range) {
-                this.$sliderThumbMin.css(pos, pctEnd + '%');
+                this.$thumbMin.css(pos, pctEnd + '%');
             } else {
-                this.$sliderThumbMin.css(pos, pctStart + '%');
-                this.$sliderThumbMax.css(pos, pctEnd + '%');
+                this.$thumbMin.css(pos, pctStart + '%');
+                this.$thumbMax.css(pos, pctEnd + '%');
             }
         },
 
         updateLabels : function() {
-            this.$sliderThumbMin.attr('aria-valuetext', this.inputMinLabelTxt + ' ' + this.$inputMin.val());
+            this.$thumbMin.attr('aria-valuetext', this.labelMinTxt + ' ' + this.$inputMin.val());
             if (this.range) {
-                this.$sliderThumbMax.attr('aria-valuetext', this.inputMaxLabelTxt + ' ' + this.$inputMax.val());
+                this.$thumbMax.attr('aria-valuetext', this.labelMaxTxt + ' ' + this.$inputMax.val());
             }
         },
 
@@ -265,10 +264,10 @@
 
         bindSlider : function() {
             var $selfRef = this;
-            var $thumbs = this.$sliderThumbMin;
+            var $thumbs = this.$thumbMin;
             var $inputs = this.$inputMin;
             if (this.range) {
-                $thumbs = $thumbs.add(this.$sliderThumbMax);
+                $thumbs = $thumbs.add(this.$thumbMax);
                 $inputs = $inputs.add(this.$inputMax);
             }
 
@@ -282,7 +281,7 @@
                     $(this).css('z-index', '');
                 });
 
-            this.$sliderTrack
+            this.$track
                 .on('dragStart.cfw.drag', function(e) {
                     $selfRef._dragStart(e);
                 })
@@ -291,9 +290,8 @@
                 })
                 .on('dragEnd.cfw.drag', function() {
                     $selfRef._dragEnd();
-                });
-
-            this.$sliderTrack.CFW_Drag();
+                })
+                .CFW_Drag();
 
             $inputs.on('change.cfw.slider', function() {
                 var $node = $(this);
@@ -303,14 +301,14 @@
         },
 
         unbindSlider : function() {
-            var $thumbs = this.$sliderThumbMin;
+            var $thumbs = this.$thumbMin;
             var $inputs = this.$inputMin;
             if (this.range) {
-                $thumbs = $thumbs.add(this.$sliderThumbMax);
+                $thumbs = $thumbs.add(this.$thumbMax);
                 $inputs = $inputs.add(this.$inputMax);
             }
             $thumbs.attr('tabindex', '').off('.cfw.slider');
-            this.$sliderTrack.CFW_Drag('dispose');
+            this.$track.CFW_Drag('dispose');
             $inputs.off('.cfw.slider');
         },
 
@@ -371,7 +369,7 @@
 
         _getInput : function(node) {
             var $node = $(node);
-            if ($node.is(this.$sliderThumbMax)) {
+            if ($node.is(this.$thumbMax)) {
                 return this.$inputMax;
             } else {
                 return this.$inputMin;
@@ -380,11 +378,9 @@
 
         _getLabel : function($input) {
             var $label = $('label[for="' + $input.attr('id') + '"]');
-
             if ($label.length <= 0) {
                 $label = $input.closest('label');
             }
-
             return $label;
         },
 
@@ -425,7 +421,7 @@
 
         _dragStart : function(e) {
             var $node = $(e.currentTarget);
-            if ($node.is(this.$sliderTrack)) {
+            if ($node.is(this.$track)) {
                 $node = this._closestThumb(e);
             }
             $node.trigger('focus');
@@ -433,7 +429,7 @@
             this.inDrag = $node[0];
 
             var pos = this.settings.vertical ? e.startY : e.startX;
-            var trackOff = this.$sliderTrack.offset();
+            var trackOff = this.$track.offset();
             var newPos = pos - trackOff[this.offsetPos];
             this.startPos = newPos;
 
@@ -445,7 +441,7 @@
         },
 
         _drag : function(e) {
-            if (this.startPos == null) { return; }
+            if (this.inDrag == null) { return; }
             var delta = this.settings.vertical ? e.deltaY : e.deltaX;
             var newPos = this.startPos + delta;
             var $input = this._getInput(this.inDrag);
@@ -462,9 +458,9 @@
         _positionToValue : function(pos) {
             var trackDim;
             if (this.settings.vertical) {
-                trackDim = this.$sliderTrack.outerHeight();
+                trackDim = this.$track.outerHeight();
             } else {
-                trackDim = this.$sliderTrack.outerWidth();
+                trackDim = this.$track.outerWidth();
             }
 
             var ratio = trackDim / this.stepsTotal;
@@ -477,12 +473,12 @@
             var $node;
             if (this.range) {
                 var pos = this.settings.vertical ? e.pageY : e.pageX;
-                var trackOff = this.$sliderTrack.offset();
-                var diff1 = Math.abs(pos - trackOff[this.offsetPos] - this.$sliderThumbMin.position()[this.offsetPos]);
-                var diff2 = Math.abs(pos - trackOff[this.offsetPos] - this.$sliderThumbMax.position()[this.offsetPos]);
-                $node = (diff1 < diff2) ? this.$sliderThumbMin : this.$sliderThumbMax;
+                var trackOff = this.$track.offset();
+                var diff1 = Math.abs(pos - trackOff[this.offsetPos] - this.$thumbMin.position()[this.offsetPos]);
+                var diff2 = Math.abs(pos - trackOff[this.offsetPos] - this.$thumbMax.position()[this.offsetPos]);
+                $node = (diff1 < diff2) ? this.$thumbMin : this.$thumbMax;
             } else {
-                $node = this.$sliderThumbMin;
+                $node = this.$thumbMin;
             }
             return $node;
         },
@@ -494,14 +490,14 @@
 
             this.$element = null;
             this.$slider = null;
-            this.$sliderTrack = null;
-            this.$sliderTrackSelection = null;
-            this.$sliderThumbMin = null;
-            this.$sliderThumbMax = null;
+            this.$track = null;
+            this.$selection = null;
+            this.$thumbMin = null;
+            this.$thumbMax = null;
             this.$inputMin = null;
-            this.inputMinLabelTxt = null;
+            this.labelMinTxt = null;
             this.$inputMax = null;
-            this.inputMaxLabelTxt = null;
+            this.labelMaxTxt = null;
             this.ordinal = null;
             this.range = null;
             this.val0 = null;

--- a/js/slider.js
+++ b/js/slider.js
@@ -20,13 +20,9 @@
         this.$sliderThumbMax = null;
 
         this.$inputMin = null;
-        this.inputMinID = '';
-        this.inputMinLabelID = '';
         this.inputMinLabelTxt = '';
 
         this.$inputMax = null;
-        this.inputMaxID = '';
-        this.inputMaxLabelID = '';
         this.inputMaxLabelTxt = '';
 
         this.ordinal = false;
@@ -54,9 +50,6 @@
         enabled : true,     // true - enabled / false - disabled
         vertical : false,   // alternate orientation
         reversed : false    // show thumbs in opposite order
-
-        // TODO
-        // tooltip : 'show'        // 'show,hide,always'
     };
 
     CFW_Widget_Slider.prototype = {
@@ -92,19 +85,10 @@
             }
 
             this.$inputMin = $inputs.eq(0);
-            this.inputMinID = this.$inputMin.CFW_getID('cfw-slider');
-            var $labelMin = this._getLabel(this.$inputMin);
-            this.inputMinLabelID = $labelMin.CFW_getID('cfw-slider');
-            this.inputMinLabelTxt = $labelMin.text();
 
             if (this.$inputMin[0].nodeName == 'SELECT') { this.ordinal = true; }
             if ($inputs.length > 1) {
                 this.$inputMax = $inputs.eq($inputs.length - 1);
-                this.inputMaxID = this.$inputMax.CFW_getID('cfw-slider');
-                var $labelMax = this._getLabel(this.$inputMax);
-                this.inputMaxLabelID = $labelMax.CFW_getID('cfw-slider');
-                this.inputMaxLabelTxt = $labelMax.text();
-
                 this.range = true;
             }
         },
@@ -134,21 +118,29 @@
             this.$sliderTrackSelection = $(sliderTrackSelection).addClass('slider-selection');
 
             /* Thumb/handle elements */
+            var $labelMin = this._getLabel(this.$inputMin);
+            var inputMinLabelID = $labelMin.CFW_getID('cfw-slider');
+            this.inputMinLabelTxt = $labelMin.text();
+
             var sliderThumbMin = document.createElement('div');
             this.$sliderThumbMin = $(sliderThumbMin).addClass('slider-thumb slider-thumb-min')
                 .attr({
                     'role': 'slider',
                     'tabindex': -1,
-                    'aria-labelledby': this.inputMinLabelID
+                    'aria-labelledby': inputMinLabelID
                 });
 
             if (this.range) {
+                var $labelMax = this._getLabel(this.$inputMax);
+                var inputMaxLabelID = $labelMax.CFW_getID('cfw-slider');
+                this.inputMaxLabelTxt = $labelMax.text();
+
                 var sliderThumbMax = document.createElement('div');
                 this.$sliderThumbMax = $(sliderThumbMax).addClass('slider-thumb slider-thumb-max')
                     .attr({
                         'role': 'slider',
                         'tabindex': -1,
-                        'aria-labelledby': this.inputMaxLabelID
+                        'aria-labelledby': inputMaxLabelID
                     });
 
                 this.$sliderThumbMin.attr('aria-controls', this.$sliderThumbMax.CFW_getID('cfw-slider'));
@@ -493,6 +485,32 @@
                 $node = this.$sliderThumbMin;
             }
             return $node;
+        },
+
+        dispose : function() {
+            this.unbindSlider();
+            this.$element.removeData('cfw.slider');
+            this.$slider.remove();
+
+            this.$element = null;
+            this.$slider = null;
+            this.$sliderTrack = null;
+            this.$sliderTrackSelection = null;
+            this.$sliderThumbMin = null;
+            this.$sliderThumbMax = null;
+            this.$inputMin = null;
+            this.inputMinLabelTxt = null;
+            this.$inputMax = null;
+            this.inputMaxLabelTxt = null;
+            this.ordinal = null;
+            this.range = null;
+            this.val0 = null;
+            this.val1 = null;
+            this.settings = null;
+            this.inDrag = null;
+            this.startPos = null;
+            this.offsetPos = null;
+            this.stepsTotal = null;
         }
     };
 

--- a/js/slider.js
+++ b/js/slider.js
@@ -318,7 +318,7 @@
                 $inputs = $inputs.add(this.$inputMax);
             }
             $thumbs.attr('tabindex', '').off('.cfw.slider');
-            this.$sliderTrack.CFW_Drag('destroy');
+            this.$sliderTrack.CFW_Drag('dispose');
             $inputs.off('.cfw.slider');
         },
 

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -81,6 +81,7 @@
             if (currIndex >= $tabs.length - 1) {
                 this.$navNext.addClass('disabled');
             }
+            this.$element.CFW_trigger('update.cfw.slideshow');
         },
 
         _getTabs : function() {

--- a/js/tab-responsive.js
+++ b/js/tab-responsive.js
@@ -11,17 +11,10 @@
     if ($.fn.CFW_Tab === undefined) throw new Error('CFW_TabResponsive requires CFW_Tab');
     if ($.fn.CFW_Collapse === undefined) throw new Error('CFW_TabResponsive requires CFW_Collapse');
 
-    var CFW_Widget_TabResponsive = function(element, options) {
+    var CFW_Widget_TabResponsive = function(element) {
         this.$element = $(element);
 
-        var parsedData = this.$element.CFW_parseData('tabresponsive', CFW_Widget_TabResponsive.DEFAULTS);
-        this.settings = $.extend({}, CFW_Widget_TabResponsive.DEFAULTS, parsedData, options);
-
         this._init();
-    };
-
-    CFW_Widget_TabResponsive.DEFAULTS = {
-        active: false   // Open the collapse for the default active tab
     };
 
     CFW_Widget_TabResponsive.prototype = {
@@ -43,14 +36,11 @@
             });
 
             // Remove animations (needs to be revisited)
-            this.$element.find('[data-cfw="tab"]').CFW_Tab('fadeDisable');
+            this.$element.find('[data-cfw="tab"]').CFW_Tab('animDisable');
             this.$element.find('[data-cfw="collapse"]').CFW_Collapse('animDisable');
 
-            // Open collapse on active item
-            if (this.settings.active) {
-                var active = this.$element.find('[data-cfw="tab"].active');
-                this.updateCollapse(active);
-            }
+            var active = this.$element.find('[data-cfw="tab"].active');
+            this.updateCollapse(active);
 
             this.$element.CFW_trigger('init.cfw.tabResponsive');
         },
@@ -63,7 +53,7 @@
             if (data) {
                 var $activePane = data.$target;
                 var $paneContainer = $activePane.closest('.tab-content');
-                this.$element.find('[data-cfw="collapse"]').each(function() {
+                $paneContainer.find('[data-cfw="collapse"]').each(function() {
                     $(this).one('afterHide.cfw.collapse', function(e) {
                             e.stopPropagation();
                             e.preventDefault();
@@ -128,10 +118,9 @@
         return this.each(function() {
             var $this = $(this);
             var data = $this.data('cfw.tabResponsive');
-            var options = typeof option === 'object' && option;
 
             if (!data) {
-                $this.data('cfw.tabResponsive', (data = new CFW_Widget_TabResponsive(this, options)));
+                $this.data('cfw.tabResponsive', (data = new CFW_Widget_TabResponsive(this)));
             }
             if (typeof option === 'string') {
                 data[option].apply(data, args);

--- a/js/tab-responsive.js
+++ b/js/tab-responsive.js
@@ -55,11 +55,8 @@
                 $(callingNode).data('cfw.collapse').$targetElm.css('height', '');
             });
 
-            // Remove fade animations and aria-hidden for all tabs
-            this.$element.find('[data-cfw="tab"]').CFW_Tab('fadeDisable').CFW_Tab('hiddenDisable');
-
-            // Remove aria-hidden for all collapse
-            this.$element.find('[data-cfw="collapse"]').CFW_Collapse('hiddenDisable');
+            // Remove fade animations for tabs
+            this.$element.find('[data-cfw="tab"]').CFW_Tab('fadeDisable');
 
             // Open collapse on active item
             if (this.settings.active) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -9,11 +9,11 @@
     'use strict';
 
     var CFW_Widget_Tab = function(element, options) {
-        this.$triggerElm = $(element);
+        this.$element = $(element);
+        this.$target = null;
         this.$navElm = null;
-        this.$targetElm = null;
 
-        var parsedData = this.$triggerElm.CFW_parseData('tab', CFW_Widget_Tab.DEFAULTS);
+        var parsedData = this.$element.CFW_parseData('tab', CFW_Widget_Tab.DEFAULTS);
         this.settings = $.extend({}, CFW_Widget_Tab.DEFAULTS, parsedData, options);
 
         this._init();
@@ -25,31 +25,30 @@
     };
 
     CFW_Widget_Tab.prototype = {
-
         _init : function() {
             var $selfRef = this;
 
             // Find nav and target elements
-            this.$navElm = this.$triggerElm.closest('ul, ol, nav');
+            this.$navElm = this.$element.closest('ul, ol, nav');
             this.$navElm.attr('role', 'tablist');
 
             var $selector = $(this.settings.target);
             if (!$selector.length) {
-                $selector = $(this.$triggerElm.attr('href'));
+                $selector = $(this.$element.attr('href'));
             }
-            this.$targetElm = $($selector);
+            this.$target = $($selector);
 
-            if (!this.$targetElm.length) {
+            if (!this.$target.length) {
                 return false;
             }
 
-            this.$triggerElm.attr('data-cfw', 'tab');
+            this.$element.attr('data-cfw', 'tab');
 
             // Check for presence of trigger id - set if not present
-            var triggerID = this.$triggerElm.CFW_getID('cfw-tab');
+            var triggerID = this.$element.CFW_getID('cfw-tab');
 
             // Target should have id already - set ARIA attributes
-            this.$targetElm.attr({
+            this.$target.attr({
                 'role': 'tabpanel',
                 'aria-labelledby': triggerID
             });
@@ -60,56 +59,56 @@
             }
 
             // Set ARIA attributes on trigger
-            this.$triggerElm.attr({
+            this.$element.attr({
                 'tabindex': -1,
                 'role': 'tab',
                 'aria-selected': 'false',
                 'aria-expanded': 'false',
-                'aria-controls': this.$targetElm.attr('id')
+                'aria-controls': this.$target.attr('id')
             });
 
             // Bind click handler
-            this.$triggerElm.on('click', function(e) {
+            this.$element.on('click.cfw.tab', function(e) {
                 e.preventDefault();
                 $selfRef.show(e);
             });
 
             // Bind key handler
-            this.$triggerElm.on('keydown', function(e) {
+            this.$element.on('keydown.cfw.tab', function(e) {
                 $selfRef._actionsKeydown(e, this);
             });
 
             // Display panel if trigger is marked active
-            if (this.$triggerElm.hasClass('active')) {
-                this.$triggerElm.attr({
+            if (this.$element.hasClass('active')) {
+                this.$element.attr({
                     'tabindex': 0,
                     'aria-selected': 'true',
                     'aria-expanded': 'true'
                 });
-                this.$targetElm.addClass('active');
+                this.$target.addClass('active');
 
                 if (this.settings.animate) {
-                    this.$targetElm.addClass('in');
+                    this.$target.addClass('in');
                 }
             }
 
             // Check to see if there is an active element defined - if not set current one as active
             if (this.$navElm.find('.active').length <= 0) {
-                this.$triggerElm.addClass('active');
+                this.$element.addClass('active');
 
-                this.$triggerElm.attr({
+                this.$element.attr({
                     'tabindex': 0,
                     'aria-selected': 'true',
                     'aria-expanded': 'true'
                 });
-                this.$targetElm.addClass('active');
+                this.$target.addClass('active');
 
                 if (this.settings.animate) {
-                    this.$targetElm.addClass('in');
+                    this.$target.addClass('in');
                 }
             }
 
-            this.$triggerElm.CFW_trigger('init.cfw.tab');
+            this.$element.CFW_trigger('init.cfw.tab');
         },
 
         show : function(e) {
@@ -117,20 +116,20 @@
                 e.preventDefault();
             }
 
-            if (this.$triggerElm.hasClass('active')
-                || this.$triggerElm.hasClass('disabled')
-                || this.$triggerElm[0].hasAttribute('disabled')) {
+            if (this.$element.hasClass('active')
+                || this.$element.hasClass('disabled')
+                || this.$element[0].hasAttribute('disabled')) {
                 return;
             }
 
             var $previous = this.$navElm.find('.active:last');
             if ($previous.length) {
-                if (!$previous.CFW_trigger('beforeHide.cfw.tab', { relatedTarget: this.$triggerElm[0] })) {
+                if (!$previous.CFW_trigger('beforeHide.cfw.tab', { relatedTarget: this.$element[0] })) {
                     return;
                 }
             }
 
-            if (!this.$triggerElm.CFW_trigger('beforeShow.cfw.tab', { relatedTarget: $previous[0] })) {
+            if (!this.$element.CFW_trigger('beforeShow.cfw.tab', { relatedTarget: $previous[0] })) {
                 return;
             }
 
@@ -140,31 +139,31 @@
                         'aria-selected': 'false',
                         'aria-expanded': 'false'
                     })
-                    .CFW_trigger('afterHide.cfw.tab', { relatedTarget: this.$triggerElm[0] });
+                    .CFW_trigger('afterHide.cfw.tab', { relatedTarget: this.$element[0] });
             }
 
-            this.$triggerElm.attr({
+            this.$element.attr({
                 'tabindex': 0,
                 'aria-selected': 'true',
                 'aria-expanded': 'true'
             });
 
-            this._activateTab(this.$triggerElm, this.$navElm, false, $previous);
-            this._activateTab(this.$targetElm, this.$targetElm.parent(), true, $previous);
+            this._activateTab(this.$element, this.$navElm, false, $previous);
+            this._activateTab(this.$target, this.$target.parent(), true, $previous);
         },
 
         fadeEnable : function() {
-            this.$targetElm.addClass('fade');
-            if (this.$targetElm.hasClass('active')) {
-                this.$targetElm.addClass('in');
+            this.$target.addClass('fade');
+            if (this.$target.hasClass('active')) {
+                this.$target.addClass('in');
             }
             this.settings.animate = true;
         },
 
         fadeDisable : function() {
-            this.$targetElm.removeClass('fade in');
-            if (this.$targetElm.hasClass('active')) {
-                this.$targetElm.addClass('in');
+            this.$target.removeClass('fade in');
+            if (this.$target.hasClass('active')) {
+                this.$target.addClass('in');
             }
             this.settings.animate = false;
         },
@@ -210,13 +209,25 @@
                 }
 
                 if (isPanel) {
-                    $selfRef.$triggerElm.CFW_trigger('afterShow.cfw.tab', { relatedTarget: $previous[0] });
+                    $selfRef.$element.CFW_trigger('afterShow.cfw.tab', { relatedTarget: $previous[0] });
                 }
             }
 
             $node.CFW_transition(null, displayTab);
 
             $prevActive.removeClass('in');
+        },
+
+        dispose : function() {
+            this.$element
+                .off('.cfw.tab')
+                .removeData('cfw.tab');
+
+            this.$element = null;
+            this.$target = null;
+            this.$navElm = null;
+            this.settings = null;
+
         }
     };
 

--- a/js/tab.js
+++ b/js/tab.js
@@ -21,8 +21,7 @@
 
     CFW_Widget_Tab.DEFAULTS = {
         target  : null,
-        animate : true, // If tabs should be allowed fade in and out
-        hidden  : true  // Use aria-hidden on target containers by default
+        animate : true // If tabs should be allowed fade in and out
     };
 
     CFW_Widget_Tab.prototype = {
@@ -54,9 +53,6 @@
                 'role': 'tabpanel',
                 'aria-labelledby': triggerID
             });
-            if (this.settings.hidden) {
-                this.$targetElm.attr('aria-hidden', true);
-            }
             if (this.settings.animate) {
                 this.fadeEnable();
             } else {
@@ -92,9 +88,6 @@
                 });
                 this.$targetElm.addClass('active');
 
-                if (this.settings.hidden) {
-                    this.$targetElm.attr('aria-hidden', false);
-                }
                 if (this.settings.animate) {
                     this.$targetElm.addClass('in');
                 }
@@ -111,9 +104,6 @@
                 });
                 this.$targetElm.addClass('active');
 
-                if (this.settings.hidden) {
-                    this.$targetElm.attr('aria-hidden', 'false');
-                }
                 if (this.settings.animate) {
                     this.$targetElm.addClass('in');
                 }
@@ -179,11 +169,6 @@
             this.settings.animate = false;
         },
 
-        hiddenDisable : function() {
-            this.$targetElm.removeAttr('aria-hidden');
-            this.settings.hidden = false;
-        },
-
         _actionsKeydown : function(e, node) {
             // 37-left, 38-up, 39-right, 40-down
             var k = e.which;
@@ -212,13 +197,7 @@
 
             function displayTab() {
                 $prevActive.removeClass('active');
-
                 $node.addClass('active');
-
-                if (isPanel) {
-                    $prevActive.attr('aria-hidden', 'true');
-                    $node.attr('aria-hidden', 'false');
-                }
 
                 if (doTransition) {
                     $node[0].offsetWidth; // Reflow for transition

--- a/js/tab.js
+++ b/js/tab.js
@@ -53,9 +53,9 @@
                 'aria-labelledby': triggerID
             });
             if (this.settings.animate) {
-                this.fadeEnable();
+                this.animEnable();
             } else {
-                this.fadeDisable();
+                this.animDisable();
             }
 
             // Set ARIA attributes on trigger
@@ -152,7 +152,7 @@
             this._activateTab(this.$target, this.$target.parent(), true, $previous);
         },
 
-        fadeEnable : function() {
+        animEnable : function() {
             this.$target.addClass('fade');
             if (this.$target.hasClass('active')) {
                 this.$target.addClass('in');
@@ -160,7 +160,7 @@
             this.settings.animate = true;
         },
 
-        fadeDisable : function() {
+        animDisable : function() {
             this.$target.removeClass('fade in');
             this.settings.animate = false;
         },

--- a/js/tab.js
+++ b/js/tab.js
@@ -191,7 +191,7 @@
             var $prevActive = container.find('.active');
             var doTransition = isPanel && this.settings.animate;
 
-            function displayTab() {
+            function complete() {
                 $prevActive.removeClass('active');
                 $node.addClass('active');
 
@@ -210,7 +210,7 @@
                 }
             }
 
-            $node.CFW_transition(null, displayTab);
+            $node.CFW_transition(null, complete);
 
             $prevActive.removeClass('in');
         },

--- a/js/tab.js
+++ b/js/tab.js
@@ -162,9 +162,6 @@
 
         fadeDisable : function() {
             this.$target.removeClass('fade in');
-            if (this.$target.hasClass('active')) {
-                this.$target.addClass('in');
-            }
             this.settings.animate = false;
         },
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -10,8 +10,8 @@
 
     var CFW_Widget_Tooltip = function(element, options) {
         this.$triggerElm = null;
-        this.dataToggle = null;
         this.$targetElm = null;
+        this.dataToggle = null;
         this.type = null;
         this.eventTypes = null;
         this.delayTimer = null;
@@ -50,7 +50,7 @@
         title           : '',               // Title text/html to be inserted
         activate        : false,            // Auto show after init
         unlink          : false,            // If on hide to remove events and attributes from tooltip and trigger
-        destroy         : false,            // If on hide to unlink, then remove tooltip from DOM
+        dispose         : false,            // If on hide to unlink, then remove tooltip from DOM
         template        : '<div class="tooltip"><div class="tooltip-inner"></div><div class="tooltip-arrow"></div></div>'
     };
 
@@ -497,13 +497,13 @@
             this.$triggerElm.CFW_trigger('afterUnlink.cfw.' + this.type);
         },
 
-        destroy : function() {
+        dispose : function() {
             var $selfRef = this;
             $(document).one('afterUnlink.cfw.' + this.type, this.$triggerElm, function() {
                 if ($selfRef.$targetElm !== null) {
                     $selfRef.$targetElm.remove();
                 }
-                $selfRef.$triggerElm.CFW_trigger('destroy.cfw.' + $selfRef.type);
+                $selfRef.$triggerElm.CFW_trigger('dispose.cfw.' + $selfRef.type);
             });
             this.unlink(true);
 
@@ -590,7 +590,7 @@
 
             // Delay to keep NVDA (and other screen readers?) from reading dialog header twice
             setTimeout(function() {
-                // Handle case of immediate destroy after show
+                // Handle case of immediate dispose after show
                 if ($selfRef.$triggerElm) {
                     $selfRef.$triggerElm.attr('aria-describedby', $selfRef.targetID);
                 }
@@ -628,7 +628,7 @@
 
             if (!this.unlinking) {
                 if (this.settings.unlink) { this.unlink(); }
-                if (this.settings.destroy) { this.destroy(); }
+                if (this.settings.dispose) { this.dispose(); }
             }
         },
 
@@ -886,7 +886,7 @@
             var data = $this.data('cfw.tooltip');
             var options = typeof option === 'object' && option;
 
-            if (!data && /unlink|destroy|hide/.test(option)) {
+            if (!data && /unlink|dispose|hide/.test(option)) {
                 return false;
             }
             if (!data) {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -9,8 +9,13 @@
     'use strict';
 
     var CFW_Widget_Tooltip = function(element, options) {
-        this.$triggerElm = null;
-        this.$targetElm = null;
+        this.$element = null;
+        this.$target = null;
+        this.$viewport = null;
+        this.$arrow = null;
+        this.$focusLast = null;
+        this.instance = null;
+        this.settings = null;
         this.dataToggle = null;
         this.type = null;
         this.eventTypes = null;
@@ -22,7 +27,6 @@
         this.hoverState = null;
         this.inState = null;
         this.dynamicTip = false;
-        this.$focusLast = null;
         this.flags = {
             keyShift: false,
             keyTab : false
@@ -57,14 +61,14 @@
     CFW_Widget_Tooltip.prototype = {
         _init : function(type, element, options) {
             this.type = type;
-            this.$triggerElm = $(element);
+            this.$element = $(element);
             this.settings = this.getSettings(options);
 
-            this.$viewport = this.settings.viewport && $($.isFunction(this.settings.viewport) ? this.settings.viewport.call(this, this.$triggerElm) : (this.settings.viewport.selector || this.settings.viewport));
+            this.$viewport = this.settings.viewport && $($.isFunction(this.settings.viewport) ? this.settings.viewport.call(this, this.$element) : (this.settings.viewport.selector || this.settings.viewport));
 
             this.inState = { click: false, hover: false, focus: false };
 
-            this.$triggerElm.attr('data-cfw', this.type);
+            this.$element.attr('data-cfw', this.type);
 
             // Find target by id/css selector - only pick first one found
             var dataToggle;
@@ -73,12 +77,12 @@
                 dataToggle = this.settings.toggle;
             } else {
                 // If not found by selector - find by 'toggle' data
-                dataToggle = this.$triggerElm.attr('data-cfw-' + this.type + '-toggle');
+                dataToggle = this.$element.attr('data-cfw-' + this.type + '-toggle');
                 $findTarget = $('[data-cfw-' + this.type + '-target="' + dataToggle + '"]');
             }
             if ($findTarget.length) {
                 this.dataToggle = dataToggle;
-                this.$targetElm = $findTarget;
+                this.$target = $findTarget;
             } else {
                 this.fixTitle();
             }
@@ -91,8 +95,8 @@
             this.eventTypes = this.settings.trigger.split(' ');
             this.bindTip(true);
 
-            if (this.$targetElm) {
-                this.$targetElm.data('cfw.' + this.type, this);
+            if (this.$target) {
+                this.$target.data('cfw.' + this.type, this);
             }
 
             if (this.settings.activate) {
@@ -100,7 +104,7 @@
                 this.show();
             }
 
-            this.$triggerElm.CFW_trigger('init.cfw.' + this.type);
+            this.$element.CFW_trigger('init.cfw.' + this.type);
         },
 
         getDefaults: function() {
@@ -108,7 +112,7 @@
         },
 
         getSettings : function(options) {
-            var parsedData = this.$triggerElm.CFW_parseData(this.type, this.getDefaults());
+            var parsedData = this.$element.CFW_parseData(this.type, this.getDefaults());
             var settings = $.extend({}, this.getDefaults(), parsedData, options);
             if (settings.delay && typeof settings.delay == 'number') {
                 settings.delay = {
@@ -125,7 +129,7 @@
         },
 
         fixTitle : function() {
-            var $e = this.$triggerElm;
+            var $e = this.$element;
             if ($e.attr('title') || typeof($e.attr('data-cfw-' + this.type +  '-original-title')) != 'string') {
                 $e.attr('data-cfw-' + this.type +  '-original-title', $e.attr('title') || '').attr('title', '');
             }
@@ -133,7 +137,7 @@
 
         getTitle : function() {
             var title;
-            var $e = this.$triggerElm;
+            var $e = this.$element;
             var s = this.settings;
 
             title = (typeof s.title == 'function' ? s.title.call($e[0]) :  s.title) || $e.attr('data-cfw-' + this.type +  '-original-title');
@@ -142,7 +146,7 @@
         },
 
         setContent : function() {
-            var $tip = this.$targetElm;
+            var $tip = this.$target;
             var $inner = $tip.find('.tooltip-inner');
 
             if (!this.dataToggle) {
@@ -160,11 +164,11 @@
 
         linkTip : function() {
             // Check for presence of trigger and target ids - set if not present
-            this.triggerID = this.$triggerElm.CFW_getID('cfw-' + this.type);
-            this.targetID = this.$targetElm.CFW_getID('cfw-' + this.type);
+            this.instance = this.$element.CFW_getID('cfw-' + this.type);
+            this.targetID = this.$target.CFW_getID('cfw-' + this.type);
 
             // Set ARIA attributes on target
-            this.$targetElm.attr({
+            this.$target.attr({
                 'role': (this.type == 'tooltip' ? 'tooltip' : (this.settings.follow ? 'dialog' : 'tooltip')),
                 'aria-hidden': 'true',
                 'tabindex': -1
@@ -178,16 +182,16 @@
                 var eventType = this.eventTypes[i];
                 if (eventType == 'click') {
                     // Click events
-                    this.$triggerElm
+                    this.$element
                         .off('click.cfw.' + this.type)
                         .on('click.cfw.' + this.type, $.proxy(this.toggle, this));
 
                     // Inject close button
-                    if (this.$targetElm != null && !this.closeAdded) {
+                    if (this.$target != null && !this.closeAdded) {
                         // Check for pre-existing close buttons
-                        if (!this.$targetElm.find('[data-cfw-dismiss="' + this.type +  '"]').length) {
+                        if (!this.$target.find('[data-cfw-dismiss="' + this.type +  '"]').length) {
                             var $close = $('<button type="button" class="close" data-cfw-dismiss="' + this.type +  '" aria-label="' + this.settings.closesrtext + '">' + this.settings.closetext + '</button>');
-                            $close.prependTo(this.$targetElm);
+                            $close.prependTo(this.$target);
                             this.closeAdded = true;
                         }
                     }
@@ -197,26 +201,26 @@
                     var eventOut = (eventType == 'hover') ? 'mouseleave' : 'focusout';
 
                     if (modeInit) {
-                        this.$triggerElm.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
-                        this.$triggerElm.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
+                        this.$element.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
+                        this.$element.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
                     } else {
-                        this.$targetElm.off('.cfw.' + this.type);
-                        this.$targetElm.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
-                        this.$targetElm.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
+                        this.$target.off('.cfw.' + this.type);
+                        this.$target.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
+                        this.$target.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
                     }
                 }
             }
 
-            if (this.$targetElm) {
+            if (this.$target) {
                 // Key handling for closing
-                this.$targetElm.off('keydown.cfw.' + this.type + '.close')
+                this.$target.off('keydown.cfw.' + this.type + '.close')
                     .on('keydown.cfw.' + this.type + '.close', function(e) {
                         var code = e.charCode || e.which;
                         if (code && code == 27) {// if ESC is pressed
                             e.stopPropagation();
                             // Click the close button if it exists otherwise force tooltip closed
-                            if ($('.close', $selfRef.$targetElm).length > 0) {
-                                $('.close', $selfRef.$targetElm).eq(0).trigger('click');
+                            if ($('.close', $selfRef.$target).length > 0) {
+                                $('.close', $selfRef.$target).eq(0).trigger('click');
                             } else {
                                 $selfRef.hide(true);
                             }
@@ -224,12 +228,12 @@
                     });
 
                 // Bind 'close' buttons
-                this.$targetElm.off('click.dismiss.cfw.' + this.type, '[data-cfw-dismiss="' + this.type + '"]')
+                this.$target.off('click.dismiss.cfw.' + this.type, '[data-cfw-dismiss="' + this.type + '"]')
                     .on('click.dismiss.cfw.' + this.type, '[data-cfw-dismiss="' + this.type + '"]', function(e) {
                         $selfRef.toggle(e);
                     });
                 // Hide tooltips on modal close
-                this.$triggerElm.closest('.modal')
+                this.$element.closest('.modal')
                     .off('beforeHide.cfw.modal')
                     .on('beforeHide.cfw.modal', function() {
                         $selfRef.hide(true);
@@ -245,7 +249,7 @@
                 this.settings.follow = true;
             }
 
-            if (this.$targetElm && this.$targetElm.hasClass('in')) {
+            if (this.$target && this.$target.hasClass('in')) {
                 var holdDelay = this.settings.delay.hide;
                 this.settings.delay.hide = 0;
                 this.hide();
@@ -260,7 +264,7 @@
                 this.inState[e.type == 'focusin' ? 'focus' : 'hover'] = true;
             }
 
-            if ((this.$targetElm && this.$targetElm.hasClass('in')) || this.hoverState == 'in') {
+            if ((this.$target && this.$target.hasClass('in')) || this.hoverState == 'in') {
                 this.hoverState = 'in';
                 return;
             }
@@ -287,7 +291,6 @@
             clearTimeout(this.delayTimer);
 
             this.hoverState = 'out';
-
             if (!this.settings.delay.hide) { return this.hide(); }
 
             var $selfRef = this;
@@ -302,11 +305,11 @@
 
             // Bail if transition in progress or already shown
             if (this.inTransition) { return; }
-            if (this.$targetElm && this.$targetElm.hasClass('in')) { return; }
+            if (this.$target && this.$target.hasClass('in')) { return; }
 
             if (!this.activate) {
                 // Start show transition
-                if (!this.$triggerElm.CFW_trigger('beforeShow.cfw.' + this.type)) {
+                if (!this.$element.CFW_trigger('beforeShow.cfw.' + this.type)) {
                     return;
                 }
             }
@@ -314,29 +317,29 @@
             this.inTransition = 1;
 
             // Create/link the tooltip container
-            if (!this.$targetElm) {
-                var targetElm = this.createTip();
-                if (targetElm.length <= 0) { return false; }
+            if (!this.$target) {
+                var target = this.createTip();
+                if (target.length <= 0) { return false; }
                 this.dynamicTip = true;
-                this.$targetElm = targetElm;
+                this.$target = target;
             }
-            if (this.$targetElm.length != 1) {
+            if (this.$target.length != 1) {
                 throw new Error(this.type + ' `template` option must consist of exactly 1 top-level element!');
             }
             this.linkTip();
             this.bindTip(false);
             this.setContent();
 
-            if (this.settings.animate) { this.$targetElm.addClass('fade'); }
+            if (this.settings.animate) { this.$target.addClass('fade'); }
 
             this.locateTip();
 
             // Additional tab/focus handlers for non-inline items
             if (this.settings.container) {
-                this.$triggerElm
+                this.$element
                     .off('focusin.cfw.' + this.type + '.focusStart')
                     .on('focusin.cfw.' + this.type + '.focusStart', function(e) {
-                        if ($selfRef.$targetElm.hasClass('in')) {
+                        if ($selfRef.$target.hasClass('in')) {
                             // Check related target and move to start or end of popover
                             var selectables = $selfRef._tabItems();
                             var prevIndex = selectables.length - 1;
@@ -347,32 +350,31 @@
                                 $prevNode = null;
                             }
                             if ($prevNode && $prevNode.length === 1) {
-                                var currIndex = selectables.index($selfRef.$triggerElm);
+                                var currIndex = selectables.index($selfRef.$element);
                                 prevIndex = selectables.index($prevNode);
                                 if (currIndex < prevIndex) {
-                                    var tipSels = $selfRef._tabItems($selfRef.$targetElm);
+                                    var tipSels = $selfRef._tabItems($selfRef.$target);
 
                                     var selsIndex = tipSels.length - 2;
                                     tipSels.eq(selsIndex).trigger('focus');
                                 } else {
-                                    $selfRef.$targetElm.trigger('focus');
+                                    $selfRef.$target.trigger('focus');
                                 }
                             } else {
-                                $selfRef.$targetElm.trigger('focus');
+                                $selfRef.$target.trigger('focus');
                             }
                         }
                     });
-                this.$targetElm
-                    .off('keydown.cfw.' + this.type + '.tabmove')
-                    .on('keydown.cfw.' + this.type + '.tabmove', function(e) {
+                this.$target
+                    .off('keydown.cfw.' + this.type)
+                    .on('keydown.cfw.' + this.type, function(e) {
                         if (e.which == 9) {
                             $selfRef.flags.keyTab = true;
                             if (e.shiftKey) { $selfRef.flags.keyShift = true; }
                         }
-                    });
-                this.$targetElm
-                    .off('keyup.cfw.' + this.type + '.tabmove')
-                    .on('keyup.cfw.' + this.type + '.tabmove', function(e) {
+                    })
+                    .off('keyup.cfw.' + this.type)
+                    .on('keyup.cfw.' + this.type, function(e) {
                         if (e.which == 9) {
                             $selfRef.flags.keyTab = false;
                             $selfRef.flags.keyShift = false;
@@ -385,32 +387,32 @@
                     this.$focusLast = $(document.createElement('span'))
                     .addClass(this.type + '-focuslast')
                     .attr('tabindex', 0)
-                    .appendTo(this.$targetElm);
+                    .appendTo(this.$target);
                 }
                 if (this.$focusLast) {
                     this.$focusLast
                         .off('focusin.cfw.' + this.type + '.focusLast')
                         .on('focusin.cfw.' + this.type + '.focusLast', function(e) {
                             // Bypass this item if coming from outside of tip
-                            if ($selfRef.$targetElm[0] !== e.relatedTarget && !$selfRef.$targetElm.has(e.relatedTarget).length) {
+                            if ($selfRef.$target[0] !== e.relatedTarget && !$selfRef.$target.has(e.relatedTarget).length) {
                                 e.preventDefault();
                                 return;
                             }
-                            $selfRef._tabNext($selfRef.$triggerElm[0]);
+                            $selfRef._tabNext($selfRef.$element[0]);
                         });
                 }
-                this.$targetElm
-                    .off('focusout.cfw.' + this.type + '.tabmove')
-                    .on('focusout.cfw.' + this.type + '.tabmove', function() {
+                this.$target
+                    .off('focusout.cfw.' + this.type)
+                    .on('focusout.cfw.' + this.type, function() {
                         $(document)
-                            .off('focusin.cfw.' + this.type + '.tabmove')
-                            .one('focusin.cfw.' + this.type + '.tabmove', function(e) {
-                                if (document !== e.target && $selfRef.$targetElm[0] !== e.target && !$selfRef.$targetElm.has(e.target).length) {
+                            .off('focusin.cfw.' + this.type + '.' + this.instance)
+                            .one('focusin.cfw.' + this.type + '.' + this.instance, function(e) {
+                                if (document !== e.target && $selfRef.$target[0] !== e.target && !$selfRef.$target.has(e.target).length) {
                                     if ($selfRef.flags.keyTab) {
                                         if ($selfRef.flags.keyShift) {
-                                            $selfRef._tabPrev($selfRef.$triggerElm[0]);
+                                            $selfRef._tabPrev($selfRef.$element[0]);
                                         } else {
-                                            $selfRef._tabNext($selfRef.$triggerElm[0]);
+                                            $selfRef._tabNext($selfRef.$element[0]);
                                         }
                                     }
                                     // Reset flags
@@ -423,17 +425,14 @@
                     });
             }
 
-            this.$targetElm.CFW_transition(null, $.proxy(this._showComplete, this));
+            this.$target.CFW_transition(null, $.proxy(this._showComplete, this));
         },
 
         hide : function(force) {
             clearTimeout(this.delayTimer);
 
             // Handle delayed show and target not created
-            if (!this.$targetElm) { return; }
-
-            // Bail if transition in progress or already hidden
-            if (this.inTransition || !this.$targetElm.hasClass('in')) { return; }
+            if (!this.$target) { return; }
 
             if (force === undefined) { force = false; }
             if (force) {
@@ -441,26 +440,17 @@
                 return;
             }
 
+            // Bail if transition in progress or already hidden
+            if (this.inTransition || !this.$target.hasClass('in')) { return; }
+
             // Start hide transition
-            if (!this.$triggerElm.CFW_trigger('beforeHide.cfw.' + this.type)) {
+            if (!this.$element.CFW_trigger('beforeHide.cfw.' + this.type)) {
                 return;
             }
 
             this.inTransition = 1;
 
-            this.$triggerElm
-                .off('.cfw.' + this.type + '.focusStart')
-                .off('.cfw.modal')
-                .removeAttr('aria-describedby');
-            this.$targetElm
-                .off('.cfw.' + this.type)
-                .removeClass('in');
-            if (this.$focusLast) {
-                this.$focusLast.off('.cfw.' + this.type + '.focusLast');
-            }
-            $(document).off('.cfw.' + this.type + '.tabmove');
-
-            this.$targetElm.CFW_transition(null, $.proxy(this._hideComplete, this));
+            this.$target.CFW_transition(null, $.proxy(this._hideComplete, this));
 
             this.hoverState = null;
         },
@@ -468,14 +458,13 @@
         unlink : function(force) {
             var $selfRef = this;
             if (force === undefined) { force = false; }
-
             clearTimeout(this.delayTimer);
 
-            this.$triggerElm.CFW_trigger('beforeUnlink.cfw.' + this.type);
+            this.$element.CFW_trigger('beforeUnlink.cfw.' + this.type);
             this.unlinking = true;
 
-            if (this.$targetElm && this.$targetElm.hasClass('in')) {
-                this.$triggerElm.one('afterHide.cfw.' + this.type, function() {
+            if (this.$target && this.$target.hasClass('in')) {
+                this.$element.one('afterHide.cfw.' + this.type, function() {
                     $selfRef.unlinkComplete();
                 });
                 this.hide(force);
@@ -485,36 +474,64 @@
         },
 
         unlinkComplete : function() {
-            if (this.$targetElm) {
-                this.$targetElm.off('.cfw.' + this.type)
+            if (this.$target) {
+                this.$target.off('.cfw.' + this.type)
                     .removeData('cfw.' + this.type);
             }
-            this.$triggerElm.off('.cfw.' + this.type)
+            this.$element.off('.cfw.' + this.type)
                 .off('.cfw.modal')
                 .removeAttr('data-cfw')
                 .removeData('cfw.' + this.type);
             this.unlinking = false;
-            this.$triggerElm.CFW_trigger('afterUnlink.cfw.' + this.type);
+            this.$element.CFW_trigger('afterUnlink.cfw.' + this.type);
         },
 
         dispose : function() {
             var $selfRef = this;
-            $(document).one('afterUnlink.cfw.' + this.type, this.$triggerElm, function() {
-                if ($selfRef.$targetElm !== null) {
-                    $selfRef.$targetElm.remove();
+            $(document).one('afterUnlink.cfw.' + this.type, this.$element, function() {
+                if ($selfRef.$target !== null) {
+                    $selfRef.$target.removeData('cfw.' + $selfRef.type).remove();
                 }
-                $selfRef.$triggerElm.CFW_trigger('dispose.cfw.' + $selfRef.type);
+                $selfRef.$element.CFW_trigger('dispose.cfw.' + $selfRef.type);
+
+                $selfRef.$element.removeData('cfw.' + $selfRef.type);
+
+
+                $selfRef.$element = null;
+                $selfRef.$target = null;
+                $selfRef.$viewport = null;
+                $selfRef.$arrow = null;
+                $selfRef.$focusLast = null;
+                // $selfRef.settings = null; (throws error ???)
+                $selfRef.dataToggle = null;
+                $selfRef.type = null;
+                $selfRef.eventTypes = null;
+                $selfRef.delayTimer = null;
+                $selfRef.inTransition = null;
+                $selfRef.closeAdded = null;
+                $selfRef.unlinking = null;
+                $selfRef.activate = null;
+                $selfRef.hoverState = null;
+                $selfRef.inState = null;
+                $selfRef.dynamicTip = null;
+                $selfRef.flags = {
+                    keyShift: null,
+                    keyTab : null
+                };
+
+
+                $selfRef._disposeExt();
             });
             this.unlink(true);
+        },
 
-            this.$arrow = null;
-            this.$viewport = null;
-            this.$targetElm = null;
-            this.$triggerElm = null;
+        _disposeExt : function() {
+            // dispose extend
+            return;
         },
 
         locateTip : function() {
-            var $tip = this.$targetElm;
+            var $tip = this.$target;
 
             $tip.removeClass('top left bottom right');
 
@@ -522,14 +539,14 @@
                 .css({ top: 0, left: 0, display: 'block' });
 
             var placement = typeof this.settings.placement == 'function' ?
-                this.settings.placement.call(this, this.$targetElm[0], this.$triggerElm[0]) :
+                this.settings.placement.call(this, this.$target[0], this.$element[0]) :
                 this.settings.placement;
 
             if (typeof placement == 'object') {
                 // Custom placement
                 this.settings.container = 'body';
                 $tip.appendTo(this.settings.container);
-                this.$triggerElm.CFW_trigger('inserted.cfw.' + this.type);
+                this.$element.CFW_trigger('inserted.cfw.' + this.type);
                 $tip.offset(placement);
                 $tip.addClass('in');
             } else {
@@ -546,9 +563,9 @@
                 if (this.settings.container) {
                     $tip.appendTo(this.settings.container);
                 } else {
-                    $tip.insertAfter(this.$triggerElm);
+                    $tip.insertAfter(this.$element);
                 }
-                this.$triggerElm.CFW_trigger('inserted.cfw.' + this.type);
+                this.$element.CFW_trigger('inserted.cfw.' + this.type);
 
                 var pos          = this._getPosition();
                 var actualWidth  = $tip[0].offsetWidth;
@@ -581,23 +598,23 @@
             var prevHoverState = this.hoverState;
             this.hoverState = null;
 
-            // this.$targetElm.addClass('in')
-            this.$targetElm.removeAttr('aria-hidden');
+            // this.$target.addClass('in')
+            this.$target.removeAttr('aria-hidden');
             this.inTransition = 0;
             if (this.settings.follow) {
-                this.$targetElm.trigger('focus');
+                this.$target.trigger('focus');
             }
 
             // Delay to keep NVDA (and other screen readers?) from reading dialog header twice
             setTimeout(function() {
                 // Handle case of immediate dispose after show
-                if ($selfRef.$triggerElm) {
-                    $selfRef.$triggerElm.attr('aria-describedby', $selfRef.targetID);
+                if ($selfRef.$element) {
+                    $selfRef.$element.attr('aria-describedby', $selfRef.targetID);
                 }
             }, 25);
 
             if (!this.activate) {
-                this.$triggerElm.CFW_trigger('afterShow.cfw.' + this.type);
+                this.$element.CFW_trigger('afterShow.cfw.' + this.type);
             }
             this.activate = false;
 
@@ -605,7 +622,19 @@
         },
 
         _hideComplete : function() {
-            this.$targetElm.removeClass('in')
+            this.$element
+                .off('.cfw.' + this.type + '.focusStart')
+                .off('.cfw.modal')
+                .removeAttr('aria-describedby');
+            this.$target
+                .off('.cfw.' + this.type)
+                .removeClass('in');
+            if (this.$focusLast) {
+                this.$focusLast.off('.cfw.' + this.type + '.focusLast');
+            }
+            $(document).off('.cfw.' + this.type + '.' + this.instance);
+
+            this.$target.removeClass('in')
                 .css('display', 'none')
                 .attr({
                     'aria-hidden': 'true',
@@ -614,8 +643,8 @@
 
             this.inTransition = 0;
             if (this.settings.follow) {
-                this.$targetElm.attr('tabindex', -1);
-                this.$triggerElm.trigger('focus');
+                this.$target.attr('tabindex', -1);
+                this.$element.trigger('focus');
             }
             this.settings.follow = false;
 
@@ -624,7 +653,7 @@
                 this._removeDynamicTip();
             }
 
-            this.$triggerElm.CFW_trigger('afterHide.cfw.' + this.type);
+            this.$element.CFW_trigger('afterHide.cfw.' + this.type);
 
             if (!this.unlinking) {
                 if (this.settings.unlink) { this.unlink(); }
@@ -633,15 +662,15 @@
         },
 
         _removeDynamicTip : function() {
-            this.$targetElm.detach();
+            this.$target.detach();
             this.dynamicTip = false;
             this.closeAdded = false;
             this.$arrow = null;
-            this.$targetElm = null;
+            this.$target = null;
         },
 
         _getPosition : function($element) {
-            $element   = $element || this.$triggerElm;
+            $element   = $element || this.$element;
 
             var el     = $element[0];
             var isBody = el.tagName == 'BODY';
@@ -672,7 +701,7 @@
         },
 
         _applyPlacement : function(offset, placement) {
-            var $tip   = this.$targetElm;
+            var $tip   = this.$target;
             var width  = $tip[0].offsetWidth;
             var height = $tip[0].offsetHeight;
 
@@ -731,7 +760,7 @@
                 elRect = $.extend({}, elRect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top });
             }
 
-            if ($viewport.is('body') && (/fixed|absolute/).test(this.$triggerElm.css('position'))) {
+            if ($viewport.is('body') && (/fixed|absolute/).test(this.$element.css('position'))) {
                 // fixed and absolute elements should be tested against the window
                 return $.extend({}, elRect, this.getScreenSpaceBounds($viewport));
             }
@@ -789,7 +818,7 @@
 
         _arrow : function() {
             if (!this.$arrow) {
-                this.$arrow = this.$targetElm.find('.tooltip-arrow');
+                this.$arrow = this.$target.find('.tooltip-arrow');
             }
             return this.$arrow;
         },

--- a/js/util.js
+++ b/js/util.js
@@ -161,7 +161,7 @@
 
     $.fn.CFW_throttle = function(fn, threshhold, scope) {
         /* From: http://remysharp.com/2010/07/21/throttling-function-calls/ */
-        threshhold || (threshhold = 250);
+        if (threshhold === undefined) { threshhold = 250; }
         var last;
         var deferTimer;
         return function() {

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -21,14 +21,15 @@
         }
 
         // Bring the "active" button to the front
-        &:focus,
         &:active,
         &.active {
             z-index: 2;
         }
-
-        @include hover {
+        &:hover {
             z-index: 2;
+        }
+        &:focus {
+            z-index: 3;
         }
     }
 }

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -22,20 +22,6 @@
             @include border-right-radius($pagination-border-radius);
         }
     }
-
-    &.disabled .page-link {
-        color: $pagination-disabled-color;
-        pointer-events: none;
-        cursor: $cursor-disabled;
-        background-color: $pagination-disabled-bg;
-    }
-
-    &.active .page-link {
-        z-index: 2;
-        color: $pagination-active-color;
-        cursor: default;
-        background-color: $pagination-active-bg;
-    }
 }
 
 .page-link {
@@ -49,12 +35,30 @@
     background-color: $pagination-bg;
     border: $pagination-border-width solid $pagination-border-color;
 
-    @include hover-focus {
+    &:hover {
         z-index: 2;
         color: $pagination-hover-color;
         text-decoration: none;
         background-color: $pagination-hover-bg;
         border-color: $pagination-hover-border;
+    }
+
+    &.active {
+        z-index: 2;
+        color: $pagination-active-color;
+        cursor: default;
+        background-color: $pagination-active-bg;
+    }
+
+    &:focus {
+        z-index: 3;
+    }
+
+    &.disabled {
+        color: $pagination-disabled-color;
+        pointer-events: none;
+        cursor: $cursor-disabled;
+        background-color: $pagination-disabled-bg;
     }
 }
 

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -2088,14 +2088,14 @@ Anchor variants:<br />
 <h3>Pagination disabled and active states</h3>
 <nav aria-label="...">
   <ul class="pagination">
-    <li class="page-item disabled">
-      <a class="page-link" href="#" tabindex="-1" aria-label="Previous">
+    <li class="page-item">
+      <a class="page-link disabled" href="#" tabindex="-1" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </a>
     </li>
-    <li class="page-item active">
-      <a class="page-link" href="#">1 <span class="sr-only">(current)</span></a>
+    <li class="page-item">
+      <a class="page-link active" href="#">1 <span class="sr-only">(current)</span></a>
     </li>
     <li class="page-item"><a class="page-link" href="#">2</a></li>
     <li class="page-item"><a class="page-link" href="#">3</a></li>
@@ -2111,13 +2111,13 @@ Anchor variants:<br />
 </nav>
 <nav aria-label="...">
   <ul class="pagination">
-    <li class="page-item disabled">
-      <span class="page-link" aria-label="Previous">
+    <li class="page-item">
+      <span class="page-link disabled" aria-label="Previous">
         <span aria-hidden="true">&laquo;</span>
         <span class="sr-only">Previous</span>
       </span>
     </li>
-    <li class="page-item active"><span class="page-link">1 <span class="sr-only">(current)</span></span></li>
+    <li class="page-item"><span class="page-link active">1 <span class="sr-only">(current)</span></span></li>
   </ul>
 </nav>
 

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -734,11 +734,11 @@ $(window).ready(function() {
 
             <script type="text/javascript">
                 $(window).ready(function() {
-                    var $zoom = $('#pop_7p').data('cfw.popover').$triggerElm;
-                    $zoom.one('beforeShow.cfw.popover', function(e) {
-                        $(this).data('cfw.popover').$targetElm.find('[data-cfw="lazy"]').each(function() {
+                    $('#pop_7p').one('beforeShow.cfw.popover', function(e) {
+                        var $popover = $(this);
+                        $popover.data('cfw.popover').$targetElm.find('[data-cfw="lazy"]').each(function() {
                             $(this).one('load', function() {
-                                $zoom.CFW_Popover('locateTip');
+                                $popover.CFW_Popover('locateTip');
                             }).CFW_Lazy('show');
                         });
                     });
@@ -778,7 +778,8 @@ $(window).ready(function() {
                 <a href="#" onclick="javascript: popLinkTest0(); return false;">Unlink 0 - Link 1</a> |
                 <a href="#" onclick="javascript: popLinkTest1(); return false;">Unlink 1 - Link 0</a> |
                 <a href="#" onclick="javascript: popLinkTest2(); return false;">Show popover data</a> |
-                <a href="#" onclick="javascript: $('#popR').CFW_Popover('unlink'); return false;">Unlink</a>
+                <a href="#" onclick="javascript: $('#popR').CFW_Popover('unlink'); return false;">Unlink</a> |
+                <a href="#" onclick="javascript: $('#popR').CFW_Popover('dispose'); return false;">Dispose</a>
             </p>
             <div class="popover" id="popR">
                 <h3 class="popover-title">Popover selector</h3>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -890,8 +890,8 @@ $(window).ready(function() {
                 </nav>
                 <div class="tab-content">
                     <div class="tab-pane" id="tabr0">
-                        <h3><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr0_collapse">First Tab <span class="caret"></span></a></h3>
-                        <div data-cfw-collapse-target="tabr0_collapse">
+                        <h3><a href="#tabr0_collapse" data-cfw="collapse">First Tab <span class="caret"></span></a></h3>
+                        <div id="tabr0_collapse">
                             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.</p>
                         </div>
                     </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -39,9 +39,9 @@ $(window).ready(function() {
     });
     var $sideBar = $('.sidebar');
     $sideBar.CFW_Affix({
-        offsetTop:
+        top:
             function() {
-                return $('.topnav').height();
+                return $('header').height();
             }
     });
 });
@@ -979,11 +979,11 @@ $(window).ready(function() {
                                 </ul>
                             </li>
                             <li class="dropdown-divider"></li>
-                            <li><a href="#0-1-3">Separated link</a></li>
+                            <li><a href="#0-1-3" class="disabled">Disabled link</a></li>
                         </ul>
                     </li>
                     <li>
-                        <a href="#">Something else here</a>
+                        <a href="#" class="active">Something else here</a>
                         <!-- <a href="#0-2">Something else here</a> -->
                         <ul>
                             <li><a href="#0-2-0">Action</a></li>
@@ -1003,7 +1003,7 @@ $(window).ready(function() {
                         </ul>
                     </li>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#0-3">Separated link</a></li>
+                    <li><a href="#0-3" class="disabled">Disabled link</a></li>
                 </ul>
             </div>
 
@@ -1093,7 +1093,7 @@ $(window).ready(function() {
                         </ul>
                     </li>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#2-3">Separated link</a></li>
+                    <li><a href="#2-3" class="disabled">Separated link</a></li>
                 </ul>
             </div>
             <script type="text/javascript">
@@ -1160,7 +1160,7 @@ $(window).ready(function() {
                         </ul>
                     </li>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#3-3">Separated link</a></li>
+                    <li><a href="#3-3" class="disabled">Separated link</a></li>
                 </ul>
             </div>
 
@@ -1174,7 +1174,7 @@ $(window).ready(function() {
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#">Separated link</a></li>
+                    <li><a href="#" class="disabled">Separated link</a></li>
                 </ul>
             </div>
 
@@ -1266,7 +1266,7 @@ $(window).ready(function() {
                         </ul>
                     </li>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#4-3">Separated link</a></li>
+                    <li><a href="#4-3" class="disabled">Separated link</a></li>
                 </ul>
             </div>
 
@@ -1327,7 +1327,7 @@ $(window).ready(function() {
                         </ul>
                     </li>
                     <li class="dropdown-divider"></li>
-                    <li class="disabled"><a href="#5-3">Separated link</a></li>
+                    <li><a href="#5-3" class="disabled">Separated link</a></li>
                 </ul>
             </div>
 
@@ -1516,12 +1516,11 @@ $(window).ready(function() {
             </div>
 
             <strong>Nested:</strong>
-            <div data-cfw="equalize" data-cfw-equalize-target="foo">
+            <div data-cfw="equalize" data-cfw-equalize-target="foo" data-cfw-equalize-row=true>
                 <div class="row" data-cfw="equalize" data-cfw-equalize-target="bar">
                     <div class="col-md-4">
                         <div class="well" data-cfw-equalize-group="foo">
                             <h3>Panel 1</h3>
-                            one
                             <div class="well" data-cfw-equalize-group="bar">one</div>
                             one
                         </div>
@@ -1530,13 +1529,14 @@ $(window).ready(function() {
                         <div class="well" data-cfw-equalize-group="foo">
                             <h3>Panel 2</h3>
                             <div class="well" data-cfw-equalize-group="bar">two<br />two</div>
-                            two
+                            two<br />two
                         </div>
                     </div>
                     <div class="col-md-4">
                         <div class="well" data-cfw-equalize-group="foo">
                             <h3>Panel 3</h3>
                             <div class="well" data-cfw-equalize-group="bar">three<br />three<br />three</div>
+                            three<br />three<br />three
                         </div>
                     </div>
                 </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -210,7 +210,7 @@ $(window).ready(function() {
             <strong>Single Slider:</strong>
             <div class="slider-sample">
                 <form class="form-inline">
-                    <div id="slider0">
+                    <div id="slider0" data-cfw="slider" data-cfw-slider-min=0 data-cfw-slider-max=100 data-cfw-slider-step=1>
                         <div class="form-group">
                             <label id="slider0_0_Label" for="slider0_0">Value</label>
                             <input id="slider0_0" type="text" class="form-control" value="50" />
@@ -218,6 +218,7 @@ $(window).ready(function() {
                     </div>
                 </form>
             </div>
+            <!--
             <script type="text/javascript">
             $('#slider0').CFW_Slider({
                 min : 0,
@@ -225,6 +226,7 @@ $(window).ready(function() {
                 step : 1
             });
             </script>
+            -->
 
             <strong>Double Slider</strong>
             <div class="slider-sample">

--- a/test/js/unit/accordion.js
+++ b/test/js/unit/accordion.js
@@ -88,42 +88,6 @@ $(function() {
         $trigger3.trigger('click');
     });
 
-    QUnit.test('should add aria-hidden="true" on inactive accordion target and remove aria-hidden for active target', function(assert) {
-        assert.expect(3);
-        var done = assert.async();
-
-        var $accordion = $('<div id="test" data-cfw="accordion">'
-            + '<div />'
-            + '<div />'
-            + '<div />'
-            + '</div>');
-
-        var $groups = $accordion.appendTo('#qunit-fixture').children('div');
-
-        var $trigger1 = $('<a href="#body1" class="open" role="button" data-cfw="collapse" />').appendTo($groups.eq(0));
-        var $target1 = $('<div id="body1" class="collapse in" />').appendTo($groups.eq(0));
-
-        var $trigger2 = $('<a href="#body2" role="button" data-cfw="collapse" />').appendTo($groups.eq(1));
-        var $target2 = $('<div id="body2" class="collapse" aria-hidden="true" />').appendTo($groups.eq(1));
-
-        var $trigger3 = $('<a href="#body3" role="button" data-cfw="collapse" />').appendTo($groups.eq(2));
-        var $target3 = $('<div id="body3" class="collapse" aria-hidden="true" />').appendTo($groups.eq(2));
-
-        $trigger3
-            .on('afterShow.cfw.collapse', function() {
-                assert.strictEqual($target1.attr('aria-hidden'), 'true', 'inactive target 1 does have  aria-hidden="true"');
-                assert.strictEqual($target2.attr('aria-hidden'), 'true', 'inactive target 2 does have  aria-hidden="true"');
-                assert.notOk($target3.is('[aria-hidden]'), 'active target 3 does not have aria-hidden');
-                done();
-            });
-
-        $trigger1.CFW_Collapse();
-        $trigger2.CFW_Collapse();
-        $trigger3.CFW_Collapse();
-        $accordion.CFW_Accordion();
-        $trigger3.trigger('click');
-    });
-
     QUnit.test('should change aria-expanded from active accordion trigger to "false" and set the newly active one to "true"', function(assert) {
         assert.expect(3);
         var done = assert.async();
@@ -176,7 +140,7 @@ $(function() {
         var $target1 = $('<div id="body1" class="collapse in" />').appendTo($groups.eq(0));
 
         var $trigger2 = $('<a href="#body2" role="button" data-cfw="collapse" />').appendTo($groups.eq(1));
-        /* var $target2 = */ $('<div id="body2" class="collapse" aria-hidden="true" />').appendTo($groups.eq(1));
+        /* var $target2 = */ $('<div id="body2" class="collapse" />').appendTo($groups.eq(1));
 
         $trigger1.CFW_Collapse();
         $trigger2.CFW_Collapse();

--- a/test/js/unit/collapse.js
+++ b/test/js/unit/collapse.js
@@ -267,40 +267,6 @@ $(function() {
         setTimeout(done, 10);
     });
 
-    QUnit.test('should remove aria-hidden on target when collapse is shown', function(assert) {
-        assert.expect(1);
-        var done = assert.async();
-
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $target = $('<div id="test" class="collapse" aria-hidden="true" />').appendTo('#qunit-fixture');
-
-        $trigger
-            .one('afterShow.cfw.collapse', function() {
-                assert.notOk($target.is('[aria-hidden]'), 'aria-hidden attribute removed');
-                done();
-            });
-
-        $trigger.CFW_Collapse();
-        $trigger.trigger('click');
-    });
-
-    QUnit.test('should set aria-hidden="true" on target when collapse is hidden', function(assert) {
-        assert.expect(1);
-        var done = assert.async();
-
-        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
-
-        $trigger
-            .one('afterHide.cfw.collapse', function() {
-                assert.strictEqual($target.attr('aria-hidden'), 'true', 'aria-hidden on target is "true"');
-                done();
-            });
-
-        $trigger.CFW_Collapse();
-        $trigger.trigger('click');
-    });
-
     QUnit.test('should set aria-expanded="true" on all triggers when the collapse is shown', function(assert) {
         assert.expect(2);
         var done = assert.async();

--- a/test/js/unit/dropdown.js
+++ b/test/js/unit/dropdown.js
@@ -222,7 +222,7 @@ $(function() {
         var dropdownHTML = '<div class="dropdown">'
             + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
             + '<ul class="dropdown-menu">'
-            + '<li class="disabled"><a href="#">Disabled link</a></li>'
+            + '<li><a href="#" class="disabled">Disabled link</a></li>'
             + '<li><a href="#">Menu link</a></li>'
             + '</ul>'
             + '</div>';

--- a/test/js/unit/lazy.js
+++ b/test/js/unit/lazy.js
@@ -26,17 +26,24 @@ $(function() {
         assert.equal($imgHtml.attr('src'), placeholder, 'image src replaced with placeholder');
     });
 
-    QUnit.test('should change src to match data-src when visible within the viewport at load', function(assert) {
+    QUnit.test('should change src to match data-src when visible within the viewport at init', function(assert) {
         assert.expect(2);
         var done = assert.async();
-        var $content = $('<style>#qunit-fixture { position: static; }</style>' +
-            '<img src="" id="img-1" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" />');
-        $content.appendTo('#qunit-fixture');
-        var $img1 = $('#img-1')
+        var styles = '<style>'
+            + '.container-viewport { position: absolute; top: 50px; left: 60px; width: 300px; height: 300px; }'
+            + '</style>';
+        var $styles = $(styles).appendTo('head');
+        var $container = $('<div class="container-viewport"/>').appendTo(document.body);
+
+        var $imgHtml = $('<img src="" id="img-1" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" />');
+        $imgHtml
+            .appendTo($container)
             .one('afterShow.cfw.lazy', function() {
                 assert.ok('show event fired');
-                assert.equal($img1.attr('src'), '../assets/img/test.gif', 'image src was updated');
+                assert.equal($('#img-1').attr('src'), '../assets/img/test.gif', 'image src was updated');
                 done();
+                $container.remove();
+                $styles.remove();
             })
             .CFW_Lazy();
     });

--- a/test/js/unit/lazy.js
+++ b/test/js/unit/lazy.js
@@ -15,4 +15,29 @@ $(function() {
         assert.ok($col instanceof $, 'returns jquery collection');
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
+
+    QUnit.test('should change src to placeholder at load', function(assert) {
+        assert.expect(1);
+        var $imgHtml = $('<img src="" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" />');
+        var placeholder = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        $imgHtml
+            .appendTo('#qunit-fixture')
+            .CFW_Lazy();
+        assert.equal($imgHtml.attr('src'), placeholder, 'image src replaced with placeholder');
+    });
+
+    QUnit.test('should change src to match data-src when visible within the viewport at load', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $content = $('<style>#qunit-fixture { position: static; }</style>' +
+            '<img src="" id="img-1" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" />');
+        $content.appendTo('#qunit-fixture');
+        var $img1 = $('#img-1')
+            .one('afterShow.cfw.lazy', function() {
+                assert.ok('show event fired');
+                assert.equal($img1.attr('src'), '../assets/img/test.gif', 'image src was updated');
+                done();
+            })
+            .CFW_Lazy();
+    });
 });

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -148,7 +148,7 @@ $(function() {
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
     });
 
-    QUnit.test('should destroy popover', function(assert) {
+    QUnit.test('should dispose popover', function(assert) {
         assert.expect(7);
         var $popover = $('<div />')
             .appendTo('#qunit-fixture')
@@ -162,7 +162,7 @@ $(function() {
         assert.strictEqual($._data($popover[0], 'events').click[0].namespace, 'foo', 'popover has extra click.foo event');
 
         $popover.CFW_Popover('show');
-        $popover.CFW_Popover('destroy');
+        $popover.CFW_Popover('dispose');
 
         assert.ok(!$popover.hasClass('in'), 'popover is hidden');
         assert.ok(!$popover.data('popover'), 'popover does not have data');
@@ -198,7 +198,7 @@ $(function() {
                         $div
                             .one('afterShow.cfw.popover', function() {
                                 $('.content-with-handler .btn').trigger('click');
-                                $div.CFW_Popover('destroy');
+                                $div.CFW_Popover('dispose');
                                 assert.ok(handlerCalled, 'content\'s event handler still present');
                                 done();
                             })

--- a/test/js/unit/scrollspy.js
+++ b/test/js/unit/scrollspy.js
@@ -51,7 +51,7 @@ $(function() {
         var $scrollspy = $section
             .show()
             .find('#scrollspy-example')
-            .CFW_Scrollspy({ target: '#ss-target' });
+            .CFW_Scrollspy({ target: '#ss-target', throttle: 0 });
 
         $scrollspy.on('scroll.cfw.scrollspy', function() {
             assert.ok($section.hasClass('active'), '"active" class still on root node');
@@ -83,7 +83,7 @@ $(function() {
             .show()
             .filter('#content');
 
-        $scrollspy.CFW_Scrollspy({ target: '#navigation', offset: $scrollspy.position().top });
+        $scrollspy.CFW_Scrollspy({ target: '#navigation', offset: $scrollspy.position().top, throttle: 0 });
 
         $scrollspy.on('scroll.cfw.scrollspy', function() {
             assert.ok(!$section.find('#a-1').hasClass('active'), '"active" class removed from first section');
@@ -111,7 +111,7 @@ $(function() {
         $(navbarHtml).appendTo('#qunit-fixture');
         var $content = $(contentHtml)
             .appendTo('#qunit-fixture')
-            .CFW_Scrollspy({ offset: 0, target: '.navbar' });
+            .CFW_Scrollspy({ target: '.navbar', offset: 0, throttle: 0 });
 
         var testElementIsActiveAfterScroll = function(element, target) {
             var deferred = $.Deferred();
@@ -154,7 +154,7 @@ $(function() {
 
         var $content = $(contentHtml)
             .appendTo('#qunit-fixture')
-            .CFW_Scrollspy({ offset: 0, target: '#navigation' });
+            .CFW_Scrollspy({ target: '#navigation', offset: 0, throttle: 0 });
 
         !function testActiveElements() {
             if (++times > 3) return done();
@@ -195,7 +195,8 @@ $(function() {
         $scrollspy
             .CFW_Scrollspy({
                 target: '#navigation',
-                offset: $scrollspy.position().top
+                offset: $scrollspy.position().top,
+                throttle: 0
             })
             .one('scroll.cfw.scrollspy', function() {
                 assert.strictEqual($('.active').length, 1, '"active" class on only one element present');
@@ -239,7 +240,8 @@ $(function() {
         $scrollspy
             .CFW_Scrollspy({
                 target: '#navigation',
-                offset: $scrollspy.position().top
+                offset: $scrollspy.position().top,
+                throttle: 0
             })
             .one('scroll.cfw.scrollspy', function() {
                 assert.strictEqual($('.active').length, 1, '"active" class on only one element present');
@@ -277,7 +279,7 @@ $(function() {
         $(navbarHtml).appendTo('#qunit-fixture');
         var $content = $(contentHtml)
             .appendTo('#qunit-fixture')
-            .CFW_Scrollspy({ offset: 0, target: '.navbar' });
+            .CFW_Scrollspy({ target: '.navbar', offset: 0, throttle: 0 });
 
         var testElementIsActiveAfterScroll = function(element, target) {
             var deferred = $.Deferred();

--- a/test/js/unit/scrollspy.js
+++ b/test/js/unit/scrollspy.js
@@ -95,13 +95,77 @@ $(function() {
         $scrollspy.scrollTop(550);
     });
 
-    QUnit.test('should add the active class to the correct element', function(assert) {
+    QUnit.test('should add the active class to the correct element (ul markup)', function(assert) {
         assert.expect(2);
-        var navbarHtml = '<nav class="navbar">'
-            + '<ul class="nav">'
+        var navbarHtml = '<ul>'
             + '<li><a href="#div-1" id="a-1">div 1</a></li>'
             + '<li><a href="#div-2" id="a-2">div 2</a></li>'
-            + '</ul>'
+            + '</ul>';
+        var contentHtml = '<div class="content" style="overflow: auto; height: 50px">'
+            + '<div id="div-1" style="height: 100px; padding: 0; margin: 0">div 1</div>'
+            + '<div id="div-2" style="height: 200px; padding: 0; margin: 0">div 2</div>'
+            + '</div>';
+
+        $(navbarHtml).appendTo('#qunit-fixture');
+        var $content = $(contentHtml)
+            .appendTo('#qunit-fixture')
+            .CFW_Scrollspy({ target: 'ul', offset: 0, throttle: 0 });
+
+        var testElementIsActiveAfterScroll = function(element, target) {
+            var deferred = $.Deferred();
+            var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top);
+            $content.one('scroll', function() {
+                assert.ok($(element).hasClass('active'), 'target:' + target + ', element' + element);
+                deferred.resolve();
+            });
+            $content.scrollTop(scrollHeight);
+            return deferred.promise();
+        };
+
+        var done = assert.async();
+        $.when(testElementIsActiveAfterScroll('#a-1', '#div-1'))
+            .then(function() { return testElementIsActiveAfterScroll('#a-2', '#div-2'); })
+            .then(function() { done(); });
+    });
+
+    QUnit.test('should add the active class to the correct element (ol markup)', function(assert) {
+        assert.expect(2);
+        var navbarHtml = '<ol>'
+            + '<li><a href="#div-1" id="a-1">div 1</a></li>'
+            + '<li><a href="#div-2" id="a-2">div 2</a></li>'
+            + '</ol>';
+        var contentHtml = '<div class="content" style="overflow: auto; height: 50px">'
+            + '<div id="div-1" style="height: 100px; padding: 0; margin: 0">div 1</div>'
+            + '<div id="div-2" style="height: 200px; padding: 0; margin: 0">div 2</div>'
+            + '</div>';
+
+        $(navbarHtml).appendTo('#qunit-fixture');
+        var $content = $(contentHtml)
+            .appendTo('#qunit-fixture')
+            .CFW_Scrollspy({ target: 'ol', offset: 0, throttle: 0 });
+
+        var testElementIsActiveAfterScroll = function(element, target) {
+            var deferred = $.Deferred();
+            var scrollHeight = Math.ceil($content.scrollTop() + $(target).position().top);
+            $content.one('scroll', function() {
+                assert.ok($(element).hasClass('active'), 'target:' + target + ', element' + element);
+                deferred.resolve();
+            });
+            $content.scrollTop(scrollHeight);
+            return deferred.promise();
+        };
+
+        var done = assert.async();
+        $.when(testElementIsActiveAfterScroll('#a-1', '#div-1'))
+            .then(function() { return testElementIsActiveAfterScroll('#a-2', '#div-2'); })
+            .then(function() { done(); });
+    });
+
+    QUnit.test('should add the active class to the correct element (nav markup)', function(assert) {
+        assert.expect(2);
+        var navbarHtml = '<nav>'
+            + '<a href="#div-1" id="a-1">div 1</a>'
+            + '<a href="#div-2" id="a-2">div 2</a>'
             + '</nav>';
         var contentHtml = '<div class="content" style="overflow: auto; height: 50px">'
             + '<div id="div-1" style="height: 100px; padding: 0; margin: 0">div 1</div>'
@@ -111,7 +175,7 @@ $(function() {
         $(navbarHtml).appendTo('#qunit-fixture');
         var $content = $(contentHtml)
             .appendTo('#qunit-fixture')
-            .CFW_Scrollspy({ target: '.navbar', offset: 0, throttle: 0 });
+            .CFW_Scrollspy({ target: 'nav', offset: 0, throttle: 0 });
 
         var testElementIsActiveAfterScroll = function(element, target) {
             var deferred = $.Deferred();
@@ -167,6 +231,88 @@ $(function() {
 
             $content.scrollTop($content.scrollTop() + 10);
         }();
+    });
+
+    QUnit.test('should add the active class correctly when there are nested elements (list markup)', function(assert) {
+        assert.expect(6);
+        var times = 0;
+        var done = assert.async();
+        var navbarHtml = '<ul id="navigation">'
+            + '<li>'
+            + '<a id="a-1" class="nav-link" href="#div-1">div 1</a>'
+            + '<ol class="nav">'
+            + '<li>'
+            + '<a id="a-2" class="nav-link" href="#div-2">div 2</a>'
+            + '</li>'
+            + '</ol>'
+            + '</li>'
+            + '</ul>';
+
+        var contentHtml = '<div class="content" style="position: absolute; top: 0px; overflow: auto; height: 50px">'
+            + '<div id="div-1" style="padding: 0; margin: 0">'
+            + '<div id="div-2" style="height: 200px; padding: 0; margin: 0">div 2</div>'
+            + '</div>'
+            + '</div>';
+
+        $(navbarHtml).appendTo('#qunit-fixture');
+
+        var $content = $(contentHtml)
+            .appendTo('#qunit-fixture')
+            .CFW_Scrollspy({ offset: 0, target: '#navigation' });
+
+        function testActiveElements() {
+            if (++times > 3) { return done(); }
+
+            $content.one('scroll', function() {
+                assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class');
+                assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class');
+                testActiveElements();
+            });
+
+            $content.scrollTop($content.scrollTop() + 10);
+        }
+
+        testActiveElements();
+    });
+
+    QUnit.test('should add the active class correctly when there are nested elements (nav markup)', function(assert) {
+        assert.expect(6);
+        var times = 0;
+        var done = assert.async();
+        var navbarHtml = '<nav id="navigation">'
+            + '<nav>'
+            + '<a id="a-1" class="nav-link" href="#div-1">div 1</a>'
+            + '<nav>'
+            + '<a id="a-2" class="nav-link" href="#div-2">div 2</a>'
+            + '</nav>'
+            + '</nav>'
+            + '</nav>';
+
+        var contentHtml = '<div class="content" style="position: absolute; top: 0px; overflow: auto; height: 50px">'
+            + '<div id="div-1" style="padding: 0; margin: 0">'
+            + '<div id="div-2" style="height: 200px; padding: 0; margin: 0">div 2</div>'
+            + '</div>'
+            + '</div>';
+
+        $(navbarHtml).appendTo('#qunit-fixture');
+
+        var $content = $(contentHtml)
+            .appendTo('#qunit-fixture')
+            .CFW_Scrollspy({ offset: 0, target: '#navigation' });
+
+        function testActiveElements() {
+            if (++times > 3) { return done(); }
+
+            $content.one('scroll', function() {
+                assert.ok($('#a-1').hasClass('active'), 'nav item for outer element has "active" class');
+                assert.ok($('#a-2').hasClass('active'), 'nav item for inner element has "active" class');
+                testActiveElements();
+            });
+
+            $content.scrollTop($content.scrollTop() + 10);
+        }
+
+        testActiveElements();
     });
 
     QUnit.test('should clear selection if above the first section', function(assert) {

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -232,7 +232,7 @@ $(function() {
             .CFW_Tooltip('show');
     });
 
-    QUnit.test('should destroy tooltip', function(assert) {
+    QUnit.test('should dispose tooltip', function(assert) {
         assert.expect(7);
         var $tooltip = $('<div/>')
             .appendTo('#qunit-fixture')
@@ -244,7 +244,7 @@ $(function() {
         assert.strictEqual($._data($tooltip[0], 'events').click[0].namespace, 'foo', 'tooltip has extra click.foo event');
 
         $tooltip.CFW_Tooltip('show');
-        $tooltip.CFW_Tooltip('destroy');
+        $tooltip.CFW_Tooltip('dispose');
 
         assert.ok(!$tooltip.hasClass('in'), 'tooltip is hidden');
         assert.ok(!$._data($tooltip[0], 'cfw.tooltip'), 'tooltip does not have data');

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -1000,12 +1000,12 @@ $(function() {
             .CFW_Tooltip({ delay: { show: 0, hide: 150 }});
 
         setTimeout(function() {
-            assert.ok($tooltip.data('cfw.tooltip').$targetElm.is('.fade.in'), '1ms: tooltip faded in');
+            assert.ok($tooltip.data('cfw.tooltip').$target.is('.fade.in'), '1ms: tooltip faded in');
 
             $tooltip.trigger('mouseout');
 
             setTimeout(function() {
-                assert.ok($tooltip.data('cfw.tooltip').$targetElm.is('.fade.in'), '100ms: tooltip still faded in');
+                assert.ok($tooltip.data('cfw.tooltip').$target.is('.fade.in'), '100ms: tooltip still faded in');
             }, 100);
 
             setTimeout(function() {
@@ -1174,7 +1174,7 @@ $(function() {
         $('<a href="#" title="tooltip title" style="position: absolute; bottom: 0; right: 0;">Foobar</a>')
             .appendTo('body')
             .on('afterShow.cfw.tooltip', function() {
-                var arrowStyles = $(this).data('cfw.tooltip').$targetElm.find('.tooltip-arrow').attr('style');
+                var arrowStyles = $(this).data('cfw.tooltip').$target.find('.tooltip-arrow').attr('style');
                 assert.ok(/left/i.test(arrowStyles) && !/top/i.test(arrowStyles), 'arrow positioned correctly');
                 $(this).CFW_Tooltip('hide');
             })


### PR DESCRIPTION
Yeah, bad form for tracking changes once again.  Yet another monolithic rework that should have be broken into smaller PRs.

First pass over the JS routines to:
- normalize some of the variable names.
- add `dispose` methods to all widgets
- rename `destory` method to `dispose` where needed

Other things are going to slip in as I work over all the widget source files.
- additional documentation examples
- fixed equalize resizing when stacking
- fix examples for dropdown to move `.active` and `.disabled` to the link items