### PR TITLE
Update print rules

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -1,4 +1,4 @@
-<header class="navbar navbar-expand-lg navbar-dark cf-header">
+<header class="navbar navbar-expand-lg navbar-dark print-hide cf-header">
     <nav class="container">
         <a class="navbar-brand" href="{{ site.baseurl }}/">CAST Figuration</a>
         <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#cf-topnav" aria-label="Toggle navigation">

--- a/scss/base/_print.scss
+++ b/scss/base/_print.scss
@@ -13,17 +13,29 @@
         *,
         *::before,
         *::after,
+        h1::first-letter,
+        h2::first-letter,
+        h3::first-letter,
+        h4::first-letter,
+        h5::first-letter,
+        h6::first-letter,
         p::first-letter,
         div::first-letter,
         blockquote::first-letter,
         li::first-letter,
+        h1::first-line,
+        h2::first-line,
+        h3::first-line,
+        h4::first-line,
+        h5::first-line,
+        h6::first-line,
         p::first-line,
         div::first-line,
         blockquote::first-line,
         li::first-line {
-            color: #000 !important; // Black prints faster: http://www.sanbeiji.com/archives/953
+            // color: #000 !important; // Black prints faster: http://www.sanbeiji.com/archives/953
             text-shadow: none !important;
-            background: transparent !important;
+            // background: transparent !important;
             box-shadow: none !important;
         }
 
@@ -32,14 +44,14 @@
             text-decoration: underline;
         }
 
-        a[href]::after {
-            content: " (" attr(href) ")";
-        }
+        // a[href]::after {
+        //     content: " (" attr(href) ")";
+        // }
 
-        a[href^="#"]::after,
-        a[href^="javascript:"]::after {
-            content: "";
-        }
+        // a[href^="#"]::after,
+        // a[href^="javascript:"]::after {
+        //     content: "";
+        // }
 
         abbr[title]::after {
             content: " (" attr(title) ")";
@@ -79,9 +91,6 @@
 
         // Figuration components start
 
-        .navbar {
-            display: none;
-        }
         .btn,
         .dropup > .btn {
             > .caret {


### PR DESCRIPTION
- Remove color overrides to allow end-user choice.
- Remove URL output - can cause bad/confusing user experience - let devs implement what they need.
- Remove forced hide of navbar - allow dev choice - this broke with the flexbox update anyway.
- Fix 'hanging' first letters in header items.

Printing is a problem in general due to browser inconsistency, and it is not currently worth trying to work-around the issues.