### PR TITLE
v3 - extend print display utils

### DIFF
--- a/docs/layout/responsive-utilities.md
+++ b/docs/layout/responsive-utilities.md
@@ -14,7 +14,7 @@ Try to use these on a limited basis and avoid creating entirely different versio
 * ToC goes here
 {:toc}
 
-##  Available classes
+##  Available Classes
 
 * The `.hide-*-up` classes hide the element when the viewport is at the given breakpoint or wider. For example, `.hide-md-up` hides an element on medium, large, and extra-large viewports.
 * The `.hide-*-down` classes hide the element when the viewport is at the given breakpoint or smaller. For example, `.hide-md-down` hides an element on extra-small, small, and medium viewports.
@@ -134,30 +134,34 @@ Try to use these on a limited basis and avoid creating entirely different versio
   </table>
 </div>
 
-<h2 id="responsive-utilities-print">Print classes</h2>
-<p>Similar to the regular responsive classes, use these for toggling content for print.</p>
+## Print Classes
+
+Similar to the regular responsive classes, use these for toggling content for print.
+
+These utilities only affect the `display` property.  You will need to take into account any other CSS properties, such as `visibility`, that might cause issues for the print layout.
+
 <div class="table-responsive">
   <table class="table table-bordered responsive-utilities">
     <thead>
       <tr>
         <th>Class</th>
-        <th>Browser</th>
+        <th>Screen</th>
         <th>Print</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th><code>.print-show-block</code></th>
+        <th><code>.print-only-block</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
       </tr>
       <tr>
-        <th><code>.print-show-inline</code></th>
+        <th><code>.print-only-inline</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
       </tr>
       <tr>
-        <th><code>.print-show-inline-block</code></th>
+        <th><code>.print-only-inline-block</code></th>
         <td class="is-hidden">Hidden</td>
         <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
       </tr>
@@ -166,11 +170,26 @@ Try to use these on a limited basis and avoid creating entirely different versio
         <td class="is-visible">Visible</td>
         <td class="is-hidden">Hidden</td>
       </tr>
+      <tr>
+        <th><code>.print-show-block</code></th>
+        <td>Any</td>
+        <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
+      </tr>
+      <tr>
+        <th><code>.print-show-inline</code></th>
+        <td>Any</td>
+        <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
+      </tr>
+      <tr>
+        <th><code>.print-show-inline-block</code></th>
+        <td>Any</td>
+        <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
+      </tr>
     </tbody>
   </table>
 </div>
 
-## Test cases
+## Test Cases
 
 Resize your browser or load on different devices to test the responsive utility classes.
 

--- a/scss/utilities/_visibility.scss
+++ b/scss/utilities/_visibility.scss
@@ -26,20 +26,36 @@
 // Print utilities
 // Media queries are placed on the inside to be mixin-friendly.
 .print-show-block {
+    @media print {
+        display: block !important;
+    }
+}
+.print-show-inline {
+    @media print {
+        display: inline !important;
+    }
+}
+.print-show-inline-block {
+    @media print {
+        display: inline-block !important;
+    }
+}
+
+.print-only-block {
     display: none !important;
 
     @media print {
         display: block !important;
     }
 }
-.print-show-inline {
+.print-only-inline {
     display: none !important;
 
     @media print {
         display: inline !important;
     }
 }
-.print-show-inline-block {
+.print-only-inline-block {
     display: none !important;
 
     @media print {


### PR DESCRIPTION
Alter and extend the print utility classes:
- `.print-only-*` takes the place of the previous `.print-show-*` utils where content is hidden in the screen (browser) view
- `.print-show-*` will no longer hide content by default for the screen view, and will override the `display` property for the the print view regardless of how it is currently on the screen.

As now noted in the docs, these utils only adjust the `display` property.  Other properties might affect the layout of the print view.
