### PR TITLE
v3 - Rework spacer vars

### DIFF
--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -269,7 +269,7 @@ h4 {
 .cf-content > table:not(.table) {
     width: 100%;
     max-width: 100%;
-    margin-bottom: $spacer;
+    margin-bottom: 1rem;
     border: $table-border-width solid $table-border-color;
 
     th,

--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -36,7 +36,7 @@ You can find and customize these variables for key global options in our `_setti
 
 | Variable                    | Values                             | Description                                                                                      |
 | --------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------|
-| `$spacer`                   | `1rem` (default), or any value > 0 | Specifies the default spacer value for our spacer utilities.                                     |
+| `$spacer`                   | `1rem` (default), or any value > 0 | Specifies the default spacer value used to programmatically generate the [Spacing utilities]({{ site.baseurl }}/utilities/spacing/). |
 | `$enable-rounded`           | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                 |
 | `$enable-shadows`           | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                    |
 | `$enable-transitions`       | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                          |

--- a/docs/utilities/spacing.md
+++ b/docs/utilities/spacing.md
@@ -28,11 +28,11 @@ Where *sides* is one of:
 Where *size* is one of:
 
 * `0` - for classes that eliminate the `margin` or `padding` by setting it to `0`
-* `0_25` - for classes that set the property to `$spacer-x * 0.25` or `$spacer-y * 0.25`
-* `0_5` - for classes that set the property to `$spacer-x * 0.5` or `$spacer-y * 0.5`
-* `1` - for classes that set the property to `$spacer-x` or `$spacer-y`
-* `1_5` - for classes that set the property to `$spacer-x * 1.5` or `$spacer-y * 1.5`
-* `2` - for classes that set the property to `$spacer-x * 2` or `$spacer-y * 2`
+* `0_25` - for classes that set the property to `$spacer * 0.25`
+* `0_5` - for classes that set the property to `$spacer * 0.5`
+* `1` - for classes that set the property to `$spacer`
+* `1_5` - for classes that set the property to `$spacer * 1.5`
+* `2` - for classes that set the property to `$spacer * 2`
 
 (You can add more sizes by adding entries to the `$spacers` Sass map variable.)
 
@@ -44,20 +44,20 @@ Here are some representative examples of these classes:
 }
 
 .ml-1 {
-  margin-left: $spacer-x !important;
+  margin-left: $spacer !important;
 }
 
 .mt-md-1 {
-  margin-top: $spacer-y !important;
+  margin-top: $spacer !important;
 }
 
 .px-1_5 {
-  padding-left: ($spacer-x * 1.5) !important;
-  padding-right: ($spacer-x * 1.5) !important;
+  padding-left: ($spacer * 1.5) !important;
+  padding-right: ($spacer * 1.5) !important;
 }
 
 .p-2 {
-  padding: ($spacer-y * 2) ($spacer-x * 2) !important;
+  padding: ($spacer * 2) ($spacer * 2) !important;
 }
 {% endhighlight %}
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -154,32 +154,30 @@ $inverse-color: (
 // =====
 // Control the default spacing of most elements by modifying these variables.
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
     "0": (
         x: 0,
         y: 0
     ),
     "0_25": (
-        x: ($spacer-x * .25),
-        y: ($spacer-y * .25)
+        x: ($spacer * .25),
+        y: ($spacer * .25)
     ),
     "0_5": (
-        x: ($spacer-x * .5),
-        y: ($spacer-y * .5)
+        x: ($spacer * .5),
+        y: ($spacer * .5)
     ),
     "1": (
-        x: $spacer-x,
-        y: $spacer-y
+        x: $spacer,
+        y: $spacer
     ),
     "1_5": (
-        x: ($spacer-x * 1.5),
-        y: ($spacer-y * 1.5)
+        x: ($spacer * 1.5),
+        y: ($spacer * 1.5)
     ),
     "2": (
-        x: ($spacer-x * 2),
-        y: ($spacer-y * 2)
+        x: ($spacer * 2),
+        y: ($spacer * 2)
     )
 ) !default;
 
@@ -300,6 +298,7 @@ $abbr-border-color: $uibase-400 !default;
 $mark-padding-x:    .25rem !default;
 $mark-bg:           #ff0 !default;
 
+$hr-spacer-y:       1rem !default;
 $hr-border-color:   rgba(0,0,0,.1) !default;
 $hr-border-width:   $border-width !default;
 
@@ -422,6 +421,7 @@ $pre-color:                 $uibase-700 !default;
 
 // Figures
 // =====
+$figure-spacer-y:           .5rem !default;
 $figure-caption-font-size:  87.5% !default;
 $figure-caption-color:      $uibase-500 !default;
 
@@ -595,7 +595,8 @@ $custom-file-text: (
 
 // Progress bars
 // =====
-$progress-height:           $spacer-y !default;
+$progress-height:           1rem !default;
+$progress-spacer-y:         1rem !default;
 $progress-bg:               $uibase-50 !default;
 $progress-border-radius:    $border-radius !default;
 $progress-box-shadow:       inset 0 .1rem .1rem rgba(0,0,0,.1) !default;
@@ -627,6 +628,7 @@ $list-group-item-padding-x:         1rem !default;
 
 // Breadcrumbs
 // =====
+$breadcrumb-spacer-y:           1rem !default;
 $breadcrumb-padding-y:          .75rem !default;
 $breadcrumb-padding-x:          1rem !default;
 $breadcrumb-item-padding:       .5rem !default;
@@ -679,7 +681,7 @@ $dropdown-border-width:         $border-width !default;
 $dropdown-border-radius:        $border-radius !default;
 $dropdown-divider-width:        $border-width !default;
 $dropdown-divider-color:        $uibase-200 !default;
-$dropdown-divider-spacer:       ($spacer-y / 2) !default;
+$dropdown-divider-spacer:       ($spacer / 2) !default;
 $dropdown-box-shadow:           0 .2rem .3rem rgba(0,0,0,.175) !default;
 
 // Border radius where menu/submenu aligns or 'attaches' to control item.
@@ -807,7 +809,7 @@ $badge-outline-link-hover-color: $white !default;
 // =====
 $alert-padding-x:           1rem !default;
 $alert-padding-y:           1rem !default;
-$alert-margin-bottom:       $spacer-y !default;
+$alert-margin-bottom:       $spacer !default;
 $alert-border-radius:       $border-radius !default;
 $alert-link-font-weight:    $font-weight-bold !default;
 $alert-border-width:        $border-width !default;

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -1,6 +1,6 @@
 .breadcrumb {
     padding: $breadcrumb-padding-y $breadcrumb-padding-x;
-    margin-bottom: $spacer-y;
+    margin-bottom: $breadcrumb-spacer-y;
     list-style: none;
     background-color: $breadcrumb-bg;
     @include border-radius($breadcrumb-border-radius);

--- a/scss/component/_progress.scss
+++ b/scss/component/_progress.scss
@@ -3,7 +3,7 @@
     display: block;
     width: 100%;
     height: $progress-height;
-    margin-bottom: $spacer-y;
+    margin-bottom: $progress-spacer-y;
     // Force rounded corners by use of cropping
     overflow: hidden;
     // Set overall background
@@ -53,7 +53,7 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
 // IE9
 .progress-bar {
     display: inline-block;
-    height: $spacer-y;
+    height: $progress-height;
     text-indent: -999rem; // Simulate hiding of value as in native `<progress>`
     vertical-align: top;
     background-color: $progress-bar-bg;
@@ -62,20 +62,20 @@ base::-moz-progress-bar, // Absurd-but-syntactically-valid selector to make thes
 // Striped
 .progress-striped[value]::-webkit-progress-value {
     @include gradient-striped();
-    background-size: $spacer-y  $spacer-y;
+    background-size: $progress-height $progress-height;
 }
 .progress-striped[value]::-moz-progress-bar {
     @include gradient-striped();
-    background-size: $spacer-y  $spacer-y;
+    background-size: $progress-height $progress-height;
 }
 .progress-striped[value]::-ms-fill {
     @include gradient-striped();
-    background-size: $spacer-y  $spacer-y;
+    background-size: $progress-height $progress-height;
 }
 // IE9
 .progress-striped .progress-bar {
     @include gradient-striped();
-    background-size: $spacer-y  $spacer-y;
+    background-size: $progress-height $progress-height;
 }
 
 // Context variations

--- a/scss/core/_images.scss
+++ b/scss/core/_images.scss
@@ -27,7 +27,7 @@
     display: inline-block;
 }
 .figure-img {
-    margin-bottom: ($spacer-y / 2);
+    margin-bottom: $figure-spacer-y;
     line-height: 1;
 }
 .figure-caption {

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -31,8 +31,8 @@ h6, .h6 { font-size: $font-size-h6; }
 // Horizontal Rule
 
 hr {
-    margin-top: $spacer-y;
-    margin-bottom: $spacer-y;
+    margin-top: $hr-spacer-y;
+    margin-bottom: $hr-spacer-y;
     border: 0;
     border-top: $hr-border-width solid $hr-border-color;
 }


### PR DESCRIPTION
- Simplify the user of `$spacer` var in the Sass, but extend with new variables where it seemed useful.
- Update docs with revised var names.
- Force a dimension for doc examples.
- Fix incorrect progress bar height setting.