### PR TITLE
v3 - Form Validation icons

### DIFF
--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -718,6 +718,7 @@ Figuration includes validation styles for danger, warning, and success states on
 
 - To use, add `.has-warning`, `.has-danger`, or `.has-success` to the parent element. Any `.form-control-label`, `.form-control`, or custom form element will receive the validation styles.
 - Contextual validation text, in addition to your usual form field help text, can be added with the use of `.form-control-feedback`. This text will adapt to the parent `.has-*` class. By default it only includes a bit of `margin` for spacing and a modified `color` for each state.
+- Add a visual validation icon to an input field by adding the `.form-control-icon` class to a `.form-control` element.  These icons will also scale with the component size.
 - Validation icons are `url()`s configured via Sass variables that are applied to `background-image` declarations for each state.
 - You may use your own base64 PNGs or SVGs by updating the Sass variables and recompiling.
 - Icons can also be disabled entirely by setting the variables to `none` or commenting out the source Sass.
@@ -747,19 +748,19 @@ Ensure that an alternative indication of state is also provided. For instance, y
 {% example html %}
 <div class="form-group has-success">
   <label class="form-control-label" for="inputSuccess1">Input with success</label>
-  <input type="text" class="form-control form-control-success" id="inputSuccess1">
+  <input type="text" class="form-control form-control-icon" id="inputSuccess1">
   <div class="form-control-feedback">Success! You've done it.</div>
   <small class="form-text text-muted">Example help text that remains unchanged.</small>
 </div>
 <div class="form-group has-warning">
   <label class="form-control-label" for="inputWarning1">Input with warning</label>
-  <input type="text" class="form-control form-control-warning" id="inputWarning1">
+  <input type="text" class="form-control form-control-icon" id="inputWarning1">
   <div class="form-control-feedback">Check the formatting of that and try again.</div>
   <small class="form-text text-muted">Example help text that remains unchanged.</small>
 </div>
 <div class="form-group has-danger">
   <label class="form-control-label" for="inputDanger1">Input with danger</label>
-  <input type="text" class="form-control form-control-danger" id="inputDanger1">
+  <input type="text" class="form-control form-control-icon" id="inputDanger1">
   <div class="form-control-feedback">Sorry, that username's taken. Try another?</div>
   <small class="form-text text-muted">Example help text that remains unchanged.</small>
 </div>
@@ -792,7 +793,7 @@ Also a slightly more horizontal layout.
 <div class="form-group row has-success">
   <label for="inputHorizontalSuccess" class="col-sm-2 form-control-label">Email</label>
   <div class="col-sm-10">
-    <input type="email" class="form-control form-control-success" id="inputHorizontalSuccess" placeholder="name@example.com">
+    <input type="email" class="form-control form-control-icon" id="inputHorizontalSuccess" placeholder="name@example.com">
     <div class="form-control-feedback">Success! You've done it.</div>
     <small class="form-text text-muted">Example help text that remains unchanged.</small>
   </div>
@@ -800,7 +801,7 @@ Also a slightly more horizontal layout.
 <div class="form-group row has-warning">
   <label for="inputHorizontalWarning" class="col-sm-2 form-control-label">Email</label>
   <div class="col-sm-10">
-    <input type="email" class="form-control form-control-warning" id="inputHorizontalWarning" placeholder="name@example.com">
+    <input type="email" class="form-control form-control-icon" id="inputHorizontalWarning" placeholder="name@example.com">
     <div class="form-control-feedback">Check the formatting of that and try again.</div>
     <small class="form-text text-muted">Example help text that remains unchanged.</small>
   </div>
@@ -808,8 +809,50 @@ Also a slightly more horizontal layout.
 <div class="form-group row has-danger">
   <label for="inputHorizontalDnger" class="col-sm-2 form-control-label">Email</label>
   <div class="col-sm-10">
-    <input type="email" class="form-control form-control-danger" id="inputHorizontalDnger" placeholder="name@example.com">
+    <input type="email" class="form-control form-control-icon" id="inputHorizontalDnger" placeholder="name@example.com">
     <div class="form-control-feedback">Sorry, that username's taken. Try another?</div>
+    <small class="form-text text-muted">Example help text that remains unchanged.</small>
+  </div>
+</div>
+{% endexample %}
+
+Validation icons can be added optionally.
+
+{% example html %}
+<div class="form-group row has-success">
+  <label for="inputOptSuccessY" class="col-sm-2 form-control-label">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control form-control-icon" id="inputOptSuccessY" placeholder="name@example.com">
+    <div class="form-control-feedback">Success! You've done it.</div>
+    <small class="form-text text-muted">Example help text that remains unchanged.</small>
+  </div>
+</div>
+<div class="form-group row has-success">
+  <label for="inputOptSuccessN" class="col-sm-2 form-control-label">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control" id="inputOptSuccessN" placeholder="name@example.com">
+    <div class="form-control-feedback">Success! You've done it.</div>
+    <small class="form-text text-muted">Example help text that remains unchanged.</small>
+  </div>
+</div>
+{% endexample %}
+
+Validation icons will also scale with the component size.
+
+{% example html %}
+<div class="form-group row has-success">
+  <label for="inputSizeSuccessSm" class="col-sm-2 form-control-label">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control form-control-sm form-control-icon" id="inputSizeSuccessSm" placeholder="name@example.com">
+    <div class="form-control-feedback">Success! You've done it.</div>
+    <small class="form-text text-muted">Example help text that remains unchanged.</small>
+  </div>
+</div>
+<div class="form-group row has-success">
+  <label for="inputSizeSuccessLg" class="col-sm-2 form-control-label">Email</label>
+  <div class="col-sm-10">
+    <input type="email" class="form-control form-control-lg form-control-icon" id="inputSizeSuccessLg" placeholder="name@example.com">
+    <div class="form-control-feedback">Success! You've done it.</div>
     <small class="form-text text-muted">Example help text that remains unchanged.</small>
   </div>
 </div>

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -171,7 +171,7 @@
         .input-group-#{$size} > .form-control,
         .input-group-#{$size} > .input-group-addon,
         .input-group-#{$size} > .input-group-btn > .btn {
-            @extend .form-control-#{$size};
+            @extend %form-control-#{$size};
         }
         .input-group-#{$size} > .input-group-addon,
         .input-group-#{$size} > .input-group-btn > .btn {

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -125,11 +125,15 @@ textarea.form-control {
         $sz-input-height:  (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
         $sz-select-height: calc(#{$sz-input-height} + #{($input-border-width * 2)});
 
-        .form-control-#{$size} {
+        %form-control-#{$size} {
             height: $sz-select-height;
             padding: $sz-padding-y ($sz-padding-x / 2);
             font-size: $sz-font-size;
             @include border-radius($sz-border-radius);
+        }
+
+        .form-control-#{$size} {
+            @extend %form-control-#{$size};
         }
 
         .form-control-label-#{$size},
@@ -220,9 +224,7 @@ textarea.form-control {
     margin-top: $form-feedback-margin-top;
 }
 
-.form-control-success,
-.form-control-warning,
-.form-control-danger {
+.form-control-icon {
     padding-right: ($input-padding-x * 3);
     background-repeat: no-repeat;
     background-position: center right ($input-height / 4);
@@ -234,7 +236,7 @@ textarea.form-control {
     .has-success {
         @include form-control-validation("success");
 
-        .form-control-success {
+        .form-control-icon {
             background-image: $icon-success;
         }
     }
@@ -243,7 +245,7 @@ textarea.form-control {
     .has-warning {
         @include form-control-validation("warning");
 
-        .form-control-warning {
+        .form-control-icon {
             background-image: $icon-warning;
         }
     }
@@ -252,8 +254,26 @@ textarea.form-control {
     .has-danger {
         @include form-control-validation("danger");
 
-        .form-control-danger {
+        .form-control-icon {
             background-image: $icon-danger;
+        }
+    }
+}
+
+@if $enable-sizing {
+    @each $size, $dims in $component-sizes {
+        $sz-font-size:     map-get($dims, "font-size");
+        $sz-padding-y:     map-get($dims, "padding-y") - ($input-line-height-delta * $sz-font-size / 2);
+        $sz-padding-x:     map-get($dims, "padding-x");
+        $sz-input-height:  (($sz-font-size * $input-line-height) + ($sz-padding-y * 2));
+
+        .form-control-#{$size},
+        .input-group-#{$size} > .form-control {
+            &.form-control-icon {
+                padding-right: ($sz-padding-x * 3);
+                background-position: center right ($sz-input-height / 4);
+                background-size: ($sz-input-height / 2) ($sz-input-height / 2);
+            }
         }
     }
 }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1321,15 +1321,15 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Form validation</h3>
 <div class="form-group has-success">
   <label class="form-control-label" for="inputSuccess1">Input with success</label>
-  <input type="text" class="form-control form-control-success" id="inputSuccess1">
+  <input type="text" class="form-control form-control-icon" id="inputSuccess1">
 </div>
 <div class="form-group has-warning">
   <label class="form-control-label" for="inputWarning1">Input with warning</label>
-  <input type="text" class="form-control form-control-warning" id="inputWarning1">
+  <input type="text" class="form-control form-control-icon" id="inputWarning1">
 </div>
 <div class="form-group has-danger">
   <label class="form-control-label" for="inputDanger1">Input with danger</label>
-  <input type="text" class="form-control form-control-danger" id="inputDanger1">
+  <input type="text" class="form-control form-control-icon" id="inputDanger1">
 </div>
 
 <div class="form-check has-success">


### PR DESCRIPTION
Consolidate the class name for the validation icons since there is only one per validation state.  New class name is `.form-control-icon`.

As before, use of the class is optional.  This has been added to docs along with examples.

Added ability of the icons to scale based component size, and added doc example as well.  For example, using `.form-control-lg` will result in a larger icon with increased spacing.

Switched the Sass to use a placeholder for extending  the `.form-control-{size}` rules.  This allows us to add the icon sizing based on the `.form-control` size without adding unneeded rules when extending for the Input groups.