### PR TITLE
Drop system-ui from font stack

### DIFF
--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -41,9 +41,7 @@ The default web fonts (Helvetica Neue, Helvetica, and Arial) have been dropped i
 $font-family-sans-serif:
   // Safari for OS X and iOS (San Francisco)
   -apple-system,
-  // Chrome >= 56 for OS X (San Francisco), Windows, Linux and Android
-  system-ui,
-  // Chrome < 56 for OS X (San Francisco)
+  // Chrome for OS X (San Francisco)
   BlinkMacSystemFont,
   // Windows
   "Segoe UI",

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -247,7 +247,7 @@ $cursor-disabled:                not-allowed !default;
 // Typography
 // =====
 // Font, line-height, and color for body text, headings, and more.
-$font-family-sans-serif:    -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
+$font-family-sans-serif:    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
 $font-family-serif:         Georgia, "Times New Roman", Times, serif !default;
 $font-family-monospace:     Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:          $font-family-sans-serif !default;


### PR DESCRIPTION
It appears that using 'system-ui' in the font stack is bad,

Some additional references:
https://infinnie.github.io/blog/2017/systemui.html
http://css-tricks.com/snippets/css/system-font-stack