### PR TITLE
Remove IE9 related material

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,6 +1,5 @@
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <meta name="description" content="CAST Figuration - A feature rich, responsive, mobile first, accessible, front-end framework inspired by Bootstrap.">
 

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -136,7 +136,7 @@ Add `.progress-bar-striped` to any `.progress-bar` to apply a stripe via CSS gra
 
 The striped gradient can also be animated. Add `.progress-bar-animated` to `.progress-bar` to animate the stripes right to left via CSS3 animations.
 
-Animated progress bars are not available in browsers that do not support CSS3 animations, such as IE 9 or Opera 12.
+Animated progress bars are not available in browsers that do not support CSS3 animations.
 
 <div class="cf-example">
     <div class="progress">

--- a/docs/content/buttons.md
+++ b/docs/content/buttons.md
@@ -143,10 +143,6 @@ Buttons will appear pressed (with a darker background, darker border, and inset 
 
 Make buttons look inactive by adding the `disabled` boolean attribute to any `<button>` element.
 
-{% callout info %}
-**Heads up!** IE9 and below render disabled buttons with gray, shadowed text that we can't override.
-{% endcallout %}
-
 {% example html %}
 <strong>Standard Buttons:</strong>
 <p>

--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -1019,7 +1019,7 @@ Custom `<select>` menus need only a custom class, `.custom-select` to trigger th
 </select>
 {% endexample %}
 
-Custom selects degrade nicely in IE9, receiving only a handful of overrides to remove the custom `background-image`. **Multiple selects (e.g., `<select multiple>`) are not currently supported.**
+**Multiple selects (e.g., `<select multiple>`) are not currently supported.**
 
 Multiple size are also available.
 

--- a/docs/content/images.md
+++ b/docs/content/images.md
@@ -25,7 +25,7 @@ Images can be made to scale with their container width by using `.img-fluid`. Th
 {% endhighlight %}
 
 {% callout warning %}
-SVG Images and IE 9-10
+SVG Images and IE 10
 {:.h5}
 
 In Internet Explorer 10, SVG images with `.img-fluid` are disproportionately sized. To fix this, add `width: 100% \9;` where necessary. This fix improperly sizes other image formats, so we do not apply it automatically.

--- a/docs/content/reboot.md
+++ b/docs/content/reboot.md
@@ -309,7 +309,7 @@ The `<abbr>` element receives basic styling to make it stand out amongst paragra
 
 ## HTML5 `[hidden]` Attribute
 
-HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which is styled as `display: none` by default. Borrowing an idea from [PureCSS](https://purecss.io), we improve upon this default by making `[hidden] { display: none !important; }` to help prevent its `display` from getting accidentally overridden. While `[hidden]` isn't natively supported by IE9-10, the explicit declaration in our CSS gets around that problem.
+HTML5 adds [a new global attribute named `[hidden]`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden), which is styled as `display: none` by default. Borrowing an idea from [PureCSS](https://purecss.io), we improve upon this default by making `[hidden] { display: none !important; }` to help prevent its `display` from getting accidentally overridden. While `[hidden]` isn't natively supported by IE10, the explicit declaration in our CSS gets around that problem.
 
 {% highlight html %}
 <input type="text" hidden>

--- a/docs/examples/grid/index.html
+++ b/docs/examples/grid/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <!-- Required meta tags always come first -->
+        <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
 
         <title>Figuration Grid Examples</title>
 

--- a/docs/examples/navbar-fixed-top/index.html
+++ b/docs/examples/navbar-fixed-top/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<!-- Required meta tags always come first -->
+<!-- Required meta tags -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta http-equiv="x-ua-compatible" content="ie=edge">
 
 <title>Fixed Top Navbar Example</title>
 

--- a/docs/examples/navbar-static-top/index.html
+++ b/docs/examples/navbar-static-top/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<!-- Required meta tags always come first -->
+<!-- Required meta tags -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta http-equiv="x-ua-compatible" content="ie=edge">
 
 <title>Static Top Navbar Example</title>
 

--- a/docs/examples/navbars/index.html
+++ b/docs/examples/navbars/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<!-- Required meta tags always come first -->
+<!-- Required meta tags -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta http-equiv="x-ua-compatible" content="ie=edge">
 
 <title>Figuration Navbar Examples</title>
 

--- a/docs/examples/starter-template/index.html
+++ b/docs/examples/starter-template/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html lang="en-us">
     <head>
-        <!-- Required meta tags always come first -->
+        <!-- Required meta tags -->
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
 
         <title>Figuration Starter Template</title>
 

--- a/docs/get-started/browsers-devices.md
+++ b/docs/get-started/browsers-devices.md
@@ -14,7 +14,7 @@ Figuration supports a wide variety of modern browsers and devices, and some olde
 
 ## Supported Browsers
 
-Figuration supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 9-11 / Microsoft Edge**.
+Figuration supports the **latest, stable releases** of all major browsers and platforms. On Windows, **we support Internet Explorer 10-11 / Microsoft Edge**.
 
 Alternative browsers which use the latest version of WebKit, Blink, or Gecko, whether directly or via the platform's web view API, are not explicitly supported. However, Figuration should (in most cases) display and function correctly in these browsers as well. More specific support information is provided below.
 
@@ -91,7 +91,7 @@ Similarly, the latest versions of most desktop browsers are supported.
       <th scope="row">Windows</th>
       <td class="text-success">Supported</td>
       <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
+      <td class="text-success">Supported IE10+</td>
       <td class="text-success">Supported</td>
       <td class="text-success">Supported</td>
       <td class="text-danger">Not supported</td>
@@ -103,58 +103,13 @@ For Firefox, in addition to the latest normal stable release, we also support th
 
 Unofficially, Figuration should look and behave well enough in Chromium and Chrome for Linux, and Firefox for Linux, though they are not officially supported.
 
-For a list of some of the browser bugs that Bootstrap has to grapple with, see their [Wall of browser bugs](http://getbootstrap.com/browser-bugs/).
+## Internet Explorer
 
-## Internet Explorer 9 & 10
-
-Internet Explorer 9 & 10 are also supported, however, please be aware that some CSS3 properties and HTML5 elements are not fully supported.
-
-<table class="table table-scroll table-bordered table-striped">
-  <thead>
-    <tr>
-      <th scope="col">Feature</th>
-      <th scope="col">Internet Explorer 9</th>
-      <th scope="col">Internet Explorer 10</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/transition"><code>transition</code></a></th>
-      <td class="text-danger">Not supported</td>
-      <td class="text-success">Supported</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-placeholder"><code>placeholder</code></a></th>
-      <td class="text-danger">Not supported</td>
-      <td class="text-success">Supported</td>
-    </tr>
-    <tr>
-      <th scope="row"><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Using_CSS_flexible_boxes">Flexbox</a></th>
-      <td class="text-danger">Not supported</td>
-      <td class="text-warning">Partially supported, with <code>-ms</code> prefix<br><a href="http://caniuse.com/#feat=flexbox">See <em>Can I use</em> for details</a></td>
-    </tr>
-  </tbody>
-</table>
-
-Visit [Can I use...](http://caniuse.com/) for details on browser support of CSS3 and HTML5 features.
-
-## IE Compatibility Modes
-
-Figuration is not supported in the old Internet Explorer compatibility modes. To be sure you're using the latest rendering mode for IE, consider including the appropriate `<meta>` tag in your pages:
-
-{% highlight html %}
-<meta http-equiv="x-ua-compatible" content="ie=edge">
-{% endhighlight %}
-
-Confirm the document mode by opening the debugging tools: press <kbd>F12</kbd> and check the "Document Mode".
-
-This tag is included in all of Figuration's documentation and examples to ensure the best rendering possible in each supported version of Internet Explorer.
-
-See [this StackOverflow question](https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do) for more information.
+Internet Explorer 10+ are also supported, IE9 and down is not. Please be aware that some CSS3 properties and HTML5 elements are not fully supported in IE10, or require prefixed properties for full functionality. Visit [Can I use…](http://caniuse.com/) for details on browser support of CSS3 and HTML5 features.
 
 ## Internet Explorer 10 in Windows Phone 8
 
-Internet Explorer 10 in Windows Phone 8 versions older than [Update 3 (a.k.a. GDR3)](http://blogs.windows.com/windows_phone/b/wpdev/archive/2013/10/14/introducing-windows-phone-preview-for-developers.aspx) doesn't differentiate **device width** from **viewport width** in `@-ms-viewport` at-rules, and thus doesn't properly apply the media queries in Figuration's CSS. To address this, you'll need to **include the following JavaScript to work around the bug**.
+Internet Explorer 10 in Windows Phone 8 versions older than [Update 3 (a.k.a. GDR3)](http://blogs.windows.com/windows_phone/b/wpdev/archive/2013/10/14/introducing-windows-phone-preview-for-developers.aspx) doesn't differentiate **device width** from **viewport width** in `@-ms-viewport` at-rules, and thus doesn't properly apply the media queries in Figuration's CSS. To address this, you'll need to **include the following JavaScript, provided by Bootstrap, to work around the bug**.
 
 {% highlight js %}
 // Copyright 2014-2015 The Bootstrap Authors
@@ -187,7 +142,7 @@ As of iOS 9.2, while a modal is open, if the initial touch of a scroll gesture i
 
 ## Browser Zooming
 
-Page zooming inevitably presents rendering artifacts in some components, both in Bootstrap and the rest of the web. Depending on the issue, we may be able to fix it (search first and then open an issue if need be). However, we tend to ignore these as they often have no direct solution other than hacky workarounds.
+Page zooming inevitably presents rendering artifacts in some components, both in Figuration and the rest of the web. Depending on the issue, we may be able to fix it (search first and then open an issue if need be). However, we tend to ignore these as they often have no direct solution other than hacky workarounds.
 
 ## Sticky `:hover`/`:focus` on Mobile
 Even though real hovering isn't possible on most touchscreens, most mobile browsers emulate hovering support and make `:hover` "sticky". In other words, `:hover` styles start applying after tapping an element and only stop applying after the user taps some other element. On mobile-first sites, this behavior is normally undesirable.

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -43,10 +43,9 @@ Essentially something like this:
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
-    <!-- Required meta tags always come first -->
+    <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta http-equiv="x-ua-compatible" content="ie=edge">
 
     <!-- Figuration CSS -->
     <link rel="stylesheet" href="{{ site.cdn.css }}" integrity="{{ site.cdn.css_hash }}" crossorigin="anonymous">

--- a/docs/layout/flexbox.md
+++ b/docs/layout/flexbox.md
@@ -4,7 +4,7 @@ title: Flexbox
 group: layout
 ---
 
-Flexbox support is coming to Figuration.  The goal is to have both an opt-in system via classes, as well as a full option that forces the use of flexbox on supported components.
+Flexbox is now a full-time part of Figuration. Many components, but not all, are flexbox enabled. Flexbox allows for greater layout flexibility, making sizing and alignment of elements much easier.
 
 ## Contents
 {:.no_toc}
@@ -16,22 +16,21 @@ Flexbox support is coming to Figuration.  The goal is to have both an opt-in sys
 
 Flexbox support is available for a number of Figuration's components:
 
-- [Grid Layout]({{ site.baseurl }}/layout/grid/#flexbox), which switches from `float`s to `display: flex;`.
-- [Button Group]({{ site.baseurl }}/components/button-group/), which switches from `float`s to `display: flex;`.
-- [Button Toolbar]({{ site.baseurl }}/components/button-group/#button-toolbar), which switches from `float`s to `display: flex;`.
-- [Card]({{ site.baseurl }}/components/cards/), which switches from `block`s to `display: flex;`.
-- [Card Deck]({{ site.baseurl }}/components/cards/#card-decks), which switches from `display: table;` to `display: flex;`.
-- [Card Group]({{ site.baseurl }}/components/cards/#card-groups), which switches from `display: table;` to `display: flex;`.
-- [Grid Lines]({{ site.baseurl }}/components/grid-lines/), which switches from `display: table;` to `display: flex;`.
-- [Inline Forms]({{ site.baseurl }}/content/forms/#inline-forms), which switches from `display: inline-block;` to `display: flex;`.
-- [Input Group]({{ site.baseurl }}/components/input-group/), which switches from `display: table;` to `display: flex;`.
-- [List Group]({{ site.baseurl }}/components/list-group/), which switches from `block`s to `display: flex;`.
-- [Media Object]({{ site.baseurl }}/components/media-object/), which switches from `display: table;` to `display: flex;`.
-- [Navs]({{ site.baseurl }}/components/navs/), which switches from `float`s to `display: flex;`.
-- [Navbar Group]({{ site.baseurl }}/components/navbar/#navbar-group), which switches from `display: table;` to `display: flex;`.
-- [Pagination]({{ site.baseurl }}/components/pagination/), which switches from `display: inline-block;` to `display: flex;`.
-- [Progress]({{ site.baseurl }}/components/progress/), which switches from `display: block;` to `display: flex;`.
-- [Utility classes]({{ site.baseurl }}/utilities/flexbox/), for alignment options for flexbox enabled components.
+- [Grid Layout]({{ site.baseurl }}/layout/grid/#flexbox)
+- [Button Group]({{ site.baseurl }}/components/button-group/)
+- [Button Toolbar]({{ site.baseurl }}/components/button-group/#button-toolbar)
+- [Card Deck]({{ site.baseurl }}/components/cards/#card-decks)
+- [Card Group]({{ site.baseurl }}/components/cards/#card-groups)
+- [Grid Lines]({{ site.baseurl }}/components/grid-lines/)
+- [Inline Forms]({{ site.baseurl }}/content/forms/#inline-forms)
+- [Input Group]({{ site.baseurl }}/components/input-group/)
+- [List Group]({{ site.baseurl }}/components/list-group/)
+- [Media Object]({{ site.baseurl }}/components/media-object/)
+- [Navs]({{ site.baseurl }}/components/navs/)
+- [Navbar]({{ site.baseurl }}/components/navbar/)
+- [Pagination]({{ site.baseurl }}/components/pagination/)
+- [Progress]({{ site.baseurl }}/components/progress/)
+- [Flexbox Utilities]({{ site.baseurl }}/utilities/flexbox/)
 
 Vendor prefixes are provided in our compiled CSS with [Autoprefixer](https://github.com/postcss/autoprefixer) via Grunt. Some bugs in IE10-11's Flexbox implementation are worked around via [postcss-flexbugs-fixes](https://github.com/luisrudge/postcss-flexbugs-fixes).
 
@@ -45,51 +44,12 @@ In a nutshell, flexbox provides simpler and more flexible layout options in CSS.
 
 All these things are possible outside flexbox, but typically require extra hacks and workarounds to do right.
 
-## Opt-in Flexbox Mode
-
-The opt-in mode is compiled into Figuration's base CSS by default.  This can be controlled by changing the `$enable-flex-opt` Sass variable.
-
-To use the opt-in mode, simply add another class to parent element. An example would be to use the grid layout in flexbox mode, you would add a `.row-flex` class to the `.row` element.  More information and caveats can be found in the documentation for each component, see the [What's Included section](#whats-included) above.
-
-A quick list of the opt-in classes are:
-
-- `.row-flex`
-- `.btn-group-flex`
-- `.btn-group-vertical-flex`
-- `.btn-toolbar-flex`
-- `.card-flex`
-- `.card-deck-flex`
-- `.card-group-flex`
-- `.form-inline-flex`
-- `.gridline-flex`
-- `.input-group-flex`
-- `.list-group-flex`
-- `.media-flex`
-- `.nav-flex`
-- `.navbar-group-flex`
-- `.pagination-flex`
-- `.progress-flex`
-
-## Full Flexbox Mode
-
-If you're familiar with modifying variables in Sass---or any other CSS preprocessor---you'll be right at home to move into flexbox mode.  Compiling the Sass in full flexbox mode will not generate the opt-in flexbox classes, as they are no longer needed.
-
-1. Open the `_settings.scss` file and find the `$enable-flex-full` variable.
-    - You may also copy the setting into the `_custom.scss` file if you wish to use a custom configuration.
-2. Change it from `false` to `true`.
-3. Recompile, and done!
-
-{% comment %}
-Alternatively, if you don't need the source Sass files, you may swap the default Figuration compiled CSS with the compiled flexbox variation. [Head to the download page]({{ site.baseurl }}/get-started/download) for more information.
-{% endcomment %}
-
 ## Browser Support
 
-Using/enabling flexbox means **reduced browser and device support:**
+Using flexbox means **reduced browser and device support**, but mostly for older technology.
 
-- Internet Explorer 9 and below do not support flexbox.
-- Internet Explorer 10 has a few known quirks (see the "Known issues" tab in [Can I use...](http://caniuse.com/#feat=flexbox)), requires using a prefix, and only supports the syntax from the old 2012 version of the spec.
-
-Please be extra conscious of your user base when enabling flexbox in your project. Visit [Can I use...](http://caniuse.com/#feat=flexbox) for details on browser support of flexbox.
+Visit [Can I use...](http://caniuse.com/#feat=flexbox) for details on browser support of flexbox.
 
 There are also a number of browser bugs and cross-browser issues with flexbox.  Some of which do not have possible workarounds, while there are other that do.  Check out the [Flexbugs](https://github.com/philipwalton/flexbugs) repository for additional information.
+
+Be aware that Internet Explorer 10 has a few known quirks and only supports the syntax from the old 2012 version of the spec.

--- a/js/player.js
+++ b/js/player.js
@@ -40,7 +40,6 @@
         var elem = document.createElement('video');
         var bool = false;
 
-        // IE9 Running on Windows Server SKU can cause an exception to be thrown, bug #224
         try {
             if (bool = !!elem.canPlayType) {
                 bool = new Boolean(bool);

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -716,12 +716,9 @@
             var height = $tip[0].getBoundingClientRect().height;
 
             // manually read margins because getBoundingClientRect includes difference
-            var marginTop = parseInt($tip.css('margin-top'), 10);
-            var marginLeft = parseInt($tip.css('margin-left'), 10);
-
-            // we must check for NaN for IE 9
-            if (isNaN(marginTop))  marginTop  = 0;
-            if (isNaN(marginLeft)) marginLeft = 0;
+            // includes protection against NaN
+            var marginTop = parseInt($tip.css('margin-top'), 10) || 0;
+            var marginLeft = parseInt($tip.css('margin-left'), 10) || 0;
 
             offset.top  = offset.top  + marginTop;
             offset.left = offset.left + marginLeft;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -9,7 +9,6 @@
 @import "mixins/breakpoints";
 @import "mixins/hover";
 @import "mixins/images";
-@import "mixins/reset-filter";
 @import "mixins/screen-reader";
 @import "mixins/reset-text";
 @import "mixins/text-emphasis";

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -19,7 +19,7 @@
         content: "#{$breadcrumb-divider}";
     }
 
-    // IE9-11 hack to properly handle hyperlink underlines for breadcrumbs built
+    // IE10-11 hack to properly handle hyperlink underlines for breadcrumbs built
     // without `<ul>`s. The `::before` pseudo-element generates an element
     // *within* the .breadcrumb-item and thereby inherits the `text-decoration`.
     //

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -90,7 +90,6 @@
         cursor: $cursor-disabled;
         background-color: $dropdown-link-disabled-bg;
         background-image: none; // Remove CSS gradient
-        @include reset-filter();
     }
 }
 

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -122,17 +122,14 @@
 
 // Select
 // Replaces the browser default select with a custom one.
-// Includes IE9-specific hacks (noted by ` \9`).
 .custom-select {
     display: block;
     width: 100%;
     height: $select-height;
     padding: $input-padding-y (($input-padding-x / 2) + $custom-select-indicator-padding) $input-padding-y ($input-padding-x / 2);
-    padding-right: ($input-padding-x / 2) \9;
     color: $input-color;
     vertical-align: middle;
     background: $input-bg $custom-select-indicator no-repeat right ($input-padding-x / 2) center;
-    background-image: none \9;
     background-size: $custom-select-indicator-size;
     border: $input-border-width solid $input-border-color;
     @include border-radius($input-border-radius);
@@ -184,7 +181,6 @@
             height: $sz-select-height;
             padding: $sz-padding-y ($sz-padding-x / 2);
             padding-right: ($sz-padding-x + $custom-select-indicator-padding);
-            padding-right: ($sz-padding-x / 2) \9;
             font-size: $sz-font-size;
             background-position: right ($sz-padding-x / 2) center;
         }

--- a/scss/mixins/_gradients.scss
+++ b/scss/mixins/_gradients.scss
@@ -2,20 +2,16 @@
 
 // Horizontal gradient, from left to right
 // Creates two color stops, start and end, by specifying a color and position for each color stop.
-// Color stops are not available in IE9.
 @mixin gradient-x($start-color: #555, $end-color: #333, $start-percent: 0%, $end-percent: 100%) {
     background-image: linear-gradient(to right, $start-color $start-percent, $end-color $end-percent);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}', GradientType=1); // IE9
 }
 
 // Vertical gradient, from top to bottom
 // Creates two color stops, start and end, by specifying a color and position for each color stop.
-// Color stops are not available in IE9.
 @mixin gradient-y($start-color: #555, $end-color: #333, $start-percent: 0%, $end-percent: 100%) {
     background-image: linear-gradient(to bottom, $start-color $start-percent, $end-color $end-percent);
     background-repeat: repeat-x;
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}', GradientType=0); // IE9
 }
 
 @mixin gradient-directional($start-color: #555, $end-color: #333, $deg: 45deg) {
@@ -24,26 +20,18 @@
 }
 
 // Striped diagonal gradient
-// IE9 uses svg background from http://www.patternify.com/ -- http://ptrn.it/26ZRweI
-// scss-lint:disable DuplicateProperty
 @mixin gradient-striped($color: rgba(255,255,255,.15), $angle: 135deg) {
-    // IE9
-    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAARUlEQVQYV43QwQ0AIAhDUTuT+4/ATBg4GIuAcu3LP4BRnKrOc0LmIjJzwRQBQrBCVOzQhi/k8AelEIDET1iMihWiYocMLqDbL/tU0QugAAAAAElFTkSuQmCC");
-    // Others
     background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
 }
-// scss-lint:enable DuplicateProperty
 
 
 //@mixin gradient-x-three-colors($start-color: #00b3ee, $mid-color: #7a43b6, $color-stop: 50%, $end-color: #c3325f) {
 //    background-image: linear-gradient(to right, $start-color, $mid-color $color-stop, $end-color);
 //    background-repeat: no-repeat;
-//    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}', GradientType=1); // IE9 gets no color-stop at all for proper fallback
 //}
 //@mixin gradient-y-three-colors($start-color: #00b3ee, $mid-color: #7a43b6, $color-stop: 50%, $end-color: #c3325f) {
 //    background-image: linear-gradient($start-color, $mid-color $color-stop, $end-color);
 //    background-repeat: no-repeat;
-//    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#{ie-hex-str($start-color)}', endColorstr='#{ie-hex-str($end-color)}', GradientType=0); // IE9 gets no color-stop at all for proper fallback
 //}
 //@mixin gradient-radial($inner-color: #555, $outer-color: #333) {
 //    background-image: radial-gradient(circle, $inner-color, $outer-color);

--- a/scss/mixins/_images.scss
+++ b/scss/mixins/_images.scss
@@ -19,7 +19,7 @@
     // There's no such thing as unprefixed min-device-pixel-ratio since it's nonstandard.
     // Compatibility info: http://caniuse.com/#feat=css-media-resolution
     @media
-    only screen and (min-resolution: 192dpi), // IE9-11 doesn't support dppx
+    only screen and (min-resolution: 192dpi), // IE10-11 doesn't support dppx
     only screen and (min-resolution: 2dppx) { // Standardized
         background-image: url($file-2x);
         background-size: $width-1x $height-1x;

--- a/scss/mixins/_reset-filter.scss
+++ b/scss/mixins/_reset-filter.scss
@@ -1,8 +1,0 @@
-// Reset filters for IE
-//
-// When you need to remove a gradient background, do not forget to use this to reset
-// the IE filter for IE9.
-
-@mixin reset-filter() {
-    filter: "progid:DXImageTransform.Microsoft.gradient(enabled = false)";
-}

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration Widget: Player</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration Widget: Player</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 <link rel="stylesheet" href="../../docs/assets/fonts/font-awesome/css/font-awesome.min.css">

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration Style Tests</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration Style Tests</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration Widget Tests</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration Widget Tests</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-button.html
+++ b/test/visual/flexbox-button.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Button Group</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Button Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-cards.html
+++ b/test/visual/flexbox-cards.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Cards</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Cards</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-form-inline.html
+++ b/test/visual/flexbox-form-inline.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Inline Forms</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Inline Forms</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-grid.html
+++ b/test/visual/flexbox-grid.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Grid</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Grid</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-input.html
+++ b/test/visual/flexbox-input.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Input Group</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Input Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-list-group.html
+++ b/test/visual/flexbox-list-group.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox List Group</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox List Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-media.html
+++ b/test/visual/flexbox-media.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Media Object</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Media Object</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-nav.html
+++ b/test/visual/flexbox-nav.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Navs</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Navs</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-navbar.html
+++ b/test/visual/flexbox-navbar.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Navbar</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Navbar</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-pagination.html
+++ b/test/visual/flexbox-pagination.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Pagination</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Pagination</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/flexbox-progress.html
+++ b/test/visual/flexbox-progress.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Progress</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Progress</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -1,11 +1,10 @@
 ﻿<!DOCTYPE html>
 <html lang="en-us">
 <head>
-<title>Figuration - Flexbox Input Group</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+<title>Figuration - Flexbox Input Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 


### PR DESCRIPTION
Removed a whole bunch of IE9 related wording, comments, and code.

- Removed most mentions of IE9 from the docs.
- Removed IE9 related 'hacks' from the scss.
- Tweaked a few items in the JS.
- Simplified the `<head>` meta tags, and fixed some ordering. Removed the `x-ua-compatible` item as it is no longer needed, and IE10 defaults to edge mode in most cases, and deprecated in IE11.  Also shortened the `content-type` designator as both are equivalent in HTML5.
  Old:
  `<meta http-equiv="x-ua-compatible" content="ie=edge">`
  `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`
  `<meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">`
  New:
  `<meta charset="utf-8">`
  `<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">`
