### PR TITLE
V3 card rework

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -119,19 +119,20 @@
     margin-left: -1rem;
 }
 .card-deck-col .card {
-    flex-basis: 100%;
+    flex-basis: auto;
+    width: calc(100% - 2rem);
     margin-right: 1rem;
     margin-bottom: 1rem;
     margin-left: 1rem;
 }
 @media (min-width: 35em) {
     .card-deck-col .card {
-        flex-basis: calc(50% - 2rem);
+        width: calc(50% - 2rem);
     }
 }
 @media (min-width: 62em) {
     .card-deck-col .card {
-        flex-basis: calc(25% - 2rem);
+        width: calc(25% - 2rem);
     }
 }
 

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -89,13 +89,75 @@ Links can placed next to each other with some spacing by adding `.card-link` to 
 
 ### Images
 
-`.card-img-top` places an image to the top of the card.
+Cards include a few options for working with images. Choose from embedding an image in a card, appending "image caps" at either end of a card, or overlaying images with card content.
+
+#### Standard Images
+
+Images can help add some visual interest to your cards.
 
 {% example html %}
-<div class="card">
-  <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
+<div class="card" style="width: 20rem;">
+  <h4 class="card-header">Sample Card</h4>
+  <img class="img-responsive" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image">
   <div class="card-body">
-    <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+    <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+  </div>
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="card" style="width: 20rem;">
+  <div class="card-body">
+    <h4 class="card-title">Card title</h4>
+    <p class="card-text">This is a card with text and a nested image.</p>
+    <img class="img-responsive mb-0_5" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image">
+    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+  </div>
+</div>
+{% endexample %}
+
+#### Image Caps
+
+Similar to headers and footers, cards can include top and bottom image caps.
+
+Use `.card-img-top` to round over the top corners when placing an image at the top of a card.
+
+{% example html %}
+<div class="card" style="width: 20rem;">
+  <img class="card-img-top img-responsive" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image cap">
+  <div class="card-body">
+    <h4 class="card-title">Card title</h4>
+    <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+  </div>
+</div>
+{% endexample %}
+
+Use `.card-img-bottom` to round over the bottom corners when placing an image at the bottom of a card.
+
+{% example html %}
+<div class="card" style="width: 20rem;">
+  <div class="card-body">
+    <h4 class="card-title">Card title</h4>
+    <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+  </div>
+  <img class="card-img-bottom img-responsive" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image cap">
+</div>
+{% endexample %}
+
+#### Image Overlay
+
+Turn an image into a card background and overlay your card's text. The use of `.card-img` will round over all corners of the image, and `.card-img-overlay` will allow content to overlay the image. Depending on the image, you may or may not need `.card-inverse` (see below).
+
+{% example html %}
+<div class="card card-inverse" style="width: 20rem;">
+  <img class="card-img" data-src="holder.js/100px225/?text=Image background" alt="Card image">
+  <div class="card-img-overlay">
+    <h4 class="card-title">Card title</h4>
+    <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+    <p class="card-text"><small>Last updated 3 mins ago</small></p>
   </div>
 </div>
 {% endexample %}
@@ -324,48 +386,6 @@ Add navigation items within a card's header (or block) with Figuration's [naviga
 </div>
 {% endexample %}
 
-## Images
-
-Cards include a few options for working with images. Choose from appending "image caps" at either end of a card, overlaying images with card content, or simply embedding the image in a card.
-
-### Image Caps
-
-Similar to headers and footers, cards include top and bottom image caps.
-
-{% example html %}
-<div class="card">
-  <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
-  <div class="card-body">
-    <h4 class="card-title">Card title</h4>
-    <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-  </div>
-</div>
-<div class="card">
-  <div class="card-body">
-    <h4 class="card-title">Card title</h4>
-    <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-  </div>
-  <img class="card-img-bottom img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
-</div>
-{% endexample %}
-
-### Image Overlays
-
-Turn an image into a card background and overlay your card's text. Depending on the image, you may or may not need `.card-inverse` (see below).
-
-{% example html %}
-<div class="card card-inverse">
-  <img class="card-img img-responsive" data-src="holder.js/100px270/#55595c:#373a3c/text:Card image" alt="Card image">
-  <div class="card-img-overlay">
-    <h4 class="card-title">Card title</h4>
-    <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-    <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
-  </div>
-</div>
-{% endexample %}
-
 ## Styling Cards
 
 Cards include various options for customizing their backgrounds, borders, and color.
@@ -542,7 +562,7 @@ Use card groups to render cards as a single, attached element with equal width a
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+      <p class="card-text">This card has supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>
@@ -558,22 +578,23 @@ Use card groups to render cards as a single, attached element with equal width a
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>
 </div>
 {% endexample %}
 
-When using card groups with footers, their content will automatically line up.
+When using card groups with footers, they will not automatically line up.  However, you can use the [Equalize widget]({{ site.baseurl }}/widgets/equalize) to achieve this layout.
 
 {% example html %}
-<div class="card-group">
+<div class="card-group" data-cfw="equalize" data-cfw-equalize-target=".card-body">
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+      <p class="card-text">This is a card with text and an image.</p>
+      <img class="img-responsive mb-0_5" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image">
     </div>
     <div class="card-footer">
       <small class="text-muted">Last updated 3 mins ago</small>
@@ -593,7 +614,7 @@ When using card groups with footers, their content will automatically line up.
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
     </div>
     <div class="card-footer">
       <small class="text-muted">Last updated 3 mins ago</small>
@@ -628,22 +649,23 @@ Need a set of equal width and height cards that aren't attached to one another? 
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>
 </div>
 {% endexample %}
 
-Just like with card groups, card footers in decks will automatically line up.
+Just like with card groups, card footers in decks will not automatically line up. Again, the [Equalize widget]({{ site.baseurl }}/widgets/equalize) can achieve this layout.
 
 {% example html %}
-<div class="card-deck">
+<div class="card-deck" data-cfw="equalize" data-cfw-equalize-target=".card-body">
   <div class="card">
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
+      <p class="card-text">This is a card with text and an image.</p>
+      <img class="img-responsive mb-0_5" src="{{ site.baseurl }}/assets/img/test.gif" alt="Card image">
     </div>
     <div class="card-footer">
       <small class="text-muted">Last updated 3 mins ago</small>
@@ -663,7 +685,7 @@ Just like with card groups, card footers in decks will automatically line up.
     <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
     </div>
     <div class="card-footer">
       <small class="text-muted">Last updated 3 mins ago</small>
@@ -676,9 +698,9 @@ Just like with card groups, card footers in decks will automatically line up.
 
 Controlling the number of cards in a row, based on the screen width is also possible using `flex-basis`.  Here is an example a way to achieve 1-across on `xs` screens, 2-across on `sm` and `md` screens, and 4-across on `lg` and up.
 
-**Heads Up!** In order for this to work, the width of the card deck gutter (margins) need to be accounted for when assigning the width with `flex-basis`.
+**Heads Up!** In order for this to work, the width of the card deck gutter (margins) need to be accounted for when assigning the `width`.  We are using `width` and `flex-basis: auto;` due to [Flexbug #8](https://github.com/philipwalton/flexbugs#8-flex-basis-doesnt-support-calc).
 
-{% example css html %}
+{% highlight scss %}
 <style>
 .card-deck-col {
     flex-flow: row wrap;
@@ -689,26 +711,25 @@ Controlling the number of cards in a row, based on the screen width is also poss
     margin-left: -1rem;
 }
 .card-deck-col .card {
-    flex-basis: 100%;
+    flex-basis: auto;
+    width: calc(100% - 2rem);
     margin-right: 1rem;
     margin-bottom: 1rem;
     margin-left: 1rem;
 }
-
 @media (min-width: 35em) {
     .card-deck-col .card {
-        /* need to account for card deck gutter */
-        flex-basis: calc(50% - 2rem);
+        width: calc(50% - 2rem);
     }
 }
 @media (min-width: 62em) {
     .card-deck-col .card {
-        /* need to account for card deck gutter */
-        flex-basis: calc(25% - 2rem);
+       width: calc(25% - 2rem);
     }
 }
 </style>
-
+{% endhighlight %}
+{% example html %}
 <div class="card-deck card-deck-col">
     <div class="card">
         <img class="card-img-top img-responsive" data-src="holder.js/100px150/" alt="Card image cap">
@@ -796,7 +817,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
     </div>
   </div>
   <div class="card">
-    <img class="card-img img-responsive" data-src="holder.js/100px260/" alt="Card image">
+    <img class="card-img" data-src="holder.js/100px260/" alt="Card image">
   </div>
   <div class="card text-right">
     <div class="card-body">
@@ -813,7 +834,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
   <div class="card">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
-      <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+      <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
       <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
     </div>
   </div>

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -14,7 +14,7 @@ A **card** is a flexible and extensible content container. It includes options f
 
 ## Example
 
-Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and customization. Built with flexbox, they offer easy alignment and mix well with other Figuration components.
+Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and customization.
 
 Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start, so they’ll naturally fill the full width of its parent element. This is easily customized with our various [sizing options](#sizing).
 

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -153,7 +153,7 @@ Turn an image into a card background and overlay your card's text. The use of `.
 
 {% example html %}
 <div class="card card-inverse" style="width: 20rem;">
-  <img class="card-img" data-src="holder.js/100px225/?text=Image background" alt="Card image">
+  <img class="card-img img-responsive" data-src="holder.js/100px225/?text=Image background" alt="Card image">
   <div class="card-img-overlay">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -817,7 +817,7 @@ Cards can be organized into [Masonry](http://masonry.desandro.com)-like columns 
     </div>
   </div>
   <div class="card">
-    <img class="card-img" data-src="holder.js/100px260/" alt="Card image">
+    <img class="card-img img-responsive" data-src="holder.js/100px260/" alt="Card image">
   </div>
   <div class="card text-right">
     <div class="card-body">

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -1,7 +1,6 @@
 .card {
     position: relative;
-    display: flex;
-    flex-direction: column;
+    display: block;
     margin-bottom: $card-spacer-y;
     background-color: $card-bg;
     border: $card-border-width solid $card-border-color;
@@ -9,7 +8,6 @@
 }
 
 .card-body {
-    flex: 1 1 auto;
     padding: $card-padding-y $card-padding-x;
 }
 

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -125,10 +125,7 @@
     border-left: 0;
 }
 
-// Card image
-.card-img {
-    @include border-radius($card-border-radius-inner);
-}
+// Card image overlay
 .card-img-overlay {
     position: absolute;
     top: 0;
@@ -138,13 +135,17 @@
     padding: $card-img-overlay-padding;
 }
 
-// Card image caps
+// Card images
+.card-img {
+    @include border-radius($card-border-radius-inner);
+}
 .card-img-top {
     @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
 }
 .card-img-bottom {
     @include border-radius(0 0 $card-border-radius-inner $card-border-radius-inner);
 }
+
 
 // Card deck
 // 1. Individual cards have margin-bottom by default.

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3511,7 +3511,7 @@ Anchor variants:<br />
 
     <h3>Card - image overlay</h3>
     <div class="card">
-      <img src="../assets/img/test.gif" class="card-img" alt="Card image" style="width: 100%; opacity: .3;">
+      <img src="../assets/img/test.gif" class="card-img img-responsive" alt="Card image" style="width: 100%; opacity: .3;">
       <div class="card-img-overlay">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
@@ -3786,7 +3786,7 @@ Anchor variants:<br />
     </div>
   </div>
   <div class="card">
-    <img class="card-img" data-src="holder.js/100px200" alt="Card image" />
+    <img class="card-img img-responsive" data-src="holder.js/100px200" alt="Card image" />
   </div>
   <div class="card text-right">
     <div class="card-body">

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3511,7 +3511,7 @@ Anchor variants:<br />
 
     <h3>Card - image overlay</h3>
     <div class="card">
-      <img src="../assets/img/test.gif" class="card-img img-responsive" alt="Card image" style="width: 100%; opacity: .3;">
+      <img src="../assets/img/test.gif" class="card-img" alt="Card image" style="width: 100%; opacity: .3;">
       <div class="card-img-overlay">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content.</p>
@@ -3786,7 +3786,7 @@ Anchor variants:<br />
     </div>
   </div>
   <div class="card">
-    <img class="card-img img-responsive" data-src="holder.js/100px200" alt="Card image" />
+    <img class="card-img" data-src="holder.js/100px200" alt="Card image" />
   </div>
   <div class="card text-right">
     <div class="card-body">
@@ -4198,9 +4198,9 @@ Anchor variants:<br />
 <strong>Single Slider:</strong>
 <div class="slider-sample">
     <form class="form-inline">
-        <div id="slider0">
+        <div id="slider0" class="d-flex flex-items-center">
             <div class="form-group">
-                <label id="slider0_0_Label" for="slider0_0">Value</label>
+                <label id="slider0_0_Label" for="slider0_0" class="mr-0_25">Value</label>
                 <input id="slider0_0" type="text" class="form-control" value="50" />
             </div>
         </div>
@@ -4217,14 +4217,14 @@ $('#slider0').CFW_Slider({
 <strong>Double Slider</strong>
 <div class="slider-sample">
     <form class="form-inline">
-        <div id="slider1">
-            <div class="form-group">
-                <label id="slider1_0_Label" for="slider1_0">Min</label>
+        <div id="slider1" class="d-flex flex-items-center">
+            <div class="form-group mr-0_25">
+                <label id="slider1_0_Label" for="slider1_0" class="mr-0_25">Min</label>
                 <input id="slider1_0" type="text" class="form-control" value="-25" />
             </div>
             <div class="form-group">
                 <input id="slider1_1" type="text" class="form-control" value="25" />
-                <label id="slider1_1_Label" for="slider1_1">Max</label>
+                <label id="slider1_1_Label" for="slider1_1" class="ml-0_25">Max</label>
             </div>
         </div>
     </form>
@@ -4241,9 +4241,9 @@ $('#slider1').CFW_Slider({
 <strong>Double Select Slider</strong>
 <div class="slider-sample">
     <form class="form-inline">
-        <div id="slider2">
-            <div class="form-group">
-                <label id="slider2_0_Label" for="slider2_0">Start</label>
+        <div id="slider2" class="d-flex flex-items-center">
+            <div class="form-group mr-0_25">
+                <label id="slider2_0_Label" for="slider2_0" class="mr-0_25">Start</label>
                 <select id="slider2_0" class="form-control">
                     <option value="12:00 am">12:00 am</option>
                     <option value="1:00 am">1:00 am</option>
@@ -4300,7 +4300,7 @@ $('#slider1').CFW_Slider({
                     <option value="11:00 pm">11:00 pm</option>
                     <option value="12:00 am">12:00 am</option>
                 </select>
-                <label id="slider2_1_Label" for="slider2_1">End</label>
+                <label id="slider2_1_Label" for="slider2_1" class="ml-0_25">End</label>
             </div>
         </div>
     </form>

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -52,7 +52,7 @@ Holder.addTheme("gray", {
 
     <div class="card-deck">
         <div class="card">
-            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -60,7 +60,7 @@ Holder.addTheme("gray", {
             </div>
         </div>
         <div class="card">
-            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -68,7 +68,7 @@ Holder.addTheme("gray", {
             </div>
         </div>
         <div class="card">
-            <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+            <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -115,7 +115,7 @@ Holder.addTheme("gray", {
 
     <div class="card-group">
       <div class="card">
-        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -123,7 +123,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -131,7 +131,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <img class="card-img-top" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
+        <img class="card-img-top img-responsive" data-src="holder.js/100px150/?text=Image Cap" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -228,20 +228,20 @@ Holder.addTheme("gray", {
         margin-bottom: 0;
     }
     .card-deck-col .card {
-        flex-basis: 100%;
+        flex-basis: auto;
+        width: calc(100% - 2rem);
+        margin-right: 1rem;
         margin-bottom: 1rem;
+        margin-left: 1rem;
     }
-
     @media (min-width: 35em) {
         .card-deck-col .card {
-            /* need to account for margin */
-            flex-basis: calc(50% - 2rem);
+            width: calc(50% - 2rem);
         }
     }
     @media (min-width: 62em) {
         .card-deck-col .card {
-            /* need to account for margin */
-            flex-basis: calc(25% - 2rem);
+           width: calc(25% - 2rem);
         }
     }
     </style>


### PR DESCRIPTION
Ok, so cards are being slightly reverted.  While using flexbox on the base card would be great, it does prevent some major issues with embedding some types of content.  Most notably images lose their aspect ratio across pretty much every browser.  This is related to [Flexbug #5](https://github.com/philipwalton/flexbugs#5-column-flex-items-dont-always-preserve-intrinsic-aspect-ratios).

Instead of fighting against this, and not getting very far with making images behave everywhere, I am going with the simpler solution of reverting the base `.card` back to `display: block;` to minimize the impact.  Otherwise it might mean taking on large amounts of tweaking layout for various pieces.

Also included:
- reworked the images in cards sections to consolidate
- reworked the responsive row example to work in IE 10+
- added equalize widget examples for footer alignment in groups/decks