### PR TITLE
v3 - Use consistent header body footer content sections

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -211,7 +211,7 @@
     min-width: 250px;
     max-width: 500px;
 }
-.container-viewport .tooltip .tooltip-inner {
+.container-viewport .tooltip .tooltip-body {
     min-width: 250px;
     max-width: 500px;
     min-height: 100px;

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -35,14 +35,14 @@ Below is an example of a basic card with mixed content and a fixed width. Cards 
 
 Cards support a wide variety of content, including images, text, list groups, links, and more. Below are examples of what's supported.
 
-### Blocks
+### Body
 
 A basic building block of a card is the `.card-body`. Use it whenever you need a padded section within a card.
 
 {% example html %}
 <div class="card">
   <div class="card-body">
-    This is some text within a card block.
+    This is some text within a card body.
   </div>
 </div>
 {% endexample %}

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -16,14 +16,14 @@ Cards have some basic support for both a `block` style layout, along with both t
 
 ## Example
 
-Cards require a small amount of markup and classes to provide you with as much control as possible. These classes and markup are flexible though and can typically be remixed and extended with ease. For example, if your card has no flush content like images, feel free to put the `.card-block` class on the `.card` element to consolidate your markup.
+Cards require a small amount of markup and classes to provide you with as much control as possible. These classes and markup are flexible though and can typically be remixed and extended with ease. For example, if your card has no flush content like images, feel free to put the `.card-body` class on the `.card` element to consolidate your markup.
 
 Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start, so they'll naturally fill the full width of its parent element.
 
 {% example html %}
 <div class="card" style="width: 20rem;">
   <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -37,11 +37,11 @@ Cards support a wide variety of content, including images, text, list groups, li
 
 ### Blocks
 
-A basic building block of a card is the `.card-block`. Use it whenever you need a padded section within a card.
+A basic building block of a card is the `.card-body`. Use it whenever you need a padded section within a card.
 
 {% example html %}
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     This is some text within a card block.
   </div>
 </div>
@@ -49,11 +49,11 @@ A basic building block of a card is the `.card-block`. Use it whenever you need 
 
 ### Titles
 
-Card titles and subtitles are used by adding `.card-title` or `.card-subtitle` to a `<h*>` tag. If the `.card-title` and the `.card-subtitle` items are placed in a `.card-block` item, the card title and subtitle are aligned nicely.
+Card titles and subtitles are used by adding `.card-title` or `.card-subtitle` to a `<h*>` tag. If the `.card-title` and the `.card-subtitle` items are placed in a `.card-body` item, the card title and subtitle are aligned nicely.
 
 {% example html %}
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <h5 class="h6 card-subtitle text-muted">Support card subtitle</h5>
   </div>
@@ -68,7 +68,7 @@ With `.card-text`, text can be added to the card. Text within `.card-text` can a
 
 {% example html %}
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
     <p class="card-text">Another portion of example text that will have the bottom margin removed.</p>
   </div>
@@ -81,7 +81,7 @@ Links can placed next to each other with some spacing by adding `.card-link` to 
 
 {% example html %}
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
     <a href="#" class="card-link">Card link</a>
     <a href="#" class="card-link">Another link</a>
@@ -96,7 +96,7 @@ Links can placed next to each other with some spacing by adding `.card-link` to 
 {% example html %}
 <div class="card">
   <img class="card-img-top img-responsive" data-src="holder.js/100px180/?text=Image cap" alt="Card image cap">
-  <div class="card-block">
+  <div class="card-body">
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
   </div>
 </div>
@@ -123,7 +123,7 @@ The multiple content types can be easily combined to create the card you need.
 {% example html %}
 <div class="card" style="width: 20rem;">
   <img class="card-img-top img-responsive" data-src="holder.js/100px180/?text=Image cap" alt="Card image cap">
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
   </div>
@@ -132,7 +132,7 @@ The multiple content types can be easily combined to create the card you need.
     <li class="list-group-item">Dapibus ac facilisis in</li>
     <li class="list-group-item">Vestibulum at eros</li>
   </ul>
-  <div class="card-block">
+  <div class="card-body">
     <a href="#" class="card-link">Card link</a>
     <a href="#" class="card-link">Another link</a>
   </div>
@@ -148,7 +148,7 @@ Add an optional header and/or footer within a card.
   <div class="card-header">
     Featured
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -161,7 +161,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
 {% example html %}
 <div class="card">
   <h3 class="card-header">Featured</h3>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -174,7 +174,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
   <div class="card-header">
     Quote
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -188,7 +188,7 @@ Card headers can be styled by adding `.card-header` to `<h*>` elements.
   <div class="card-header">
     Featured
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -212,14 +212,14 @@ Using the grid, wrap cards in columns and rows as needed.
 {% example html %}
 <div class="row">
   <div class="col-sm-6">
-    <div class="card card-block">
+    <div class="card card-body">
       <h3 class="card-title">Special title treatment</h3>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
     </div>
   </div>
   <div class="col-sm-6">
-    <div class="card card-block">
+    <div class="card card-body">
       <h3 class="card-title">Special title treatment</h3>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -233,7 +233,7 @@ Using the grid, wrap cards in columns and rows as needed.
 Use custom CSS in your stylesheets or as inline styles to set a width.
 
 {% example html %}
-<div class="card card-block" style="width: 20rem;">
+<div class="card card-body" style="width: 20rem;">
   <h3 class="card-title">Special title treatment</h3>
   <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
   <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -245,19 +245,19 @@ Use custom CSS in your stylesheets or as inline styles to set a width.
 You can quickly change the text alignment of any card---in its entirety or specific parts---with our [text align classes]({{ site.baseurl }}/utilities/typography/#text-alignment).
 
 {% example html %}
-<div class="card card-block">
+<div class="card card-body">
   <h4 class="card-title">Special title treatment</h4>
   <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
   <a href="#" class="btn btn-primary">Go somewhere</a>
 </div>
 
-<div class="card card-block text-center">
+<div class="card card-body text-center">
   <h4 class="card-title">Special title treatment</h4>
   <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
   <a href="#" class="btn btn-primary">Go somewhere</a>
 </div>
 
-<div class="card card-block text-right">
+<div class="card card-body text-right">
   <h4 class="card-title">Special title treatment</h4>
   <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
   <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -283,7 +283,7 @@ Add navigation items within a card's header (or block) with Figuration's [naviga
       </li>
     </ul>
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -306,7 +306,7 @@ Add navigation items within a card's header (or block) with Figuration's [naviga
       </li>
     </ul>
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -325,14 +325,14 @@ Similar to headers and footers, cards include top and bottom image caps.
 {% example html %}
 <div class="card">
   <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
   </div>
 </div>
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -368,7 +368,7 @@ You can also use `.card-inverse` with the [contextual backgrounds variants](#bac
 
 {% example html %}
 <div class="card card-inverse" style="background-color: #333; border-color: #333;">
-  <div class="card-block">
+  <div class="card-body">
     <h3 class="card-title">Special title treatment</h3>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -379,7 +379,7 @@ You can also use `.card-inverse` with the [contextual backgrounds variants](#bac
   <div class="card-header">
     Inverse card
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h3 class="card-title">Special title treatment</h3>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
   </div>
@@ -402,7 +402,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
 
 {% example html %}
 <div class="card card-inverse card-primary text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -410,7 +410,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
   </div>
 </div>
 <div class="card card-inverse card-success text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -418,7 +418,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
   </div>
 </div>
 <div class="card card-inverse card-info text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -426,7 +426,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
   </div>
 </div>
 <div class="card card-inverse card-warning text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -434,7 +434,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
   </div>
 </div>
 <div class="card card-inverse card-danger text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -449,7 +449,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
 
 {% example html %}
 <div class="card card-outline-primary text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -457,7 +457,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
   </div>
 </div>
 <div class="card card-outline-secondary text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -465,7 +465,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
   </div>
 </div>
 <div class="card card-outline-success text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -473,7 +473,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
   </div>
 </div>
 <div class="card card-outline-info text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -481,7 +481,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
   </div>
 </div>
 <div class="card card-outline-warning text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -489,7 +489,7 @@ In need of a colored card, but not the hefty background colors they bring? Repla
   </div>
 </div>
 <div class="card card-outline-danger text-center">
-  <div class="card-block">
+  <div class="card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -505,7 +505,7 @@ Recolor the header and footer sections of your cards by using the background con
 {% example html %}
 <div class="card">
   <h3 class="card-header card-inverse bg-primary">Featured</h3>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -532,7 +532,7 @@ Groups have support for both a `table` style layout, along with both the opt-in 
 <div class="card-group">
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -540,7 +540,7 @@ Groups have support for both a `table` style layout, along with both the opt-in 
   </div>
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -548,7 +548,7 @@ Groups have support for both a `table` style layout, along with both the opt-in 
   </div>
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -563,7 +563,7 @@ When in flexbox mode, or with `.card-group-flex` and `.card-flex`, using card gr
 <div class="card-group card-group-flex">
   <div class="card card-flex">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
@@ -573,7 +573,7 @@ When in flexbox mode, or with `.card-group-flex` and `.card-flex`, using card gr
   </div>
   <div class="card card-flex">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
     </div>
@@ -583,7 +583,7 @@ When in flexbox mode, or with `.card-group-flex` and `.card-flex`, using card gr
   </div>
   <div class="card card-flex">
     <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
     </div>
@@ -607,7 +607,7 @@ If you wish to have a card deck that matches the grid layout, you will need to u
   <div class="card-deck">
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -615,7 +615,7 @@ If you wish to have a card deck that matches the grid layout, you will need to u
     </div>
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -623,7 +623,7 @@ If you wish to have a card deck that matches the grid layout, you will need to u
     </div>
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -640,7 +640,7 @@ When in flexbox mode, or with `.card-deck-flex` and `.card-flex`, using card dec
   <div class="card-deck card-deck-flex">
     <div class="card card-flex">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
       </div>
@@ -650,7 +650,7 @@ When in flexbox mode, or with `.card-deck-flex` and `.card-flex`, using card dec
     </div>
     <div class="card card-flex">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
       </div>
@@ -660,7 +660,7 @@ When in flexbox mode, or with `.card-deck-flex` and `.card-flex`, using card dec
     </div>
     <div class="card card-flex">
       <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
       </div>
@@ -682,12 +682,12 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
 <div class="card-columns">
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px160/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title that wraps to a new line</h4>
       <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <div class="card card-block">
+  <div class="card card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>
@@ -699,13 +699,13 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
   </div>
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px160/" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>
-  <div class="card card-block card-inverse card-primary text-center">
+  <div class="card card-body card-inverse card-primary text-center">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
       <footer>
@@ -715,7 +715,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
       </footer>
     </blockquote>
   </div>
-  <div class="card card-block text-center">
+  <div class="card card-body text-center">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -723,7 +723,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
   <div class="card">
     <img class="card-img img-responsive" data-src="holder.js/100px260/" alt="Card image">
   </div>
-  <div class="card card-block text-right">
+  <div class="card card-body text-right">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>
@@ -733,7 +733,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
       </footer>
     </blockquote>
   </div>
-  <div class="card card-block">
+  <div class="card card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>

--- a/docs/get-started/download.md
+++ b/docs/get-started/download.md
@@ -14,12 +14,12 @@ group: get-started
 
 ## Quick Download
 
-<div data-cfw="equalize" data-cfw-equalize-target=".card-block">
+<div data-cfw="equalize" data-cfw-equalize-target=".card-body">
   <div class="row mt-2" data-cfw="equalize" data-cfw-equalize-target=".card-footer">
     <div class="col-sm-6">
       <div class="card card-download">
         <h3 class="h4 card-header card-inverse" style="background-color: #246;">Compiled</h3>
-        <div class="card-block">
+        <div class="card-body">
 {% markdown %}
 Download just the compiled and minified CSS and JavaScript. Doesn't include any documentation or original source files.
 {% endmarkdown %}
@@ -32,7 +32,7 @@ Download just the compiled and minified CSS and JavaScript. Doesn't include any 
     <div class="col-sm-6">
       <div class="card card-download">
         <h3 class="h4 card-header card-inverse" style="background-color: #246;">Source Files</h3>
-        <div class="card-block">
+        <div class="card-body">
 {% markdown %}
 Download everything: source Sass, JavaScript, and documentation files. **Requires a Sass compiler, [Autoprefixer](https://github.com/postcss/autoprefixer), [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes), and [some setup]({{ site.baseurl }}/get-started/build-tools/#tooling-setup).**
 {% endmarkdown %}

--- a/docs/widgets/accordion.md
+++ b/docs/widgets/accordion.md
@@ -57,7 +57,7 @@ Here some cards are used to add a bit of layout.
             <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card0">Collapse Toggle #1</a></h4>
         </div>
         <div class="collapse" data-cfw-collapse-target="card0">
-            <div class="card-block">
+            <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>
         </div>
@@ -67,7 +67,7 @@ Here some cards are used to add a bit of layout.
             <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card1">Collapse Toggle #2</a></h4>
         </div>
         <div class="collapse" data-cfw-collapse-target="card1">
-            <div class="card-block">
+            <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>
         </div>
@@ -77,7 +77,7 @@ Here some cards are used to add a bit of layout.
             <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card2">Collapse Toggle #3</a></h4>
         </div>
         <div class="collapse" data-cfw-collapse-target="card2">
-            <div class="card-block">
+            <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>
         </div>

--- a/docs/widgets/equalize.md
+++ b/docs/widgets/equalize.md
@@ -22,19 +22,19 @@ Create equal height containers using a few data attributes. Apply the `data-cfw=
 <div class="cf-example">
     <div class="row" data-cfw="equalize" data-cfw-equalize-target="foo">
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
+            <div class="card card-body" data-cfw-equalize-group="foo">
                 <h4>Panel 1</h4>
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ac nisi sem. Maecenas elementum a lectus quis fermentum.</p>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
+            <div class="card card-body" data-cfw-equalize-group="foo">
                 <h4>Panel 2</h4>
                 <p>Etiam nec pulvinar quam. Duis aliquam ut turpis et vulputate. Proin malesuada sem purus, in hendrerit ex dapibus sed. Cras orci quam, vestibulum eget purus at, ultricies ultricies libero! Morbi fringilla accumsan purus, eu sodales enim suscipit nec.</p>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
+            <div class="card card-body" data-cfw-equalize-group="foo">
                 <h4>Panel 3</h4>
                 <p>Nam porta malesuada mi, quis hendrerit purus.</p>
                 <img src="{{ site.baseurl }}/assets/img/test.gif" alt="test pattern" class="img-responsive" />
@@ -45,17 +45,17 @@ Create equal height containers using a few data attributes. Apply the `data-cfw=
 {% highlight html %}
 <div class="row" data-cfw="equalize" data-cfw-equalize-target="foo">
     <div class="col-md-4">
-        <div class="card card-block" data-cfw-equalize-group="foo">
+        <div class="card card-body" data-cfw-equalize-group="foo">
             ...
         </div>
     </div>
     <div class="col-md-4">
-        <div class="card card-block" data-cfw-equalize-group="foo">
+        <div class="card card-body" data-cfw-equalize-group="foo">
             ...
         </div>
     </div>
     <div class="col-md-4">
-        <div class="card card-block" data-cfw-equalize-group="foo">
+        <div class="card card-body" data-cfw-equalize-group="foo">
             ...
         </div>
     </div>
@@ -70,23 +70,23 @@ Creating nested Equalize behaviour is as simple as creating another Equalize set
     <div data-cfw="equalize" data-cfw-equalize-target="foo">
         <div class="row" data-cfw="equalize" data-cfw-equalize-target="bar">
             <div class="col-md-4">
-                <div class="card card-block" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="foo">
                     <h4>Panel 1</h4>
-                    <div class="card card-block" data-cfw-equalize-group="bar">one</div>
+                    <div class="card card-body" data-cfw-equalize-group="bar">one</div>
                     one<br />one
                 </div>
             </div>
             <div class="col-md-4">
-                <div class="card card-block" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="foo">
                     <h4>Panel 2</h4>
-                    <div class="card card-block" data-cfw-equalize-group="bar">two<br />two</div>
+                    <div class="card card-body" data-cfw-equalize-group="bar">two<br />two</div>
                     two
                 </div>
             </div>
             <div class="col-md-4">
-                <div class="card card-block" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="foo">
                     <h4>Panel 3</h4>
-                    <div class="card card-block" data-cfw-equalize-group="bar">three<br />three<br />three</div>
+                    <div class="card card-body" data-cfw-equalize-group="bar">three<br />three<br />three</div>
                 </div>
             </div>
         </div>
@@ -96,18 +96,18 @@ Creating nested Equalize behaviour is as simple as creating another Equalize set
 <div data-cfw="equalize" data-cfw-equalize-target="foo">
     <div class="row" data-cfw="equalize" data-cfw-equalize-target="bar">
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
-                <div class="card card-block" data-cfw-equalize-group="bar">...</div>
+            <div class="card card-body" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="bar">...</div>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
-                <div class="card card-block" data-cfw-equalize-group="bar">...</div>
+            <div class="card card-body" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="bar">...</div>
             </div>
         </div>
         <div class="col-md-4">
-            <div class="card card-block" data-cfw-equalize-group="foo">
-                <div class="card card-block" data-cfw-equalize-group="bar">...</div>
+            <div class="card card-body" data-cfw-equalize-group="foo">
+                <div class="card card-body" data-cfw-equalize-group="bar">...</div>
             </div>
         </div>
     </div>
@@ -121,30 +121,30 @@ When using `row` mode, Equalize looks for items at the same starting top offset 
 {% example html %}
 <div class="row" data-cfw="equalize" data-cfw-equalize-target=".card" data-cfw-equalize-row="true">
     <div class="col-md-4 col-lg-3">
-        <div class="card card-block">
+        <div class="card card-body">
             <h4>Panel 1-1</h4>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
-        <div class="card card-block">
+        <div class="card card-body">
             <h4>Panel 1-2</h4>
             <p>row one</p>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
-        <div class="card card-block">
+        <div class="card card-body">
             <h4>Panel 1-3</h4>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
-        <div class="card card-block">
+        <div class="card card-body">
             <h4>Panel 2-1</h4>
             <p>row two</p>
             <p>row two</p>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
-        <div class="card card-block">
+        <div class="card card-body">
             <h4>Panel 2-2</h4>
         </div>
     </div>

--- a/docs/widgets/equalize.md
+++ b/docs/widgets/equalize.md
@@ -23,19 +23,19 @@ Create equal height containers using a few data attributes. Apply the `data-cfw=
     <div class="row" data-cfw="equalize" data-cfw-equalize-target="foo">
         <div class="col-md-4">
             <div class="card card-body" data-cfw-equalize-group="foo">
-                <h4>Panel 1</h4>
+                <h4>Card 1</h4>
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ac nisi sem. Maecenas elementum a lectus quis fermentum.</p>
             </div>
         </div>
         <div class="col-md-4">
             <div class="card card-body" data-cfw-equalize-group="foo">
-                <h4>Panel 2</h4>
+                <h4>Card 2</h4>
                 <p>Etiam nec pulvinar quam. Duis aliquam ut turpis et vulputate. Proin malesuada sem purus, in hendrerit ex dapibus sed. Cras orci quam, vestibulum eget purus at, ultricies ultricies libero! Morbi fringilla accumsan purus, eu sodales enim suscipit nec.</p>
             </div>
         </div>
         <div class="col-md-4">
             <div class="card card-body" data-cfw-equalize-group="foo">
-                <h4>Panel 3</h4>
+                <h4>Card 3</h4>
                 <p>Nam porta malesuada mi, quis hendrerit purus.</p>
                 <img src="{{ site.baseurl }}/assets/img/test.gif" alt="test pattern" class="img-responsive" />
             </div>
@@ -71,21 +71,21 @@ Creating nested Equalize behaviour is as simple as creating another Equalize set
         <div class="row" data-cfw="equalize" data-cfw-equalize-target="bar">
             <div class="col-md-4">
                 <div class="card card-body" data-cfw-equalize-group="foo">
-                    <h4>Panel 1</h4>
+                    <h4>Card 1</h4>
                     <div class="card card-body" data-cfw-equalize-group="bar">one</div>
                     one<br />one
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card card-body" data-cfw-equalize-group="foo">
-                    <h4>Panel 2</h4>
+                    <h4>Card 2</h4>
                     <div class="card card-body" data-cfw-equalize-group="bar">two<br />two</div>
                     two
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card card-body" data-cfw-equalize-group="foo">
-                    <h4>Panel 3</h4>
+                    <h4>Card 3</h4>
                     <div class="card card-body" data-cfw-equalize-group="bar">three<br />three<br />three</div>
                 </div>
             </div>
@@ -122,30 +122,30 @@ When using `row` mode, Equalize looks for items at the same starting top offset 
 <div class="row" data-cfw="equalize" data-cfw-equalize-target=".card" data-cfw-equalize-row="true">
     <div class="col-md-4 col-lg-3">
         <div class="card card-body">
-            <h4>Panel 1-1</h4>
+            <h4>Card 1-1</h4>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
         <div class="card card-body">
-            <h4>Panel 1-2</h4>
+            <h4>Card 1-2</h4>
             <p>row one</p>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
         <div class="card card-body">
-            <h4>Panel 1-3</h4>
+            <h4>Card 1-3</h4>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
         <div class="card card-body">
-            <h4>Panel 2-1</h4>
+            <h4>Card 2-1</h4>
             <p>row two</p>
             <p>row two</p>
         </div>
     </div>
     <div class="col-md-4 col-lg-3">
         <div class="card card-body">
-            <h4>Panel 2-2</h4>
+            <h4>Card 2-2</h4>
         </div>
     </div>
 </div>

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -40,32 +40,32 @@ Four options are available: top, right, bottom, and left aligned.
 
 <div class="cf-example cf-example-bottom cf-example-popover">
     <div class="popover top">
-        <h3 class="popover-title">Popover top</h3>
-        <div class="popover-content">
+        <h3 class="popover-header">Popover top</h3>
+        <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
         <div class="popover-arrow"></div>
     </div>
 
     <div class="popover right">
-        <h3 class="popover-title">Popover right</h3>
-        <div class="popover-content">
+        <h3 class="popover-header">Popover right</h3>
+        <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
         <div class="popover-arrow"></div>
     </div>
 
     <div class="popover bottom">
-        <h3 class="popover-title">Popover bottom</h3>
-        <div class="popover-content">
+        <h3 class="popover-header">Popover bottom</h3>
+        <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
         <div class="popover-arrow"></div>
     </div>
 
     <div class="popover left">
-        <h3 class="popover-title">Popover left</h3>
-        <div class="popover-content">
+        <h3 class="popover-header">Popover left</h3>
+        <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
         <div class="popover-arrow"></div>
@@ -146,8 +146,8 @@ Have a complex content that you would like to show in a popover, or one that is 
 <button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-toggle="#popoverExample0" data-cfw-popover-placement="right">Show Popover</button>
 
 <div class="popover" id="popoverExample0">
-    <h3 class="popover-title">Popover title</h3>
-    <div class="popover-content">
+    <h3 class="popover-header">Popover title</h3>
+    <div class="popover-body">
         <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         <figure class="figure">
           <img src="{{ site.baseurl }}/assets/img/test.gif" class="figure-img img-responsive" alt="Sample image">

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -27,28 +27,28 @@ Four options are available: top, right, bottom, and left aligned.
 
 <div class="cf-example cf-example-bottom cf-example-tooltip">
     <div class="tooltip top" role="tooltip">
-        <div class="tooltip-inner">
+        <div class="tooltip-body">
             Tooltip on the top
         </div>
         <div class="tooltip-arrow"></div>
     </div>
 
     <div class="tooltip right" role="tooltip">
-        <div class="tooltip-inner">
+        <div class="tooltip-body">
             Tooltip on the right
         </div>
         <div class="tooltip-arrow"></div>
     </div>
 
     <div class="tooltip bottom" role="tooltip">
-        <div class="tooltip-inner">
+        <div class="tooltip-body">
             Tooltip on the bottom
         </div>
         <div class="tooltip-arrow"></div>
     </div>
 
     <div class="tooltip left" role="tooltip">
-        <div class="tooltip-inner">
+        <div class="tooltip-body">
             Tooltip on the left
         </div>
         <div class="tooltip-arrow"></div>

--- a/js/popover.js
+++ b/js/popover.js
@@ -31,7 +31,7 @@
         dragtext    : '<span aria-hidden="true">+</span>', // Text for drag handle
         dragsrtext  : 'Drag',       // Screen reader text for drag handle
         dragstep     : 10,          // 'Drag' increment for keyboard
-        template    : '<div class="popover"><h3 class="popover-title"></h3><div class="popover-content"></div><div class="popover-arrow"></div></div>'
+        template    : '<div class="popover"><h3 class="popover-header"></h3><div class="popover-body"></div><div class="popover-arrow"></div></div>'
     });
 
     CFW_Widget_Popover.prototype = $.extend({}, $.fn.CFW_Tooltip.Constructor.prototype);
@@ -49,8 +49,8 @@
 
     CFW_Widget_Popover.prototype.setContent = function() {
         var $tip = this.$target;
-        var $title = $tip.find('.popover-title');
-        var $content = $tip.find('.popover-content');
+        var $title = $tip.find('.popover-header');
+        var $content = $tip.find('.popover-body');
 
         if (!this.dataToggle) {
             var title = this.getTitle();
@@ -69,7 +69,7 @@
             }
         }
 
-        // Use '.popover-title' for labelledby
+        // Use '.popover-header' for labelledby
         if ($title.length) {
             var labelledby = $title.eq(0).CFW_getID('cfw-popover');
             this.$target.attr('aria-labelledby', labelledby);

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -54,7 +54,7 @@
         activate        : false,            // Auto show after init
         unlink          : false,            // If on hide to remove events and attributes from tooltip and trigger
         dispose         : false,            // If on hide to unlink, then remove tooltip from DOM
-        template        : '<div class="tooltip"><div class="tooltip-inner"></div><div class="tooltip-arrow"></div></div>'
+        template        : '<div class="tooltip"><div class="tooltip-body"></div><div class="tooltip-arrow"></div></div>'
     };
 
     CFW_Widget_Tooltip.prototype = {
@@ -147,7 +147,7 @@
 
         setContent : function() {
             var $tip = this.$target;
-            var $inner = $tip.find('.tooltip-inner');
+            var $inner = $tip.find('.tooltip-body');
 
             if (!this.dataToggle) {
                 var title = this.getTitle();

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -892,14 +892,14 @@ $popover-border-color:          $uibase-200 !default;
 $popover-border-radius:         .3125rem !default;
 $popover-box-shadow:            0 .2rem .3rem rgba(0,0,0,.175) !default;
 
-$popover-title-padding-x:       .75rem !default;
-$popover-title-padding-y:       .5rem !default;
-$popover-title-bg:              $uibase-50 !default;
-$popover-title-border-width:    $border-width !default;
-$popover-title-border-color:    $uibase-100 !default;
+$popover-header-padding-x:     .75rem !default;
+$popover-header-padding-y:     .5rem !default;
+$popover-header-bg:            $uibase-50 !default;
+$popover-header-border-width:  $border-width !default;
+$popover-header-border-color:  $uibase-100 !default;
 
-$popover-content-padding-x:     .75rem !default;
-$popover-content-padding-y:     .5rem !default;
+$popover-body-padding-x:       .75rem !default;
+$popover-body-padding-y:       .5rem !default;
 
 // Arrow dimension in pixels to get proper visual layout
 $popover-arrow-width:           10px !default;

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -18,7 +18,7 @@
     }
 }
 
-.card-block {
+.card-body {
     @include clearfix;
     padding: $card-padding-y $card-padding-x;
     @if $enable-flex-full {
@@ -27,7 +27,7 @@
 }
 @if $enable-flex-opt {
     .card-flex {
-        .card-block {
+        .card-body {
             flex: 1 1 auto;
         }
     }

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -92,13 +92,13 @@
     }
 }
 
-.popover-title {
-    padding: $popover-title-padding-y $popover-title-padding-x;
-    padding-right: ($popover-title-padding-x * 2);
+.popover-header {
+    padding: $popover-header-padding-y $popover-header-padding-x;
+    padding-right: ($popover-header-padding-x * 2);
     margin: 0; // reset heading margin
     font-size: $font-size-base;
-    background-color: $popover-title-bg;
-    border-bottom: $popover-title-border-width solid $popover-title-border-color;
+    background-color: $popover-header-bg;
+    border-bottom: $popover-header-border-width solid $popover-header-border-color;
     @include border-radius($popover-border-radius $popover-border-radius 0 0);
 
     &:empty {
@@ -106,8 +106,8 @@
     }
 }
 
-.popover-content {
-    padding: $popover-content-padding-y $popover-content-padding-x;
+.popover-body {
+    padding: $popover-body-padding-y $popover-body-padding-x;
 }
 
 // Arrows
@@ -135,8 +135,8 @@
 // Control buttons
 .popover .close,
 .popover .drag {
-    padding: ($popover-title-padding-y / 2) ($popover-title-padding-x / 2);
-    margin-top: -($popover-title-padding-y / 2);
+    padding: ($popover-header-padding-y / 2) ($popover-header-padding-x / 2);
+    margin-top: -($popover-header-padding-y / 2);
 }
 
 // Draggable variant

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -32,7 +32,7 @@
 }
 
 // Wrapper for the tooltip content
-.tooltip-inner {
+.tooltip-body {
     max-width: $tooltip-max-width;
     padding: $tooltip-padding-y $tooltip-padding-x;
     color: $tooltip-color;

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3337,7 +3337,7 @@ Anchor variants:<br />
 <div class="card-sample">
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
         <a href="#" class="btn btn-primary">Button</a>
@@ -3349,7 +3349,7 @@ Anchor variants:<br />
 <div class="card-sample">
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
       </div>
@@ -3358,7 +3358,7 @@ Anchor variants:<br />
         <li class="list-group-item">Dapibus ac facilisis in</li>
         <li class="list-group-item">Vestibulum at eros</li>
       </ul>
-      <div class="card-block">
+      <div class="card-body">
         <a href="#" class="card-link">Card link</a>
         <a href="#" class="card-link">Another link</a>
       </div>
@@ -3374,12 +3374,12 @@ Anchor variants:<br />
 
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
       </div>
     </div>
 
-    <div class="card card-block">
+    <div class="card card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
       <a href="#" class="card-link">Card link</a>
@@ -3387,12 +3387,12 @@ Anchor variants:<br />
     </div>
 
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <h6 class="card-subtitle text-muted">Support card subtitle</h6>
       </div>
       <img data-src="holder.js/100px150/?text=Image Cap" alt="Card image">
-      <div class="card-block">
+      <div class="card-body">
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
         <a href="#" class="card-link">Card link</a>
         <a href="#" class="card-link">Another link</a>
@@ -3404,14 +3404,14 @@ Anchor variants:<br />
 <div class="card-sample">
     <div class="row">
       <div class="col-sm-6">
-        <div class="card card-block">
+        <div class="card card-body">
           <h3 class="card-title">Special title treatment</h3>
           <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
           <a href="#" class="btn btn-primary">Go somewhere</a>
         </div>
       </div>
       <div class="col-sm-6">
-        <div class="card card-block">
+        <div class="card card-body">
           <h3 class="card-title">Special title treatment</h3>
           <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
           <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3419,7 +3419,7 @@ Anchor variants:<br />
       </div>
     </div>
 
-    <div class="card card-block" style="width: 12rem;">
+    <div class="card card-body" style="width: 12rem;">
       <h3 class="card-title">Special title treatment</h3>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3428,19 +3428,19 @@ Anchor variants:<br />
 
 <h3>Card text-alignment</h3>
 <div class="card-sample">
-    <div class="card card-block">
+    <div class="card card-body">
       <h4 class="card-title">Special title treatment</h4>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
     </div>
 
-    <div class="card card-block text-center">
+    <div class="card card-body text-center">
       <h4 class="card-title">Special title treatment</h4>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
     </div>
 
-    <div class="card card-block text-right">
+    <div class="card card-body text-right">
       <h4 class="card-title">Special title treatment</h4>
       <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
       <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3453,7 +3453,7 @@ Anchor variants:<br />
       <div class="card-header">
         Featured
       </div>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
         <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3462,7 +3462,7 @@ Anchor variants:<br />
 
     <div class="card">
       <h3 class="card-header">Featured</h3>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
         <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3473,7 +3473,7 @@ Anchor variants:<br />
       <div class="card-header">
         Quote
       </div>
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3485,7 +3485,7 @@ Anchor variants:<br />
       <div class="card-header">
         Featured
       </div>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
         <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3498,14 +3498,14 @@ Anchor variants:<br />
     <h3>Card - image caps</h3>
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
       </div>
     </div>
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3524,7 +3524,7 @@ Anchor variants:<br />
 
     <h3>Card - inverted text</h3>
     <div class="card card-inverse" style="background-color: #333; border-color: #333;">
-      <div class="card-block">
+      <div class="card-body">
         <h3 class="card-title">Special title treatment</h3>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
         <a href="#" class="btn btn-primary">Button</a>
@@ -3533,7 +3533,7 @@ Anchor variants:<br />
 
     <h3>Card - context variants</h3>
     <div class="card card-inverse card-primary text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3541,7 +3541,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-inverse card-secondary text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3549,7 +3549,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-inverse card-success text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3557,7 +3557,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-inverse card-info text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3565,7 +3565,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-inverse card-warning text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3573,7 +3573,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-inverse card-danger text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3583,7 +3583,7 @@ Anchor variants:<br />
 
     <h3>Card - outline variants</h3>
     <div class="card card-outline-primary text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3591,7 +3591,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-outline-secondary text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3599,7 +3599,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-outline-success text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3607,7 +3607,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-outline-info text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3615,7 +3615,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-outline-warning text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3623,7 +3623,7 @@ Anchor variants:<br />
       </div>
     </div>
     <div class="card card-outline-danger text-center">
-      <div class="card-block">
+      <div class="card-body">
         <blockquote class="card-blockquote">
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
           <footer>Someone famous in <cite title="Source Title">Source Title</cite></footer>
@@ -3634,7 +3634,7 @@ Anchor variants:<br />
     <h3>Card - color tests</h3>
     <div class="card">
       <h3 class="card-header card-inverse bg-primary">Featured</h3>
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
         <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3645,7 +3645,7 @@ Anchor variants:<br />
     </div>
 
     <h3>Card - link test</h3>
-    <a href="#" class="card card-block">
+    <a href="#" class="card card-body">
       <h4 class="card-text">Entire card as link</h4>
       <p class="card-text">This is some text</p>
     </a>
@@ -3656,7 +3656,7 @@ Anchor variants:<br />
     <div class="card-group">
       <div class="card">
         <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3664,7 +3664,7 @@ Anchor variants:<br />
       </div>
       <div class="card">
         <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3672,7 +3672,7 @@ Anchor variants:<br />
       </div>
       <div class="card">
         <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3686,7 +3686,7 @@ Anchor variants:<br />
   <div class="card-deck">
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3694,7 +3694,7 @@ Anchor variants:<br />
     </div>
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3702,7 +3702,7 @@ Anchor variants:<br />
     </div>
     <div class="card">
       <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-      <div class="card-block">
+      <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3714,22 +3714,22 @@ Anchor variants:<br />
 <div class="card-deck-wrapper">
   <div class="card-deck">
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         Card 1
       </div>
     </div>
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         Card 2
       </div>
     </div>
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         Card 3
       </div>
     </div>
     <div class="card">
-      <div class="card-block">
+      <div class="card-body">
         Card 4
       </div>
     </div>
@@ -3741,16 +3741,16 @@ Anchor variants:<br />
 <div class="card-columns">
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px150" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title that wraps to a new line</h4>
       <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
     </div>
   </div>
-  <a href="#" class="card card-block">
+  <a href="#" class="card card-body">
     <h4 class="card-text">Entire card as link</h4>
     <p class="card-text">This is some text</p>
   </a>
-  <div class="card card-block">
+  <div class="card card-body">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>
@@ -3762,13 +3762,13 @@ Anchor variants:<br />
   </div>
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px150" alt="Card image cap">
-    <div class="card-block">
+    <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>
-  <div class="card card-block card-inverse card-primary text-center">
+  <div class="card card-body card-inverse card-primary text-center">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
       <footer>
@@ -3778,7 +3778,7 @@ Anchor variants:<br />
       </footer>
     </blockquote>
   </div>
-  <div class="card card-block text-center">
+  <div class="card card-body text-center">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3786,7 +3786,7 @@ Anchor variants:<br />
   <div class="card">
     <img class="card-img img-responsive" data-src="holder.js/100px200" alt="Card image" />
   </div>
-  <div class="card card-block text-right">
+  <div class="card card-body text-right">
     <blockquote class="card-blockquote">
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
       <footer>
@@ -3796,7 +3796,7 @@ Anchor variants:<br />
       </footer>
     </blockquote>
   </div>
-  <div class="card card-block">
+  <div class="card card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -3805,13 +3805,13 @@ Anchor variants:<br />
 
 <h3>Card columns - short count</h3>
 <div class="card-columns">
-  <div class="card card-block">
+  <div class="card card-body">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
   </div>
-  <div class="card card-block">
+  <div class="card card-body">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
   </div>
-  <div class="card card-block">
+  <div class="card card-body">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat.</p>
   </div>
 </div>
@@ -3832,7 +3832,7 @@ Anchor variants:<br />
       </li>
     </ul>
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3853,7 +3853,7 @@ Anchor variants:<br />
       </li>
     </ul>
   </div>
-  <div class="card-block">
+  <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
     <a href="#" class="btn btn-primary">Go somewhere</a>
@@ -3864,25 +3864,25 @@ Anchor variants:<br />
 <h3>Static Tooltip</h3>
 <div class="tooltip-sample">
   <div class="tooltip top" role="tooltip">
-    <div class="tooltip-inner">
+    <div class="tooltip-body">
       Tooltip on the top
     </div>
     <div class="tooltip-arrow"></div>
   </div>
   <div class="tooltip right" role="tooltip">
-    <div class="tooltip-inner">
+    <div class="tooltip-body">
       Tooltip on the right
     </div>
     <div class="tooltip-arrow"></div>
   </div>
   <div class="tooltip bottom" role="tooltip">
-    <div class="tooltip-inner">
+    <div class="tooltip-body">
       Tooltip on the bottom
     </div>
     <div class="tooltip-arrow"></div>
   </div>
   <div class="tooltip left" role="tooltip">
-    <div class="tooltip-inner">
+    <div class="tooltip-body">
       Tooltip on the left
     </div>
     <div class="tooltip-arrow"></div>
@@ -3908,32 +3908,32 @@ Anchor variants:<br />
 <h3>Static Popover</h3>
 <div class="popover-sample">
   <div class="popover top">
-    <h3 class="popover-title">Popover top</h3>
-    <div class="popover-content">
+    <h3 class="popover-header">Popover top</h3>
+    <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
     <div class="popover-arrow"></div>
   </div>
 
   <div class="popover right">
-    <h3 class="popover-title">Popover right</h3>
-    <div class="popover-content">
+    <h3 class="popover-header">Popover right</h3>
+    <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
     <div class="popover-arrow"></div>
   </div>
 
   <div class="popover bottom">
-    <h3 class="popover-title">Popover bottom</h3>
-    <div class="popover-content">
+    <h3 class="popover-header">Popover bottom</h3>
+    <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
     <div class="popover-arrow"></div>
   </div>
 
   <div class="popover left">
-    <h3 class="popover-title">Popover left</h3>
-    <div class="popover-content">
+    <h3 class="popover-header">Popover left</h3>
+    <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
     <div class="popover-arrow"></div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -101,7 +101,7 @@ $(window).ready(function() {
   min-width: 250px;
   max-width: 500px;
 }
-.container-viewport .tooltip .tooltip-inner {
+.container-viewport .tooltip .tooltip-body {
   min-width: 250px;
   max-width: 500px;
   min-height: 100px;
@@ -712,8 +712,8 @@ $(window).ready(function() {
             <a href="#" onclick="$('#pop_1').CFW_Popover('hide', true); return false;">Force Close</a> -
             <a href="#" onclick="$('#pop_1').CFW_Popover('hide'); return false;">Normal Close</a>
             <div class="popover" data-cfw-popover-target="pop_1">
-                <h3 class="popover-title">Popover top</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover top</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                     <p><a href="#" data-cfw-dismiss="popover">Close popover</a></p>
                 </div>
@@ -722,8 +722,8 @@ $(window).ready(function() {
             --
             <button type="button" class="btn btn-info" data-cfw-popover-toggle="pop_2" id="pop_2">Popover Hover/focus</button>
             <div class="popover" data-cfw-popover-target="pop_2">
-                <h3 class="popover-title">Popover top</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover top</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                 </div>
                 <div class="popover-arrow"></div>
@@ -732,8 +732,8 @@ $(window).ready(function() {
             <button type="button" class="btn btn-info" data-cfw-popover-toggle="pop_3" id="pop_3">Popover Hover/focus</button>
             &lt;- preventDefault() - should not show popover
             <div class="popover" data-cfw-popover-target="pop_3">
-                <h3 class="popover-title">Popover top</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover top</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                 </div>
                 <div class="popover-arrow"></div>
@@ -744,8 +744,8 @@ $(window).ready(function() {
             <button type="button" class="btn btn-info" id="pop_5">Popover from selector</button>
             <a href="#" onclick="$('#pop_5p').CFW_Popover('hide');return false;">Close by calling on popover</a>
             <div class="popover" id="pop_5p">
-                <h3 class="popover-title">Popover selector</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover selector</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                     <img src="" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-responsive" />
                 </div>
@@ -754,8 +754,8 @@ $(window).ready(function() {
             <br />
             <button type="button" class="btn btn-info" id="pop_7t" data-cfw="popover" data-cfw-popover-toggle="#pop_7">Popover from selector</button>
             <div class="popover" id="pop_7">
-                <h3 class="popover-title">Popover selector</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover selector</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                     <img src="" data-cfw="lazy" data-cfw-lazy-src="../assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-responsive" />
                 </div>
@@ -815,8 +815,8 @@ $(window).ready(function() {
                 <a href="#" onclick="javascript: $('#popR').CFW_Popover('dispose'); return false;">Dispose</a>
             </p>
             <div class="popover" id="popR">
-                <h3 class="popover-title">Popover selector</h3>
-                <div class="popover-content">
+                <h3 class="popover-header">Popover selector</h3>
+                <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
                 </div>
                 <div class="popover-arrow"></div>

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -63,8 +63,8 @@ $(function() {
         $popover.CFW_Popover('show');
 
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.strictEqual($('.popover .popover-title').text(), 'popover title', 'title correctly inserted');
-        assert.strictEqual($('.popover .popover-content').text(), 'popover content', 'content correctly inserted');
+        assert.strictEqual($('.popover .popover-header').text(), 'popover title', 'title correctly inserted');
+        assert.strictEqual($('.popover .popover-body').text(), 'popover content', 'content correctly inserted');
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
@@ -84,14 +84,14 @@ $(function() {
 
         $popover.CFW_Popover('show');
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.equal($('.popover .popover-content').html(), $div, 'content correctly inserted');
+        assert.equal($('.popover .popover-body').html(), $div, 'content correctly inserted');
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
 
         $popover.CFW_Popover('show');
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.equal($('.popover .popover-content').html(), $div, 'content correctly inserted');
+        assert.equal($('.popover .popover-body').html(), $div, 'content correctly inserted');
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
@@ -105,8 +105,8 @@ $(function() {
             .CFW_Popover('show');
 
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.strictEqual($('.popover .popover-title').text(), 'popover title', 'title correctly inserted');
-        assert.strictEqual($('.popover .popover-content').text(), 'popover content', 'content correctly inserted');
+        assert.strictEqual($('.popover .popover-header').text(), 'popover title', 'title correctly inserted');
+        assert.strictEqual($('.popover .popover-body').text(), 'popover content', 'content correctly inserted');
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
@@ -123,8 +123,8 @@ $(function() {
             .CFW_Popover('show');
 
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.strictEqual($('.popover .popover-title').text(), 'popover title', 'title correctly inserted');
-        assert.strictEqual($('.popover .popover-content').text(), 'popover content', 'content correctly inserted');
+        assert.strictEqual($('.popover .popover-header').text(), 'popover title', 'title correctly inserted');
+        assert.strictEqual($('.popover .popover-body').text(), 'popover content', 'content correctly inserted');
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -116,7 +116,7 @@ $(function() {
         assert.expect(2);
         var $tooltip = $('<a href="#" title="Another tooltip"/>')
             .appendTo('#qunit-fixture')
-            .CFW_Tooltip({ template: '<div class="tooltip some-class"><div class="tooltip-arrow"/><div class="tooltip-inner"/></div>' });
+            .CFW_Tooltip({ template: '<div class="tooltip some-class"><div class="tooltip-arrow"/><div class="tooltip-body"/></div>' });
 
         $tooltip.CFW_Tooltip('show');
         assert.ok($('.tooltip').hasClass('some-class'), 'custom class is present');
@@ -291,7 +291,7 @@ $(function() {
         assert.expect(1);
         var styles = '<style>'
             + '.tooltip.right { white-space: nowrap; }'
-            + '.tooltip.right .tooltip-inner { max-width: none; }'
+            + '.tooltip.right .tooltip-body { max-width: none; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
 
@@ -323,7 +323,7 @@ $(function() {
             .CFW_Tooltip();
 
         $tooltip.CFW_Tooltip('show');
-        assert.strictEqual($('.tooltip').children('.tooltip-inner').text(), 'Simple tooltip', 'title from title attribute is set');
+        assert.strictEqual($('.tooltip').children('.tooltip-body').text(), 'Simple tooltip', 'title from title attribute is set');
 
         $tooltip.CFW_Tooltip('hide');
         assert.strictEqual($('.tooltip').length, 0, 'tooltip removed from dom');
@@ -338,7 +338,7 @@ $(function() {
             });
 
         $tooltip.CFW_Tooltip('show');
-        assert.strictEqual($('.tooltip').children('.tooltip-inner').text(), 'tooltip title', 'title from title option is set');
+        assert.strictEqual($('.tooltip').children('.tooltip-body').text(), 'tooltip title', 'title from title option is set');
 
         $tooltip.CFW_Tooltip('hide');
         assert.strictEqual($('.tooltip').length, 0, 'tooltip removed from dom');
@@ -353,7 +353,7 @@ $(function() {
             });
 
         $tooltip.CFW_Tooltip('show');
-        assert.strictEqual($('.tooltip').children('.tooltip-inner').text(), 'tooltip title', 'title is set from title option while preferred over title attribute');
+        assert.strictEqual($('.tooltip').children('.tooltip-body').text(), 'tooltip title', 'title is set from title option while preferred over title attribute');
 
         $tooltip.CFW_Tooltip('hide');
         assert.strictEqual($('.tooltip').length, 0, 'tooltip removed from dom');
@@ -599,7 +599,7 @@ $(function() {
     QUnit.test('should adjust the tip\'s top position when up against the top of the viewport', function(assert) {
         assert.expect(2);
         var styles = '<style>'
-            + '.tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.trigger { position: fixed; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
@@ -625,7 +625,7 @@ $(function() {
     QUnit.test('should adjust the tip\'s top position when up against the bottom of the viewport', function(assert) {
         assert.expect(2);
         var styles = '<style>'
-            + '.tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.trigger { position: fixed; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
@@ -653,7 +653,7 @@ $(function() {
     QUnit.test('should adjust the tip\'s left position when up against the left of the viewport', function(assert) {
         assert.expect(2);
         var styles = '<style>'
-            + '.tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.trigger { position: fixed; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
@@ -680,7 +680,7 @@ $(function() {
     QUnit.test('should adjust the tip\'s left position when up against the right of the viewport', function(assert) {
         assert.expect(2);
         var styles = '<style>'
-            + '.tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.trigger { position: fixed; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
@@ -708,7 +708,7 @@ $(function() {
     QUnit.test('should adjust the tip when up against the right of an arbitrary viewport', function(assert) {
         assert.expect(2);
         var styles = '<style>'
-            + '.tooltip, .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip, .tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.container-viewport { position: absolute; top: 50px; left: 60px; width: 300px; height: 300px; }'
             + '.trigger { position: fixed; }'
             + '</style>';
@@ -736,7 +736,7 @@ $(function() {
     QUnit.test('should get viewport element from function', function(assert) {
         assert.expect(3);
         var styles = '<style>'
-            + '.tooltip, .tooltip .tooltip-inner { width: 200px; height: 200px; max-width: none; }'
+            + '.tooltip, .tooltip .tooltip-body { width: 200px; height: 200px; max-width: none; }'
             + '.container-viewport { position: absolute; top: 50px; left: 60px; width: 300px; height: 300px; }'
             + '.trigger { position: fixed; }'
             + '</style>';
@@ -769,7 +769,7 @@ $(function() {
         var styles = '<style>'
             + '.tooltip, .tooltip *, .tooltip *:before, .tooltip *:after { box-sizing: border-box; }'
             + '.container-viewport, .container-viewport *, .container-viewport *:before, .container-viewport *:after { box-sizing: border-box; }'
-            + '.tooltip .tooltip-inner { width: 50px; height: 50px; max-width: none; background: red; }'
+            + '.tooltip .tooltip-body { width: 50px; height: 50px; max-width: none; background: red; }'
             + '.container-viewport { padding: 100px; margin-left: 100px; width: 100px; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
@@ -1031,7 +1031,7 @@ $(function() {
         var styles = '<style>'
             + '.tooltip, .tooltip *, .tooltip *:before, .tooltip *:after { box-sizing: border-box; }'
             + '.tooltip { position: absolute; }'
-            + '.tooltip .tooltip-inner { width: 24px; height: 24px; font-family: Helvetica; }'
+            + '.tooltip .tooltip-body { width: 24px; height: 24px; font-family: Helvetica; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
 
@@ -1074,7 +1074,7 @@ $(function() {
         var styles = '<style>'
             + '.tooltip, .tooltip *, .tooltip *:before, .tooltip *:after { box-sizing: border-box; }'
             + '.tooltip { position: absolute; display: block; font-size: 12px; line-height: 1.4; }'
-            + '.tooltip .tooltip-inner { max-width: 200px; padding: 3px 8px; font-family: Helvetica; text-align: center; }'
+            + '.tooltip .tooltip-body { max-width: 200px; padding: 3px 8px; font-family: Helvetica; text-align: center; }'
             + '#trigger-parent {'
             + '  position: fixed;'
             + '  top: 100px;'
@@ -1088,7 +1088,7 @@ $(function() {
 
         $trigger
             .on('afterShow.cfw.tooltip', function() {
-                var $tip = $('.tooltip-inner');
+                var $tip = $('.tooltip-body');
                 var tipXrightEdge = $tip.offset().left + $tip.width();
                 var triggerXleftEdge = $trigger.offset().left;
                 assert.ok(tipXrightEdge < triggerXleftEdge, 'tooltip with auto left placement, when near the right edge of the viewport, gets left placement');
@@ -1167,7 +1167,7 @@ $(function() {
             + '.tooltip, .tooltip *, .tooltip *:before, .tooltip *:after { box-sizing: border-box; }'
             + '.tooltip { position: absolute; }'
             + '.tooltip-arrow { position: absolute; width: 0; height: 0; }'
-            + '.tooltip .tooltip-inner { max-width: 200px; padding: 3px 8px; }'
+            + '.tooltip .tooltip-body { max-width: 200px; padding: 3px 8px; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
 
@@ -1205,7 +1205,7 @@ $(function() {
             + '#qunit-fixture { top: 0; left: 0; }'
             + '.tooltip, .tooltip *, .tooltip *:before, .tooltip *:after { box-sizing: border-box; }'
             + '.tooltip { position: absolute; }'
-            + '.tooltip .tooltip-inner { width: 24px; height: 24px; font-family: Helvetica; }'
+            + '.tooltip .tooltip-body { width: 24px; height: 24px; font-family: Helvetica; }'
             + '#target { position: absolute; top: 100px; left: 50px; width: 100px; height: 200px; -webkit-transform: rotate(270deg); -ms-transform: rotate(270deg); transform: rotate(270deg); }'
             + '</style>';
         var $styles = $(styles).appendTo('head');

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -64,7 +64,7 @@ Holder.addTheme("gray", {
         <div class="card-deck">
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -72,7 +72,7 @@ Holder.addTheme("gray", {
             </div>
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -80,7 +80,7 @@ Holder.addTheme("gray", {
             </div>
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -94,7 +94,7 @@ Holder.addTheme("gray", {
         <div class="card-deck card-deck-flex">
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -102,7 +102,7 @@ Holder.addTheme("gray", {
             </div>
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -110,7 +110,7 @@ Holder.addTheme("gray", {
             </div>
             <div class="card">
                 <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-                <div class="card-block">
+                <div class="card-body">
                     <h4 class="card-title">Card title</h4>
                     <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
                     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -123,7 +123,7 @@ Holder.addTheme("gray", {
     <div class="card-deck card-deck-flex">
         <div class="card">
             <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-            <div class="card-block">
+            <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
                 <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -131,7 +131,7 @@ Holder.addTheme("gray", {
         </div>
         <div class="card">
             <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-            <div class="card-block">
+            <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
                 <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -139,7 +139,7 @@ Holder.addTheme("gray", {
         </div>
         <div class="card">
             <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-            <div class="card-block">
+            <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
                 <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -160,22 +160,22 @@ Holder.addTheme("gray", {
     <div class="card-deck-wrapper">
         <div class="card-deck">
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 1
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 2
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 3
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 4
                 </div>
             </div>
@@ -186,22 +186,22 @@ Holder.addTheme("gray", {
     <div class="card-deck-wrapper">
         <div class="card-deck card-deck-flex">
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 1
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 2
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 3
                 </div>
             </div>
             <div class="card">
-                <div class="card-block">
+                <div class="card-body">
                     Card 4
                 </div>
             </div>
@@ -211,22 +211,22 @@ Holder.addTheme("gray", {
     flex (no wrapper):
     <div class="card-deck card-deck-flex">
         <div class="card">
-            <div class="card-block">
+            <div class="card-body">
                 Card 1
             </div>
         </div>
         <div class="card">
-            <div class="card-block">
+            <div class="card-body">
                 Card 2
             </div>
         </div>
         <div class="card">
-            <div class="card-block">
+            <div class="card-body">
                 Card 3
             </div>
         </div>
         <div class="card">
-            <div class="card-block">
+            <div class="card-body">
                 Card 4
             </div>
         </div>
@@ -240,7 +240,7 @@ Holder.addTheme("gray", {
     <div class="card-group">
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -248,7 +248,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -256,7 +256,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -268,7 +268,7 @@ Holder.addTheme("gray", {
     <div class="card-group card-group-flex">
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -276,7 +276,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -284,7 +284,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card">
         <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
           <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -301,7 +301,7 @@ Holder.addTheme("gray", {
       <div class="card-deck card-deck-flex">
         <div class="card card-flex">
           <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-          <div class="card-block">
+          <div class="card-body">
             <h4 class="card-title">Card title</h4>
             <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
           </div>
@@ -311,7 +311,7 @@ Holder.addTheme("gray", {
         </div>
         <div class="card card-flex">
           <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-          <div class="card-block">
+          <div class="card-body">
             <h4 class="card-title">Card title</h4>
             <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
           </div>
@@ -321,7 +321,7 @@ Holder.addTheme("gray", {
         </div>
         <div class="card card-flex">
           <img class="card-img-top img-responsive" data-src="holder.js/100px200/" alt="Card image cap">
-          <div class="card-block">
+          <div class="card-body">
             <h4 class="card-title">Card title</h4>
             <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
           </div>
@@ -337,7 +337,7 @@ Holder.addTheme("gray", {
     <div class="card-group card-group-flex">
       <div class="card card-flex">
         <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
         </div>
@@ -347,7 +347,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card card-flex">
         <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
         </div>
@@ -357,7 +357,7 @@ Holder.addTheme("gray", {
       </div>
       <div class="card card-flex">
         <img class="card-img-top img-responsive" data-src="holder.js/100px180/" alt="Card image cap">
-        <div class="card-block">
+        <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
         </div>


### PR DESCRIPTION
Normalize the naming convention for header, content, and footer areas.  Current use case is a bit all over the place, and can be confusing.

This PR takes care of all the following components, and their related js, doc, and test items

## Old Classes
- Card
  - Header: `.card-header`
  - Content: `.card-block`
  - Footer: `.card-footer`
- Modals
  - Header: `.modal-header`
  - Content: `.modal-body`
  - Footer: `.modal-footer`
- Popover
  - Header: `.popover-title`
  - Content: `.popover-content`
- Tooltips
  - Content: `.tooltip-inner`

## New Classes
- Card
  - Header: `.card-header`
  - Content: `.card-body`
  - Footer: `.card-footer`
- Modals
  - Header: `.modal-header`
  - Content: `.modal-body`
  - Footer: `.modal-footer`
- Popover
  - Header: `.popover-header`
  - Content: `.popover-body`
- Tooltips
  - Content: `.tooltip-body`
