### PR TITLE
Flexbox the grid

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -49,19 +49,24 @@
             padding-top: .75rem;
             padding-bottom: .75rem;
             background-color: rgba(34,68,102,.15);
-            border: $gridline-border-width solid rgba(34,68,102,.2);
+            border: $border-width solid rgba(34,68,102,.2);
         }
+    }
+}
+.cf-example-row-grid {
+    .row {
+        background-color: rgba(34,68,102,.05);
     }
 }
 .cf-example-row-flex {
     .row {
-        border: $gridline-border-width solid rgba(34,68,102,.5);
+        border: $border-width solid rgba(34,68,102,.5);
     }
 }
 .cf-example-row-flex-v {
     .row {
         height: 7rem;
-        border: $gridline-border-width solid rgba(34,68,102,.5);
+        border: $border-width solid rgba(34,68,102,.5);
     }
 }
 
@@ -279,7 +284,7 @@
 // Flex utilities
 .cf-example-flex {
     > div div {
-        background-color: rgba(34,68,102,.15);
+        background-color: rgba(34,68,102,.05);
         border: $gridline-border-width solid rgba(34,68,102,.2);
     }
 }

--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -579,30 +579,33 @@ Be sure to add `.form-control-label` to your `<label>`s as well so they're verti
         <input type="password" class="form-control" id="inputPassword3" placeholder="Password">
       </div>
     </div>
-    <fieldset class="form-group row">
-      <legend class="col-sm-2 form-control-legend">Radios</legend>
-      <div class="col-sm-10">
-        <div class="form-check">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
-            Option one is this and that&mdash;be sure to include why it's great
-          </label>
-        </div>
-        <div class="form-check">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
-            Option two can be something else and selecting it will deselect option one
-          </label>
-        </div>
-        <div class="form-check disabled">
-          <label class="form-check-label">
-            <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios3" value="option3" disabled>
-            Option three is disabled
-          </label>
+    <fieldset class="form-group">
+      <div class="row">
+        <legend class="col-sm-2 form-control-legend">Radios</legend>
+        <div class="col-sm-10">
+          <div class="form-check">
+            <label class="form-check-label">
+              <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
+              Option one is this and that&mdash;be sure to include why it's great
+            </label>
+          </div>
+          <div class="form-check">
+            <label class="form-check-label">
+              <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios2" value="option2">
+              Option two can be something else and selecting it will deselect option one
+            </label>
+          </div>
+          <div class="form-check disabled">
+            <label class="form-check-label">
+              <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios3" value="option3" disabled>
+              Option three is disabled
+            </label>
+          </div>
         </div>
       </div>
     </fieldset>
-    <fieldset class="form-group row">
+    <fieldset class="form-group">
+      <div class="row">
         <legend class="col-sm-2 form-control-legend">Checkbox</legend>
         <div class="col-sm-10">
           <div class="form-check">
@@ -611,6 +614,7 @@ Be sure to add `.form-control-label` to your `<label>`s as well so they're verti
             </label>
           </div>
         </div>
+      </div>
     </fieldset>
     <div class="form-group row">
       <div class="offset-sm-2 col-sm-10">

--- a/docs/examples/grid/grid.css
+++ b/docs/examples/grid/grid.css
@@ -18,7 +18,3 @@ h2 {
     background-color: rgba(34,68,102,.15);
     border: 1px solid rgba(34,68,102,.2);
 }
-.row-flex > [class^="col-"],
-.row-flex > .col {
-    background-color: rgba(102,0,102,.15);
-}

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -24,78 +24,33 @@
         <h1>Figuration Grid Examples</h1>
         <p class="lead">Basic grid layouts to help get you familiar with building within the grid system.</p>
 
-        <p>
-            Here we are showing the two different styles for grid layouts using the opt-in flexbox classes.
-            They are designated as follows:
-        </p>
-        <ul>
-            <li><strong>normal:</strong> float model</li>
-            <li><strong>flex:</strong> opt-in flexbox model</li>
-        </ul>
-
         <h2>Five grid tiers</h2>
         <p>There are five tiers to the grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
-
-        normal:
         <div class="row">
           <div class="col-4">.col-4</div>
           <div class="col-4">.col-4</div>
           <div class="col-4">.col-4</div>
         </div>
-        flex:
-        <div class="row row-flex">
-          <div class="col-4">.col-4</div>
-          <div class="col-4">.col-4</div>
-          <div class="col-4">.col-4</div>
-        </div>
 
-        normal:
         <div class="row">
           <div class="col-sm-4">.col-sm-4</div>
           <div class="col-sm-4">.col-sm-4</div>
           <div class="col-sm-4">.col-sm-4</div>
         </div>
-        flex:
-        <div class="row row-flex">
-          <div class="col-sm-4">.col-sm-4</div>
-          <div class="col-sm-4">.col-sm-4</div>
-          <div class="col-sm-4">.col-sm-4</div>
-        </div>
 
-        normal:
         <div class="row">
           <div class="col-md-4">.col-md-4</div>
           <div class="col-md-4">.col-md-4</div>
           <div class="col-md-4">.col-md-4</div>
         </div>
-        flex:
-        <div class="row row-flex">
-          <div class="col-md-4">.col-md-4</div>
-          <div class="col-md-4">.col-md-4</div>
-          <div class="col-md-4">.col-md-4</div>
-        </div>
 
-        normal:
         <div class="row">
           <div class="col-lg-4">.col-lg-4</div>
           <div class="col-lg-4">.col-lg-4</div>
           <div class="col-lg-4">.col-lg-4</div>
         </div>
-        flex:
-        <div class="row row-flex">
-          <div class="col-lg-4">.col-lg-4</div>
-          <div class="col-lg-4">.col-lg-4</div>
-          <div class="col-lg-4">.col-lg-4</div>
-        </div>
 
-        normal:
         <div class="row">
-          <div class="col-xl-4">.col-xl-4</div>
-          <div class="col-xl-4">.col-xl-4</div>
-          <div class="col-xl-4">.col-xl-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
           <div class="col-xl-4">.col-xl-4</div>
           <div class="col-xl-4">.col-xl-4</div>
           <div class="col-xl-4">.col-xl-4</div>
@@ -103,14 +58,8 @@
 
         <h2>Three equal columns</h2>
         <p>Get three equal-width columns <strong>starting at desktops and scaling to extra large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
-        normal:
+
         <div class="row">
-            <div class="col-md-4">.col-md-4</div>
-            <div class="col-md-4">.col-md-4</div>
-            <div class="col-md-4">.col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-md-4">.col-md-4</div>
             <div class="col-md-4">.col-md-4</div>
             <div class="col-md-4">.col-md-4</div>
@@ -118,14 +67,8 @@
 
         <h2>Three unequal columns</h2>
         <p>Get three columns <strong>starting at desktops and scaling to extra large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
-        normal:
+
         <div class="row">
-            <div class="col-md-3">.col-md-3</div>
-            <div class="col-md-6">.col-md-6</div>
-            <div class="col-md-3">.col-md-3</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-md-3">.col-md-3</div>
             <div class="col-md-6">.col-md-6</div>
             <div class="col-md-3">.col-md-3</div>
@@ -133,13 +76,8 @@
 
         <h2>Two columns</h2>
         <p>Get two columns <strong>starting at desktops and scaling to extra large desktops</strong>.</p>
-        normal:
+
         <div class="row">
-            <div class="col-md-8">.col-md-8</div>
-            <div class="col-md-4">.col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-md-8">.col-md-8</div>
             <div class="col-md-4">.col-md-4</div>
         </div>
@@ -152,19 +90,8 @@
         <h2>Two columns with two nested columns</h2>
         <p>Per the documentation, nesting is easy&mdash;just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to extra large desktops</strong>, with another two (equal widths) within the larger column.</p>
         <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
-        normal:
+
         <div class="row">
-            <div class="col-md-8">
-                .col-md-8
-                <div class="row">
-                    <div class="col-md-6">.col-md-6</div>
-                    <div class="col-md-6">.col-md-6</div>
-                </div>
-            </div>
-            <div class="col-md-4">.col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-md-8">
                 .col-md-8
                 <div class="row">
@@ -180,37 +107,19 @@
         <h2>Mixed: mobile and desktop</h2>
         <p>The grid system has five tiers of classes: xs (extra small), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
         <p>Each tier of classes scales up, meaning if you plan on setting the same widths for xs and sm, you only need to specify xs.</p>
-        normal:
+
         <div class="row">
-            <div class="col-12 col-md-8">.col-12 .col-md-8</div>
-            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-12 col-md-8">.col-12 .col-md-8</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         </div>
 
-        normal:
         <div class="row">
-            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-            <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
             <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         </div>
 
-        normal:
         <div class="row">
-            <div class="col-6">.col-6</div>
-            <div class="col-6">.col-6</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-6">.col-6</div>
             <div class="col-6">.col-6</div>
         </div>
@@ -218,25 +127,12 @@
         <hr />
 
         <h2>Mixed: mobile, tablet, and desktop</h2>
-        normal:
         <div class="row">
-            <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
-            <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
             <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
         </div>
 
-        normal:
         <div class="row">
-            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-            <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
             <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
@@ -245,99 +141,42 @@
         <hr />
 
         <h2>Column clearing</h2>
-        <p>Use <a href="../../layout/grid/#example-responsive-column-resets">responsive column resets</a> at specific breakpoints to prevent awkward wrapping with uneven content.</p>
-        normal:
+        <p>Use <a href="../../layout/grid/#column-resets">column resets</a> at specific breakpoints to prevent awkward wrapping with uneven content.</p>
         <div class="row">
-            <div class="col-6 col-sm-3">
-                .col-6 .col-sm-3
+            <div class="col-4 col-sm-3">
+                .col-4 .col-sm-3
                 <br />
                 Resize your viewport or check it out on your phone for an example.
             </div>
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+            <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
 
             <!-- Add the extra clearfix for only the required viewport -->
-            <div class="clearfix d-sm-none"></div>
+            <div class="w-100 d-sm-none"></div>
 
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-        </div>
-        flex:
-        <div class="row row-flex">
-            <div class="col-6 col-sm-3">
-                .col-6 .col-sm-3
-                <br />
-                Resize your viewport or check it out on your phone for an example.
-            </div>
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-
-            <!-- Add the extra clearfix for only the required viewport -->
-            <div class="clearfix d-sm-none"></div>
-
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-            <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+            <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
+            <div class="col-8 col-sm-3">.col-8 .col-sm-3</div>
         </div>
 
         <hr />
 
         <h2>Offset, push, and pull resets</h2>
         <p>Reset offsets, pushes, and pulls at specific breakpoints.</p>
-        normal:
         <div class="row">
             <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
             <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
         </div>
-        flex:
-        <div class="row row-flex">
-            <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
-            <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
-        </div>
 
-        normal:
         <div class="row">
             <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
             <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
-        </div>
-        flex:
-        <div class="row row-flex">
-            <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
-            <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
-        </div>
-
-        <hr />
-
-        <h2>Nested float/flex Examples</h2>
-
-        normal:
-        <div class="row">
-            <div class="col-md-8">
-                .col-md-8
-                <div class="row row-flex">
-                    <div class="col-md-6">.col-md-6<br />more</div>
-                    <div class="col-md-6">.col-md-6</div>
-                </div>
-            </div>
-            <div class="col-md-4">.col-md-4</div>
-        </div>
-        flex:
-        <div class="row row-flex">
-            <div class="col-md-8">
-                .col-md-8
-                <div class="row">
-                    <div class="col-md-6">.col-md-6<br />more</div>
-                    <div class="col-md-6">.col-md-6</div>
-                </div>
-            </div>
-            <div class="col-md-4">.col-md-4</div>
         </div>
 
         <hr />
 
         <h2>Auto layout columns</h2>
 
-        <p>When flexbox is enabled, you can utilize breakpoint specific column classes for equal width columns.</p>
-
         <code>xs</code> breakpoint
-        <div class="row row-flex">
+        <div class="row">
             <div class="col">
                 1 of 2
             </div>
@@ -347,7 +186,7 @@
         </div>
 
         <code>md</code> breakpoint
-        <div class="row row-flex">
+        <div class="row">
             <div class="col-md">
                 1 of 3
             </div>
@@ -360,7 +199,7 @@
         </div>
 
         <code>xs</code> breakpoint
-        <div class="row row-flex">
+        <div class="row">
             <div class="col">
                 1 of 5
             </div>
@@ -382,7 +221,7 @@
 
         <h2>Vertical Flex Alignment</h2>
 
-        <div class="row row-flex flex-items-start">
+        <div class="row flex-items-start">
             <div class="col">
                 <code>.flex-*-items-start</code>
             </div>
@@ -394,7 +233,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-items-center">
+        <div class="row flex-items-center">
             <div class="col">
                 <code>.flex-*-items-center</code>
             </div>
@@ -406,7 +245,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-items-end">
+        <div class="row flex-items-end">
             <div class="col">
                 <code>.flex-*-items-end</code>
             </div>
@@ -418,7 +257,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-items-stretch">
+        <div class="row flex-items-stretch">
             <div class="col">
                 <code>.flex-*-items-stretch</code>
             </div>
@@ -430,7 +269,7 @@
             </div>
         </div>
 
-        <div class="row row-flex" style="height: 7rem;">
+        <div class="row" style="height: 7rem;">
             <div class="col flex-self-start">
                 align top
             </div>
@@ -447,7 +286,7 @@
 
         <h2>Horizontal Flex Alignment</h2>
 
-        <div class="row row-flex flex-start">
+        <div class="row flex-start">
             <div class="col-4">
                 aligned to
             </div>
@@ -456,7 +295,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-center">
+        <div class="row flex-center">
             <div class="col-4">
                 aligned to
             </div>
@@ -465,7 +304,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-end">
+        <div class="row flex-end">
             <div class="col-4">
                 aligned to
             </div>
@@ -474,7 +313,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-around">
+        <div class="row flex-around">
             <div class="col-4">
                 aliged to
             </div>
@@ -483,7 +322,7 @@
             </div>
         </div>
 
-        <div class="row row-flex flex-between">
+        <div class="row flex-between">
             <div class="col-4">
                 aligned to
             </div>

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -20,6 +20,7 @@ At a high level, here's how the grid system works:
 - Containers---`.container` for fixed width or `.container-fluid` for full width---center your site's contents and help align your grid content.
 - Rows are horizontal groups of columns that ensure your columns are lined up properly.
 - Content should be placed within columns, and only columns may be immediate children of rows.
+- Thanks to flexbox, grid columns without a set width will automatically layout with equal widths. For example, four instances of `.col-sm` will each automatically be 25% wide for small breakpoints.
 - Column classes indicate the number of columns you'd like to use out of the possible 12 per row. So if you want three equal-width columns, you'd use `.col-4`.
 - Column `width`s are set in percentages, so they're always fluid and sized relative to their parent element.
 - Columns have horizontal `padding` to create the gutters between individual columns.
@@ -28,29 +29,31 @@ At a high level, here's how the grid system works:
 - Grid tiers are based on minimum widths, meaning they apply to that one tier and all those above it (e.g., `.col-sm-4` applies to small, medium, large, and extra large devices).
 - You can use predefined grid classes or Sass mixins for more semantic markup.
 
+Be aware of the limitations and [bugs around flexbox](https://github.com/philipwalton/flexbugs), like the [inability to use some HTML elements as flex containers](https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers).
+
 Sounds good? Great, let's move on to seeing all that in an example.
 
 ## Quick Start Example
 
-If you're using Figuration's compiled CSS, this the example you'll want to start with.
+This example creates three equal-width columns on small, medium, large, and extra large devices using our [predefined grid classes](#predefined-classes). Those columns are centered in the page with the parent `.container`.
+
+Examples further down the page include some row and column colors to give a better visual example of their relationship.
 
 {% example html %}
 <div class="container">
   <div class="row">
     <div class="col-sm-4">
-      1 of 3
+      Fisrt column
     </div>
     <div class="col-sm-4">
-      1 of 3
+      Second column
     </div>
     <div class="col-sm-4">
-      1 of 3
+      Third column
     </div>
   </div>
 </div>
 {% endexample %}
-
-The above example creates three equal-width columns on small, medium, large, and extra large devices using our [predefined grid classes](#predefined-classes). Those columns are centered in the page with the parent `.container`.
 
 ## Grid Options
 
@@ -136,55 +139,180 @@ The example pixel values are calculated based upon assumption where the average 
   </table>
 </div>
 
-## Predefined Classes
+## Auto-Layout Columns
 
-In addition to our semantic mixins, Figuration includes an extensive set of prebuilt classes for quickly creating grid columns. It includes options for device-based column sizing, reordering columns, and more.
+Utilize breakpoint-specific column classes for equal-width columns. Add any number of unit-less classes for each breakpoint you need and every column will be the same width.
 
-### Example: Stacked-to-horizontal
+### Equal Width
 
-Using a single set of `.col-md-*` grid classes, you can create a basic grid system that starts out stacked on mobile devices and tablet devices (the extra small to small range) before becoming horizontal on desktop (medium) devices. Place grid columns in any `.row`.
+Equal-width columns are easliy done by adding any number of `.col-{breakpoint}`s for each breakpoint you need and every column will be the same width.
+
+For example, here's are some grid layouts that apply to every device and viewport possible, from `xs` to `xl`.
 
 <div class="cf-example-row">
 {% example html %}
 <div class="row">
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
-  <div class="col-md-1">.col-md-1</div>
+    <div class="col">
+        1 of 2
+    </div>
+    <div class="col">
+        1 of 2
+    </div>
 </div>
+
 <div class="row">
-  <div class="col-md-8">.col-md-8</div>
-  <div class="col-md-4">.col-md-4</div>
+    <div class="col">
+        1 of 3
+    </div>
+    <div class="col">
+        1 of 3
+    </div>
+    <div class="col">
+        1 of 3
+    </div>
 </div>
-<div class="row">
-  <div class="col-md-4">.col-md-4</div>
-  <div class="col-md-4">.col-md-4</div>
-  <div class="col-md-4">.col-md-4</div>
-</div>
-<div class="row">
-  <div class="col-md-6">.col-md-6</div>
-  <div class="col-md-6">.col-md-6</div>
+
+<div class="row no-gutters">
+  <div class="col">Columns</div>
+  <div class="col">with no</div>
+  <div class="col">gutters</div>
 </div>
 {% endexample %}
 </div>
 
-### Example: Mobile and Desktop
+### Controlling One Column Width
 
-Don't want your columns to simply stack in smaller devices? Use the extra small and medium device grid classes by adding `.col-*` and `.col-md-*` to your columns. See the example below for a better idea of how it all works.
+You can also set the width of one column and the others will automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths.
+
+Note that the other columns will resize no matter the width of the center column.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="row">
+    <div class="col">
+        1 of 3
+    </div>
+    <div class="col-6">
+        2 of 3 (wider)
+    </div>
+    <div class="col">
+        3 of 3
+    </div>
+</div>
+
+<div class="row">
+    <div class="col">
+        1 of 3
+    </div>
+    <div class="col-5">
+        2 of 3 (wider)
+    </div>
+    <div class="col">
+        3 of 3
+    </div>
+</div>
+{% endexample %}
+</div>
+
+### Variable Width
+
+Using the `col-{breakpoint}-auto` classes, a column can size itself based on the natural width of its content. This can be handy when dealing with single line content like inputs, numbers, etc.  This, in conjunction with [justify content utilities]({{ site.baseurl }}/utilities/flexbox/#justify-content) utility classes, is very useful for centering layouts with uneven column sizes as viewport width changes.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="container">
+    <div class="row flex-md-center">
+        <div class="col col-lg-2">
+            1 of 3
+        </div>
+        <div class="col-12 col-md-auto">
+            Variable width content
+        </div>
+        <div class="col col-lg-2">
+            3 of 3
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            1 of 3
+        </div>
+        <div class="col-12 col-md-auto">
+            Variable width content
+        </div>
+        <div class="col col-lg-2">
+            3 of 3
+        </div>
+    </div>
+</div>
+{% endexample %}
+ </div>
+
+### Equal-Width with Multiple Rows
+
+Create equal-width columns that span multiple rows by inserting a `.w-100` where you want the columns to break to a new line. Make the breaks responsive by mixing the `.w-100` with some [responsive display utilities]({{ site.baseurl }}/utilities/display/#responsively-hiding-content).
+
+<div class="cf-example-row">
+{% example html %}
+<div class="row">
+  <div class="col">1 of 4</div>
+  <div class="col">2 of 4</div>
+  <div class="w-100"></div>
+  <div class="col">3 of 4</div>
+  <div class="col">4 of 4</div>
+</div>
+{% endexample %}
+</div>
+
+## Responsive Classes
+
+Figuration's grid includes five tiers of predefined classes for building complex responsive layouts. Customize the size of your columns on extra small, small, medium, large, or extra large devices however you see fit.
+
+### All Breakpoints
+
+For grids that are the same from the smallest of devices to the largest, use the `.col` and `.col-*` classes. Specify a numbered class when you need a particularly sized column; otherwise, feel free to stick to `.col`.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="row">
+  <div class="col">col</div>
+  <div class="col">col</div>
+  <div class="col">col</div>
+  <div class="col">col</div>
+</div>
+<div class="row">
+  <div class="col-8">col-8</div>
+  <div class="col-4">col-4</div>
+</div>
+{% endexample %}
+</div>
+
+### Stacked to Horizontal
+
+Using a single set of `.col-sm-*` classes, you can create a basic grid system that starts out stacked on mobile and tablet devices (the extra small to small range) before becoming horizontal on desktop (medium) devices.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="row">
+  <div class="col-sm-8">.col-sm-8</div>
+  <div class="col-sm-4">.col-sm-4</div>
+</div>
+<div class="row">
+  <div class="col-sm-4">.col-sm-4</div>
+  <div class="col-sm-4">.col-sm-4</div>
+  <div class="col-sm-4">.col-sm-4</div>
+</div>
+{% endexample %}
+</div>
+
+### Mix and Match
+
+Don't want your columns to simply stack in some grid tiers. Use a combination of different classes for each tier as needed. See the example below for a better idea of how it all works.
 
 <div class="cf-example-row">
 {% example html %}
 <!-- Stack the columns on mobile by making one full-width and the other half-width -->
 <div class="row">
-  <div class="col-12 col-md-8">.col-12 .col-md-8</div>
+  <div class="col-12 col-md-8">.col .col-md-8</div>
   <div class="col-6 col-md-4">.col-6 .col-md-4</div>
 </div>
 
@@ -203,27 +331,120 @@ Don't want your columns to simply stack in smaller devices? Use the extra small 
 {% endexample %}
 </div>
 
-### Example: Mobile, Tablet, Desktop
+## Alignment
 
-Build on the previous example by creating even more dynamic and powerful layouts with tablet `.col-sm-*` classes.
+Use [Flexbox alignment utilities]({{ site.baseurl }}/utilities/flexbox/) to vertically and horizontally align columns.
 
-<div class="cf-example-row">
+### Vertical Alignment
+
+<div class="cf-example-row cf-example-row-grid cf-example-row-flex-v">
 {% example html %}
-<div class="row">
-  <div class="col-12 col-sm-6 col-md-8">.col-12 .col-sm-6 .col-md-8</div>
-  <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-</div>
-<div class="row">
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-  <!-- Optional: clear the XS cols if their content doesn't match in height -->
-  <div class="clearfix d-sm-none"></div>
-  <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
+<div class="container">
+  <div class="row flex-items-start">
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+  </div>
+  <div class="row flex-items-center">
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+  </div>
+  <div class="row flex-items-end">
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+    <div class="col">
+      One of three columns
+    </div>
+  </div>
 </div>
 {% endexample %}
 </div>
 
-### Example: Remove Gutters
+<div class="cf-example-row cf-example-row-grid cf-example-row-flex-v">
+{% example html %}
+<div class="container">
+  <div class="row">
+    <div class="col flex-self-start">
+      One of three columns
+    </div>
+    <div class="col flex-self-center">
+      One of three columns
+    </div>
+    <div class="col flex-self-end">
+      One of three columns
+    </div>
+  </div>
+</div>
+{% endexample %}
+</div>
+
+### Horizontal Alignment
+
+<div class="cf-example-row">
+{% example html %}
+<div class="container">
+  <div class="row flex-start">
+    <div class="col-4">
+      One of two columns
+    </div>
+    <div class="col-4">
+      One of two columns
+    </div>
+  </div>
+  <div class="row flex-center">
+    <div class="col-4">
+      One of two columns
+    </div>
+    <div class="col-4">
+      One of two columns
+    </div>
+  </div>
+  <div class="row flex-end">
+    <div class="col-4">
+      One of two columns
+    </div>
+    <div class="col-4">
+      One of two columns
+    </div>
+  </div>
+  <div class="row flex-around">
+    <div class="col-4">
+      One of two columns
+    </div>
+    <div class="col-4">
+      One of two columns
+    </div>
+  </div>
+  <div class="row flex-between">
+    <div class="col-4">
+      One of two columns
+    </div>
+    <div class="col-4">
+      One of two columns
+    </div>
+  </div>
+</div>
+{% endexample %}
+</div>
+
+### No Gutters
 
 The gutters between columns in our default, predefined grid classes can be removed with `.no-gutters`. This removes the negative `margin`s from `.row` and the horizontal `padding` from all immediate children columns.
 
@@ -247,13 +468,13 @@ In practice, here's how it looks. Note you can continue to use this with all oth
 <div class="cf-example-row">
 {% example html %}
 <div class="row no-gutters">
-  <div class="col-12 col-sm-6 col-md-8">.col-12 .col-sm-6 .col-md-8</div>
+  <div class="col-12 col-sm-6 col-md-8">.col .col-sm-6 .col-md-8</div>
   <div class="col-6 col-md-4">.col-6 .col-md-4</div>
 </div>
 {% endexample %}
 </div>
 
-### Example: Column Wrapping
+### Column Wrapping
 
 If more than 12 columns are placed within a single row, each group of extra columns will, as one unit, wrap onto a new line.
 
@@ -267,21 +488,18 @@ If more than 12 columns are placed within a single row, each group of extra colu
 {% endexample %}
 </div>
 
-### Example: Responsive Column Resets
+### Column Resets
 
-With the four tiers of grids available you're bound to run into issues where, at certain breakpoints, your columns don't clear quite right as one is taller than the other. To fix that, use a combination of a `.clearfix` and our [display utilities]({{ site.baseurl }}/utilities/display/#responsively-hiding-content).
+With the five tiers of grids available you might run into issues where, at certain breakpoints, your columns don't wrap quite right. To counteract that, use a combination of a `.w-100` and our [display utilities]({{ site.baseurl }}/utilities/display/#responsively-hiding-content).
 
 <div class="cf-example-row">
 {% example html %}
 <div class="row">
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-
-  <!-- Add the extra clearfix for only the required viewport -->
-  <div class="clearfix d-sm-none"></div>
-
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-  <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+  <div class="col-4 col-md-3">.col-4 .col-md-3</div>
+  <div class="col-4 col-md-3">.col-4 .col-md-3<br>taller</div>
+  <div class="w-100 d-md-none"></div>
+  <div class="col-4 col-md-3">.col-4 .col-md-3</div>
+  <div class="col-8 col-md-3">.col-8 .col-md-3</div>
 </div>
 {% endexample %}
 </div>
@@ -302,9 +520,33 @@ In addition to column clearing at responsive breakpoints, you may need to **rese
 {% endexample %}
 </div>
 
-### Example: Offsetting Columns
+## Reordering
 
-Move columns to the right using `.offset-md-*` classes. These classes increase the left margin of a column by `*` columns. For example, `.offset-md-4` moves `.col-md-4` over four columns.
+### Flex Order
+
+Use flexbox utilities for controlling the **visual order** of your content.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="container">
+  <div class="row">
+    <div class="col flex-unordered">
+      First, but unordered
+    </div>
+    <div class="col flex-last">
+      Second, but last
+    </div>
+    <div class="col flex-first">
+      Third, but first
+    </div>
+  </div>
+</div>
+{% endexample %}
+</div>
+
+### Offsetting Columns
+
+Move columns to the right using `.offset-*` classes. These classes increase the left margin of a column by `*` columns. For example, `.offset-md-4` moves a column over four columns on medium and larger devices.
 
 <div class="cf-example-row">
 {% example html %}
@@ -322,7 +564,20 @@ Move columns to the right using `.offset-md-*` classes. These classes increase t
 {% endexample %}
 </div>
 
-### Example: Nesting Columns
+### Push an Pull
+
+Easily change the order of our built-in grid columns with `.push-*` and `.pull-*` modifier classes.
+
+<div class="cf-example-row">
+{% example html %}
+<div class="row">
+  <div class="col-md-9 push-md-3">.col-md-9 .push-md-3</div>
+  <div class="col-md-3 pull-md-9">.col-md-3 .pull-md-9</div>
+</div>
+{% endexample %}
+</div>
+
+## Nesting
 
 To nest your content with the default grid, add a new `.row` and set of `.col-sm-*` columns within an existing `.col-sm-*` column. Nested rows should include a set of columns that add up to 12 or fewer (it is not required that you use all 12 available columns).
 
@@ -344,27 +599,33 @@ To nest your content with the default grid, add a new `.row` and set of `.col-sm
 {% endexample %}
 </div>
 
-### Example: Column Ordering
-
-Easily change the order of our built-in grid columns with `.push-md-*` and `.pull-md-*` modifier classes.
-
-<div class="cf-example-row">
-{% example html %}
-<div class="row">
-  <div class="col-md-9 push-md-3">.col-md-9 .push-md-3</div>
-  <div class="col-md-3 pull-md-9">.col-md-3 .pull-md-9</div>
-</div>
-{% endexample %}
-</div>
-
 ## Customizing the Grid
 
 Using our built-in grid Sass variables and maps, it's possible to completely customize the predefined grid classes. Change the number of tiers, the media query dimensions, the container widths, and the grid gutter widths---then recompile.
 
-For example, if you wanted just three grid tiers, you'd update the `$grid-breakpoints`, `$container-max-widths`, and `$grid-gutter-widths` to something like this:
+### Columns and Gutters
+
+The number of grid columns and their horizontal padding (aka, gutters) can be modified via Sass variables. `$grid-columns` is used to generate the widths (in percent) of each individual column while `$grid-gutter-widths` allows breakpoint-specific widths that are divided evenly across `padding-left` and `padding-right` for the column gutters.
+
+{% highlight scss %}
+$grid-columns: 12;
+$grid-gutter-width: 2rem;
+$grid-gutter-widths: (
+    xs: $grid-gutter-width,
+    sm: $grid-gutter-width,
+    md: $grid-gutter-width,
+    lg: $grid-gutter-width,
+    xl: $grid-gutter-width
+);
+{% endhighlight %}
+
+### Grid Tiers
+
+Moving beyond the columns themselves, you may also customize the number of grid tiers. If you wanted just four grid tiers, you would update the `$grid-breakpoints`, `$container-max-widths`, and `$grid-gutter-widths` to something like this:
 
 {% highlight scss %}
 $grid-breakpoints: (
+  xs: 0,
   sm: bp-to-em(480px),
   md: bp-to-em(768px),
   lg: bp-to-em(1024px)
@@ -377,6 +638,7 @@ $container-max-widths: (
 );
 
 $grid-gutter-widths: (
+    xs: 1.5rem,
     sm: 1.5rem,
     md: 2rem,
     lg: 2rem
@@ -434,32 +696,16 @@ Mixins are used in conjunction with the grid variables to generate semantic CSS 
 
 {% highlight scss %}
 // Creates a wrapper for a series of columns
-@mixin make-row($gutter: $grid-gutter-width) {
-    @include clearfix();
-    margin-left:  ($gutter / -2);
-    margin-right: ($gutter / -2);
-}
+@include make-row($gutters: $grid-gutter-widths);
 
-// Make the element grid-ready
-@mixin make-col($size, $columns: $grid-columns, $gutter: $grid-gutter-width) {
-    position: relative;
-    min-height: 1px;
-    padding-right: ($gutter / 2);
-    padding-left:  ($gutter / 2);
-    float: left;
-    width: percentage($size / $columns);
-}
+// Make the element grid-ready (applying everything but the width)
+@include make-col-ready($gutters: $grid-gutter-widths);
+@include make-col($size, $columns: $grid-columns);
 
 // Get fancy by offsetting, or changing the sort order
-@mixin make-col-offset($columns) {
-  margin-left: percentage(($columns / $grid-columns));
-}
-@mixin make-col-push($columns) {
-  left: percentage(($columns / $grid-columns));
-}
-@mixin make-col-pull($columns) {
-  right: percentage(($columns / $grid-columns));
-}
+@include make-col-offset($size, $columns: $grid-columns);
+@include make-col-push($size, $columns: $grid-columns);
+@include make-col-pull($size, $columns: $grid-columns);
 {% endhighlight %}
 
 ### Example Usage
@@ -477,6 +723,8 @@ See it in action in <a href="http://jsbin.com/ruxona/edit">this rendered example
   @include make-row();
 }
 .content-main {
+  @include make-col-ready();
+
   @media (max-width: 32em) {
     @include make-col(6);
   }
@@ -485,6 +733,8 @@ See it in action in <a href="http://jsbin.com/ruxona/edit">this rendered example
   }
 }
 .content-secondary {
+  @include make-col-ready();
+
   @media (max-width: 32em) {
     @include make-col(6);
   }
@@ -502,148 +752,3 @@ See it in action in <a href="http://jsbin.com/ruxona/edit">this rendered example
   </div>
 </div>
 {% endhighlight %}
-
-
-## Flexbox
-
-Looking for a more modern grid system?  Use the opt-in flexbox mode, or [enable full flexbox support in Figuration]({{ site.baseurl }}/layout/flexbox#full-flexbox-mode), to take full advantage of CSS's Flexible Box module for even more control over your site's layout, alignment, and distribution of content.
-
-### Opt-in vs Full Mode
-
-The **opt-in mode** for flexbox support is available by default, and is easily triggered by adding `.row-flex` to any `.row` containers.  Any nested containers using just the `.row` class resets to the standard `float` grid layout.
-
-**Full mode** needs to be enabled in the Sass and the CSS needs to be recompiled.  In this mode, you do not need to use the `.row-flex` class, and all grid items will use `display: flex;` for layout.
-
-### What is Available
-
-- Nesting, offsets, pushes, pulls, and `.no-gutters` are all supported in the flexbox grid system.
-- Flexbox grid columns without a set width will automatically layout with equal widths. For example, four columns will each automatically be 25% wide.
-- Flexbox grid columns have significantly more alignment options available, including vertical alignment.
-
-### Auto-Layout Columns
-
-When flexbox support is used/enabled, you can utilize breakpoint-specific column classes to control column widths.
-
-#### Equal Width Columns
-
-Equal-width columns are easliy done by adding any number of `.col-{breakpoint}`s for each breakpoint you need and every column will be the same width.
-
-For example, here's are some grid layouts that apply to every device and viewport possible.
-
-<div class="cf-example-row">
-{% example html %}
-<div class="row row-flex">
-    <div class="col">
-        1 of 2
-    </div>
-    <div class="col">
-        1 of 2
-    </div>
-</div>
-
-<div class="row row-flex">
-    <div class="col">
-        1 of 3
-    </div>
-    <div class="col">
-        1 of 3
-    </div>
-    <div class="col">
-        1 of 3
-    </div>
-</div>
-
-<div class="row row-flex no-gutters">
-  <div class="col">Columns</div>
-  <div class="col">with no</div>
-  <div class="col">gutters</div>
-</div>
-{% endexample %}
-</div>
-
-#### Equal Width with Multiple Rows
-
-Create equal-width columns that span multiple rows by inserting a `.w-100` where you want the columns to break to a new line. Make the breaks responsive by mixing the `.w-100` with some [responsive display utilities]({{ site.baseurl }}/utilities/display/#responsively-hiding-content).
-
-<div class="cf-example-row">
-{% example html %}
-<div class="row row-flex">
-  <div class="col">1 of 4</div>
-  <div class="col">2 of 4</div>
-  <div class="w-100"></div>
-  <div class="col">3 of 4</div>
-  <div class="col">4 of 4</div>
-</div>
-{% endexample %}
-</div>
-
-#### Controlled Width Column
-
-You can also set the width of one column and the others will automatically resize around it. You may use predefined grid classes (as shown below), grid mixins, or inline widths.
-
-In the examples below, note that the other columns will resize no matter the width of the center column.
-
-<div class="cf-example-row">
-{% example html %}
-<div class="row row-flex">
-    <div class="col">
-        1 of 3
-    </div>
-    <div class="col-6">
-        2 of 3 (col-6)
-    </div>
-    <div class="col">
-        3 of 3
-    </div>
-</div>
-
-<div class="row row-flex">
-    <div class="col">
-        1 of 3
-    </div>
-    <div class="col-5">
-        2 of 3 (col-5)
-    </div>
-    <div class="col">
-        3 of 3
-    </div>
-</div>
-{% endexample %}
-</div>
-
-#### Variable Width Column
-
-Using the `col-{breakpoint}-auto` classes, a column can size itself based on the natural width of its content. This can be handy when dealing with single line content like inputs, numbers, etc.  This, in conjunction with [justify content utilities]({{ site.baseurl }}/utilities/flexbox/#justify-content) utility classes, is very useful for centering layouts with uneven column sizes as viewport width changes.
-
-<div class="cf-example-row">
-{% example html %}
-<div class="container">
-    <div class="row row-flex flex-md-center">
-        <div class="col col-lg-2">
-            1 of 3
-        </div>
-        <div class="col-12 col-md-auto">
-            Variable width content
-        </div>
-        <div class="col col-lg-2">
-            3 of 3
-        </div>
-    </div>
-    <div class="row row-flex">
-        <div class="col">
-            1 of 3
-        </div>
-        <div class="col-12 col-md-auto">
-            Variable width content
-        </div>
-        <div class="col col-lg-2">
-            3 of 3
-        </div>
-    </div>
-</div>
-{% endexample %}
- </div>
-
-### Alignment
-
-If you wish to have better control over your flexbox grid alignment, there are a handful of utility classes that might be helpful.  Information and examples can be found in the [Flexbox utilities page]({{ site.baseurl }}/utilities/flexbox/).

--- a/docs/utilities/flexbox.md
+++ b/docs/utilities/flexbox.md
@@ -333,7 +333,7 @@ Responsive order utilities:
 
 <div class="cf-example-row">
 {% example html %}
-<div class="row row-flex">
+<div class="row">
     <div class="col-1 flex-last">
         1
     </div>

--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -1,20 +1,15 @@
 // Container widths
-//
 // Set the container width, and override it for fixed navbars in media queries.
-
 @if $enable-grid-classes {
     .container {
         @include make-container();
         @include make-container-max-widths();
-        max-width: 100%;
     }
 }
 
 // Fluid container
-//
 // Utilizes the mixin meant for fixed width containers, but without any defined
 // width for fluid, full width layouts.
-
 @if $enable-grid-classes {
     .container-fluid {
         @include make-container();
@@ -22,9 +17,7 @@
 }
 
 // Row
-//
 // Rows contain and clear the floats of your columns.
-
 @if $enable-grid-classes {
     .row {
         @include make-row();
@@ -36,112 +29,16 @@
         margin-right: 0;
         margin-left: 0;
 
-        > [class*="col-"],
-        > .col {
+        > .col,
+        > [class*="col-"] {
             padding-right: 0;
             padding-left: 0;
-        }
-    }
-
-    @if $enable-flex-opt {
-        .row-flex {
-            display: flex;
-            flex-wrap: wrap;
-
-            // Disable clearfix or strange things happen with flex alignments
-            @include clearfix-disable();
         }
     }
 }
 
 // Columns
-//
 // Common styles for grid columns
-
 @if $enable-grid-classes {
-    // Use a placeholder selector to extend upon
-    // Additional per breakpoint placeholders are created in the `make-grid-columns()` mixin
-    %col {
-        position: relative;
-        min-height: 1px; // Prevent collapsing
-    }
-
-    // In flexbox modes, prevent columns from becoming too narrow when at
-    // smaller grid tiers by always setting `width: 100%;`. This works
-    // because we use `flex-basis` values  (using shorthand property `flex`)
-    // later on to override this initial width.
-    %col-flex {
-        width: 100%;
-    }
-
-    @each $breakpoint in map-keys($grid-breakpoints) {
-        $bprule: breakpoint-designator($breakpoint);
-
-        .col#{$bprule} {
-            @extend %col;
-        }
-
-        @for $i from 1 through $grid-columns {
-            .col#{$bprule}-#{$i} {
-                @extend %col;
-
-                @if $enable-flex-full {
-                    @extend %col-flex;
-                }
-            }
-
-            @if $enable-flex-opt {
-                .row-flex .col#{$bprule}-#{$i} {
-                    @extend %col-flex;
-                }
-            }
-        }
-
-        // Default for basic `.col-{bp}` classes for equal-width flexbox columns
-        @if $enable-flex-full {
-            .col#{$bprule} {
-                @extend %col;
-                @extend %col-flex;
-            }
-        }
-
-        @if $enable-flex-opt {
-            .row-flex .col#{$bprule} {
-                @extend %col-flex;
-            }
-        }
-    }
-
-    // Create responsive grid gutters
-    @each $breakpoint in map-keys($grid-breakpoints) {
-        $bprule: breakpoint-designator($breakpoint);
-
-        @include check-gutter-change($breakpoint, $grid-gutter-widths) {
-            %col-gutter {
-                @include media-breakpoint-up($breakpoint) {
-                    $gutter: map-get($grid-gutter-widths, $breakpoint);
-                    padding-right: ($gutter / 2);
-                    padding-left:  ($gutter / 2);
-                }
-            }
-        }
-
-        .col#{$bprule} {
-            @extend %col-gutter;
-        }
-
-        @for $i from 1 through $grid-columns {
-            .col#{$bprule}-#{$i} {
-                @extend %col-gutter;
-            }
-        }
-
-        @if $enable-flex-full or $enable-flex-opt {
-            .col#{$bprule}-auto {
-                @extend %col-gutter;
-            }
-        }
-    }
-
     @include make-grid-columns();
 }

--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -93,10 +93,11 @@
 // Media that spans multiple breakpoint widths.
 // Makes the @content apply between the min and max breakpoints
 @mixin media-breakpoint-between($lower, $upper, $breakpoints: $grid-breakpoints) {
-    @include media-breakpoint-up($lower, $breakpoints) {
-        @include media-breakpoint-down($upper, $breakpoints) {
-            @content;
-        }
+    $min: breakpoint-min($lower, $breakpoints);
+    $max: breakpoint-max($upper, $breakpoints);
+
+    @media (min-width: $min) and (max-width: $max) {
+        @content;
     }
 }
 
@@ -104,7 +105,10 @@
 // No minimum for the smallest breakpoint, and no maximum for the largest one.
 // Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
 @mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
-    @include media-breakpoint-between($name, $name, $breakpoints) {
+    $min: breakpoint-min($name, $breakpoints);
+    $max: breakpoint-max($name, $breakpoints);
+
+    @media (min-width: $min) and (max-width: $max) {
         @content;
     }
 }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -1,28 +1,11 @@
 /// Grid system
-//
 // Generate semantic grid columns with these mixins.
 
-@mixin check-gutter-change($breakpoint, $gutters: $grid-gutter-widths) {
-    $prev-breakpoint: breakpoint-prev($breakpoint, $gutters);
-
-    @if $prev-breakpoint {
-        $prev-gutter: map-get($gutters, $prev-breakpoint);
-        $curr-gutter: map-get($gutters, $breakpoint);
-
-        @if $prev-gutter != $curr-gutter {
-            @content;
-        }
-    } @else {
-        @content;
-    }
-}
-
+// Containers
 @mixin make-container($gutters: $grid-gutter-widths) {
+    max-width: 100%;
     margin-right: auto;
     margin-left: auto;
-    @if not $enable-flex-full {
-        @include clearfix();
-    }
 
     @each $breakpoint in map-keys($gutters) {
         @include check-gutter-change($breakpoint, $gutters) {
@@ -35,7 +18,6 @@
     }
 }
 
-
 // For each breakpoint, define the maximum width of the container in a media query
 @mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
     @each $breakpoint, $container-max-width in $max-widths {
@@ -45,7 +27,12 @@
     }
 }
 
+
+// Rows
 @mixin make-row($gutters: $grid-gutter-widths) {
+    display: flex;
+    flex-wrap: wrap;
+
     @each $breakpoint in map-keys($gutters) {
         @include check-gutter-change($breakpoint, $gutters) {
             @include media-breakpoint-up($breakpoint) {
@@ -55,30 +42,30 @@
             }
         }
     }
+}
 
-    @if $enable-flex-opt {
-        display: block;
-        flex-wrap: initial;
-    }
 
-    @if $enable-flex-full {
-        display: flex;
-        flex-wrap: wrap;
-    } @else {
-        @include clearfix();
+// Columns
+@mixin make-col-ready($gutters: $grid-gutter-widths) {
+    position: relative;
+    width: 100%; // Prevent too narrow
+    min-height: 1px; // Prevent collapsing
+
+    @each $breakpoint in map-keys($gutters) {
+        @include media-breakpoint-up($breakpoint) {
+            $gutter: map-get($gutters, $breakpoint);
+            padding-right: ($gutter / 2);
+            padding-left:  ($gutter / 2);
+        }
     }
 }
 
-@mixin make-col($size, $columns: $grid-columns, $flex-mode: false) {
-    @if $flex-mode {
-        flex: 0 0 percentage($size / $columns);
-        // Add a `max-width` to ensure content within each column does not blow out
-        // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
-        // do not appear to require this.
-        max-width: percentage($size / $columns);
-    } @else {
-        width: percentage($size / $columns);
-    }
+@mixin make-col($size, $columns: $grid-columns) {
+    flex: 0 0 percentage($size / $columns);
+    // Add a `max-width` to ensure content within each column does not blow out
+    // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
+    // do not appear to require this.
+    max-width: percentage($size / $columns);
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
@@ -104,38 +91,99 @@
     }
 }
 
-// Grid generation
-//
-// Generate the correct number of grid classes given any value of `$grid-columns`
 
-@mixin make-grid-columns($columns: $grid-columns, $gutter: $grid-gutter-width, $breakpoints: $grid-breakpoints) {
-    $breakpoint-counter: 0;
+// Gutters
+@mixin check-gutter-change($breakpoint, $gutters: $grid-gutter-widths) {
+    $prev-breakpoint: breakpoint-prev($breakpoint, $gutters);
+
+    @if $prev-breakpoint {
+        $prev-gutter: map-get($gutters, $prev-breakpoint);
+        $curr-gutter: map-get($gutters, $breakpoint);
+
+        @if $prev-gutter != $curr-gutter {
+            @content;
+        }
+    } @else {
+        @content;
+    }
+}
+
+@mixin make-grid-gutters($gutters: $grid-gutter-widths) {
+    // Create responsive grid gutters
+    @each $breakpoint in map-keys($grid-breakpoints) {
+        $bprule: breakpoint-designator($breakpoint);
+
+        @include check-gutter-change($breakpoint, $grid-gutter-widths) {
+            %col-gutter {
+                @include media-breakpoint-up($breakpoint) {
+                    $gutter: map-get($grid-gutter-widths, $breakpoint);
+                    padding-right: ($gutter / 2);
+                    padding-left:  ($gutter / 2);
+                }
+            }
+        }
+
+        .col#{$bprule},
+        .col#{$bprule}-auto {
+            @extend %col-gutter;
+        }
+
+        @for $i from 1 through $grid-columns {
+            .col#{$bprule}-#{$i} {
+                @extend %col-gutter;
+            }
+        }
+    }
+}
+
+// Grid generation
+// Generate the correct number of grid classes given any value of `$grid-columns`
+@mixin make-grid-columns($columns: $grid-columns, $breakpoints: $grid-breakpoints) {
+    // Use a placeholder selector to extend upon
+    %col {
+        position: relative;
+        width: 100%; // Prevent too narrow
+        min-height: 1px; // Prevent collapsing
+    }
+
+    @include make-grid-gutters();
+
     @each $breakpoint in map-keys($breakpoints) {
         $bprule: breakpoint-designator($breakpoint);
 
-        $breakpoint-counter: ($breakpoint-counter + 1);
-        @include media-breakpoint-up($breakpoint, $breakpoints) {
+        // Allow columns to stretch full width below their breakpoints
+        .col#{$bprule},
+        .col#{$bprule}-auto {
+            @extend %col;
+        }
+        @for $i from 1 through $grid-columns {
+            .col#{$bprule}-#{$i} {
+                @extend %col;
+            }
+        }
 
-            // Use a placeholders selector to extend upon
-            %col-#{$breakpoint} {
-                float: left;
+        @include media-breakpoint-up($breakpoint, $breakpoints) {
+            // Provide basic `.col-{bp}` classes for equal-width flexbox columns
+            %col-flex-basic-#{$breakpoint} {
+                flex-basis: 0;
+                flex-grow: 1;
+                max-width: 100%;
             }
 
+            %col-flex-auto-#{$breakpoint} {
+                flex: 0 0 auto;
+                width: auto;
+            }
+
+            .col#{$bprule} {
+                @extend %col-flex-basic-#{$breakpoint};
+            }
+            .col#{$bprule}-auto {
+                @extend %col-flex-auto-#{$breakpoint};
+            }
             @for $i from 1 through $columns {
                 .col#{$bprule}-#{$i} {
-                    @include make-col($i, $columns, $enable-flex-full);
-
-                    // No floating if in full flex mode
-                    @if not $enable-flex-full {
-                        @extend %col-#{$breakpoint};
-                    }
-
-                    // Opt-in flex mode
-                    @if $enable-flex-opt {
-                        .row-flex & {
-                            @include make-col($i, $columns, $enable-flex-opt);
-                        }
-                    }
+                    @include make-col($i, $columns);
                 }
             }
 
@@ -149,39 +197,10 @@
 
             // `$columns - 1` because offsetting by the width of an entire row isn't possible
             @for $i from 0 through ($columns - 1) {
-                @if $breakpoint-counter != 1 or $i != 0 { // Avoid emitting useless .offset-0
+                @if not($bprule == "" and $i == 0) { // Avoid emitting useless .offset-0
                     .offset#{$bprule}-#{$i} {
                         @include make-col-modifier(offset, $i, $columns);
                     }
-                }
-            }
-
-            // Provide basic `.col-{bp}` classes for equal-width flexbox columns
-            %col-flex-basic-#{$breakpoint} {
-                flex-basis: 0;
-                flex-grow: 1;
-                max-width: 100%;
-            }
-
-            %col-flex-auto-#{$breakpoint} {
-                flex: 0 0 auto;
-                width: auto;
-            }
-
-            @if $enable-flex-full {
-                .col#{$bprule} {
-                    @extend %col-flex-basic-#{$breakpoint};
-                }
-                .col#{$bprule}-auto {
-                    @extend %col-flex-auto-#{$breakpoint};
-                }
-            }
-            @if $enable-flex-opt {
-                .row-flex .col#{$bprule} {
-                    @extend %col-flex-basic-#{$breakpoint};
-                }
-                .row-flex .col#{$bprule}-auto {
-                    @extend %col-flex-auto-#{$breakpoint};
                 }
             }
         }

--- a/test/visual/flexbox-grid.html
+++ b/test/visual/flexbox-grid.html
@@ -27,10 +27,6 @@
     background-color: rgba(34,68,102,.15);
     border: 1px solid rgba(34,68,102,.2);
 }
-.row-flex > [class^="col-"],
-.row-flex > .col {
-    background-color: rgba(102,0,102,.15);
-}
 </style>
 
 </head>
@@ -51,78 +47,34 @@
     <h1>Figuration Grid Examples</h1>
     <p class="lead">Basic grid layouts to help get you familiar with building within the grid system.</p>
 
-    <p>
-        Here we are testing the two different styles for grid layouts using the opt-in flexbox classes.
-        They are designated as follows:
-    </p>
-    <ul>
-        <li><strong>normal:</strong> float model</li>
-        <li><strong>flex:</strong> opt-in flexbox model</li>
-    </ul>
-
     <h2>Five grid tiers</h2>
     <p>There are five tiers to the grid system, one for each range of devices we support. Each tier starts at a minimum viewport size and automatically applies to the larger devices unless overridden.</p>
 
-    normal:
     <div class="row">
-      <div class="col-4">.col-4</div>
-      <div class="col-4">.col-4</div>
-      <div class="col-4">.col-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
       <div class="col-4">.col-4</div>
       <div class="col-4">.col-4</div>
       <div class="col-4">.col-4</div>
     </div>
 
-    normal:
     <div class="row">
-      <div class="col-sm-4">.col-sm-4</div>
-      <div class="col-sm-4">.col-sm-4</div>
-      <div class="col-sm-4">.col-sm-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
       <div class="col-sm-4">.col-sm-4</div>
       <div class="col-sm-4">.col-sm-4</div>
       <div class="col-sm-4">.col-sm-4</div>
     </div>
 
-    normal:
     <div class="row">
-      <div class="col-md-4">.col-md-4</div>
-      <div class="col-md-4">.col-md-4</div>
-      <div class="col-md-4">.col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
       <div class="col-md-4">.col-md-4</div>
       <div class="col-md-4">.col-md-4</div>
       <div class="col-md-4">.col-md-4</div>
     </div>
 
-    normal:
     <div class="row">
-      <div class="col-lg-4">.col-lg-4</div>
-      <div class="col-lg-4">.col-lg-4</div>
-      <div class="col-lg-4">.col-lg-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
       <div class="col-lg-4">.col-lg-4</div>
       <div class="col-lg-4">.col-lg-4</div>
       <div class="col-lg-4">.col-lg-4</div>
     </div>
 
-    normal:
     <div class="row">
-      <div class="col-xl-4">.col-xl-4</div>
-      <div class="col-xl-4">.col-xl-4</div>
-      <div class="col-xl-4">.col-xl-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
       <div class="col-xl-4">.col-xl-4</div>
       <div class="col-xl-4">.col-xl-4</div>
       <div class="col-xl-4">.col-xl-4</div>
@@ -130,14 +82,7 @@
 
     <h2>Three equal columns</h2>
     <p>Get three equal-width columns <strong>starting at desktops and scaling to extra large desktops</strong>. On mobile devices, tablets and below, the columns will automatically stack.</p>
-    normal:
     <div class="row">
-        <div class="col-md-4">.col-md-4</div>
-        <div class="col-md-4">.col-md-4</div>
-        <div class="col-md-4">.col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-md-4">.col-md-4</div>
         <div class="col-md-4">.col-md-4</div>
         <div class="col-md-4">.col-md-4</div>
@@ -145,14 +90,7 @@
 
     <h2>Three unequal columns</h2>
     <p>Get three columns <strong>starting at desktops and scaling to extra large desktops</strong> of various widths. Remember, grid columns should add up to twelve for a single horizontal block. More than that, and columns start stacking no matter the viewport.</p>
-    normal:
     <div class="row">
-        <div class="col-md-3">.col-md-3</div>
-        <div class="col-md-6">.col-md-6</div>
-        <div class="col-md-3">.col-md-3</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-md-3">.col-md-3</div>
         <div class="col-md-6">.col-md-6</div>
         <div class="col-md-3">.col-md-3</div>
@@ -160,13 +98,7 @@
 
     <h2>Two columns</h2>
     <p>Get two columns <strong>starting at desktops and scaling to extra large desktops</strong>.</p>
-    normal:
     <div class="row">
-        <div class="col-md-8">.col-md-8</div>
-        <div class="col-md-4">.col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-md-8">.col-md-8</div>
         <div class="col-md-4">.col-md-4</div>
     </div>
@@ -179,19 +111,7 @@
     <h2>Two columns with two nested columns</h2>
     <p>Per the documentation, nesting is easy&mdash;just put a row of columns within an existing column. This gives you two columns <strong>starting at desktops and scaling to extra large desktops</strong>, with another two (equal widths) within the larger column.</p>
     <p>At mobile device sizes, tablets and down, these columns and their nested columns will stack.</p>
-    normal:
     <div class="row">
-        <div class="col-md-8">
-            .col-md-8
-            <div class="row">
-                <div class="col-md-6">.col-md-6</div>
-                <div class="col-md-6">.col-md-6</div>
-            </div>
-        </div>
-        <div class="col-md-4">.col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-md-8">
             .col-md-8
             <div class="row">
@@ -207,37 +127,18 @@
     <h2>Mixed: mobile and desktop</h2>
     <p>The grid system has five tiers of classes: xs (extra small), sm (small), md (medium), lg (large), and xl (extra large). You can use nearly any combination of these classes to create more dynamic and flexible layouts.</p>
     <p>Each tier of classes scales up, meaning if you plan on setting the same widths for xs and sm, you only need to specify xs.</p>
-    normal:
     <div class="row">
-        <div class="col-12 col-md-8">.col-12 .col-md-8</div>
-        <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-12 col-md-8">.col-12 .col-md-8</div>
         <div class="col-6 col-md-4">.col-6 .col-md-4</div>
     </div>
 
-    normal:
     <div class="row">
-        <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-        <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-        <div class="col-6 col-md-4">.col-6 .col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         <div class="col-6 col-md-4">.col-6 .col-md-4</div>
         <div class="col-6 col-md-4">.col-6 .col-md-4</div>
     </div>
 
-    normal:
     <div class="row">
-        <div class="col-6">.col-6</div>
-        <div class="col-6">.col-6</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-6">.col-6</div>
         <div class="col-6">.col-6</div>
     </div>
@@ -245,25 +146,12 @@
     <hr />
 
     <h2>Mixed: mobile, tablet, and desktop</h2>
-    normal:
     <div class="row">
-        <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
-        <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-12 col-sm-6 col-lg-8">.col-12 .col-sm-6 .col-lg-8</div>
         <div class="col-6 col-lg-4">.col-6 .col-lg-4</div>
     </div>
 
-    normal:
     <div class="row">
-        <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-        <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-        <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
         <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
         <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
         <div class="col-6 col-sm-4">.col-6 .col-sm-4</div>
@@ -273,88 +161,33 @@
 
     <h2>Column clearing</h2>
     <p>Use <a href="../layout/grid/#example-responsive-column-resets">responsive column resets</a> at specific breakpoints to prevent awkward wrapping with uneven content.</p>
-    normal:
     <div class="row">
-        <div class="col-6 col-sm-3">
-            .col-6 .col-sm-3
+        <div class="col-4 col-sm-3">
+            .col-4 .col-sm-3
             <br />
             Resize your viewport or check it out on your phone for an example.
         </div>
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+        <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
 
         <!-- Add the extra clearfix for only the required viewport -->
         <div class="clearfix d-sm-none"></div>
 
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-    </div>
-    flex:
-    <div class="row row-flex">
-        <div class="col-6 col-sm-3">
-            .col-6 .col-sm-3
-            <br />
-            Resize your viewport or check it out on your phone for an example.
-        </div>
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-
-        <!-- Add the extra clearfix for only the required viewport -->
-        <div class="w-100 d-sm-none"></div>
-
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
-        <div class="col-6 col-sm-3">.col-6 .col-sm-3</div>
+        <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
+        <div class="col-8 col-sm-3">.col-8 .col-sm-3</div>
     </div>
 
     <hr />
 
     <h2>Offset, push, and pull resets</h2>
     <p>Reset offsets, pushes, and pulls at specific breakpoints.</p>
-    normal:
     <div class="row">
         <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
         <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
     </div>
-    flex:
-    <div class="row row-flex">
-        <div class="col-sm-5 col-md-6">.col-sm-5 .col-md-6</div>
-        <div class="col-sm-5 offset-sm-2 col-md-6 offset-md-0">.col-sm-5 .offset-sm-2 .col-md-6 .offset-md-0</div>
-    </div>
 
-    normal:
     <div class="row">
         <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
         <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
-    </div>
-    flex:
-    <div class="row row-flex">
-        <div class="col-sm-6 col-md-5 col-lg-6">.col-sm-6 .col-md-5 .col-lg-6</div>
-        <div class="col-sm-6 col-md-5 offset-md-2 col-lg-6 offset-lg-0">.col-sm-6 .col-md-5 .offset-md-2 .col-lg-6 .offset-lg-0</div>
-    </div>
-
-    <hr />
-
-    <h2>Nested float/flex Examples</h2>
-
-    normal:
-    <div class="row">
-        <div class="col-md-8">
-            .col-md-8
-            <div class="row row-flex">
-                <div class="col-md-6">.col-md-6<br />more</div>
-                <div class="col-md-6">.col-md-6</div>
-            </div>
-        </div>
-        <div class="col-md-4">.col-md-4</div>
-    </div>
-    flex:
-    <div class="row row-flex">
-        <div class="col-md-8">
-            .col-md-8
-            <div class="row">
-                <div class="col-md-6">.col-md-6<br />more</div>
-                <div class="col-md-6">.col-md-6</div>
-            </div>
-        </div>
-        <div class="col-md-4">.col-md-4</div>
     </div>
 
     <hr />
@@ -364,7 +197,7 @@
     <p>When flexbox is enabled, you can utilize breakpoint specific column classes for equal width columns.</p>
 
     <code>xs</code> breakpoint
-    <div class="row row-flex">
+    <div class="row">
         <div class="col">
             1 of 2
         </div>
@@ -374,7 +207,7 @@
     </div>
 
     <code>md</code> breakpoint
-    <div class="row row-flex">
+    <div class="row">
         <div class="col-md">
             1 of 3
         </div>
@@ -387,7 +220,7 @@
     </div>
 
     <code>xs</code> breakpoint
-    <div class="row row-flex">
+    <div class="row">
         <div class="col">
             1 of 5
         </div>
@@ -409,7 +242,7 @@
 
     <h2>Vertical Flex Alignment</h2>
 
-    <div class="row row-flex flex-items-start">
+    <div class="row flex-items-start">
         <div class="col">
             <code>.flex-*-items-start</code>
         </div>
@@ -421,7 +254,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-items-center">
+    <div class="row flex-items-center">
         <div class="col">
             <code>.flex-*-items-center</code>
         </div>
@@ -433,7 +266,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-items-end">
+    <div class="row flex-items-end">
         <div class="col">
             <code>.flex-*-items-end</code>
         </div>
@@ -445,7 +278,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-items-stretch">
+    <div class="row flex-items-stretch">
         <div class="col">
             <code>.flex-*-items-stretch</code>
         </div>
@@ -457,14 +290,14 @@
         </div>
     </div>
 
-    <div class="row row-flex" style="height: 7rem;">
-        <div class="col flex-self-top">
+    <div class="row" style="height: 7rem;">
+        <div class="col flex-self-start">
             align top
         </div>
-        <div class="col flex-self-middle">
+        <div class="col flex-self-center">
             align middle
         </div>
-        <div class="col flex-self-bottom">
+        <div class="col flex-self-end">
             align bottom
         </div>
         <div class="col flex-self-stretch">
@@ -474,7 +307,7 @@
 
     <h2>Horizontal Flex Alignment</h2>
 
-    <div class="row row-flex flex-left">
+    <div class="row flex-start">
         <div class="col-4">
             aligned to
         </div>
@@ -483,7 +316,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-center">
+    <div class="row flex-center">
         <div class="col-4">
             aligned to
         </div>
@@ -492,7 +325,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-right">
+    <div class="row flex-end">
         <div class="col-4">
             aligned to
         </div>
@@ -501,7 +334,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-around">
+    <div class="row flex-around">
         <div class="col-4">
             aliged to
         </div>
@@ -510,7 +343,7 @@
         </div>
     </div>
 
-    <div class="row row-flex flex-between">
+    <div class="row flex-between">
         <div class="col-4">
             aligned to
         </div>


### PR DESCRIPTION
Updated grid to use flexbox for layout.  Bye bye floats!
Added `max-width: 100%`. to up `.container-fluid`.

Updated grid docs with new order and examples.
Updated grid doc example page.
Updated grid tests page.
Fixed breakpoint mixins for between and only.
Changed example where flexbox row is used on fieldsets- Flexbox layout bug.  However, this creates invalid nested location of `<legend>` element.  Need to investigate more.
