### PR TITLE
v3: JS - update toggle and target options

### DIFF
--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -1,7 +1,7 @@
 <header class="navbar navbar-expand-lg navbar-dark print-hide cf-header">
     <nav class="container">
         <a class="navbar-brand" href="{{ site.baseurl }}/">CAST Figuration</a>
-        <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#cf-topnav" aria-label="Toggle navigation">
+        <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-target="#cf-topnav" aria-label="Toggle navigation">
             <span class="icon-menu" aria-hidden="true">&#8801;</span>
         </button>
         <div class="navbar-collapse collapse" id="cf-topnav">

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -151,10 +151,10 @@ Place a `.btn-group` within another `.btn-group` when you want dropdown menus mi
   <button type="button" class="btn">2</button>
 
   <div class="btn-group" role="group">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupDrop1">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
       Dropdown
     </button>
-    <ul class="dropdown-menu" id="btnGroupDrop1">
+    <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       <li><a class="dropdown-item" href="#">Dropdown link</a></li>
     </ul>
@@ -171,10 +171,10 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
     <button type="button" class="btn">Button</button>
     <button type="button" class="btn">Button</button>
     <div class="btn-group" role="group">
-      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop1">
+      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
         Dropdown
       </button>
-      <ul class="dropdown-menu" id="btnGroupVerticalDrop1">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       </ul>
@@ -182,28 +182,28 @@ Make a set of buttons appear vertically stacked rather than horizontally. **Spli
     <button type="button" class="btn">Button</button>
     <button type="button" class="btn">Button</button>
     <div class="btn-group" role="group">
-      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop2">
+      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
         Dropdown
       </button>
-      <ul class="dropdown-menu" id="btnGroupVerticalDrop2">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       </ul>
     </div>
     <div class="btn-group" role="group">
-      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop3">
+      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
         Dropdown
       </button>
-      <ul class="dropdown-menu" id="btnGroupVerticalDrop3">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       </ul>
     </div>
     <div class="btn-group" role="group">
-      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop1">
+      <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
         Dropdown
       </button>
-      <ul class="dropdown-menu" id="btnGroupVerticalDrop4">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
         <li><a class="dropdown-item" href="#">Dropdown link</a></li>
       </ul>

--- a/docs/components/input-group.md
+++ b/docs/components/input-group.md
@@ -159,10 +159,10 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
   <div class="col-lg-6">
     <div class="input-group">
       <div class="input-group-btn">
-        <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#inputGroupDropdown1">
+        <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu" id="inputGroupDropdown1">
+        <ul class="dropdown-menu">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -177,10 +177,10 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with dropdown button">
       <div class="input-group-btn">
-        <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#inputGroupDropdown2">
+        <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu dropdown-menu-right" id="inputGroupDropdown2">
+        <ul class="dropdown-menu dropdown-menu-right">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -201,10 +201,10 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
     <div class="input-group">
       <div class="input-group-btn">
         <button type="button" class="btn">Action</button>
-        <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown" data-cfw-dropdown-toggle="#inputGroupDropdown3">
+        <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu" id="inputGroupDropdown3">
+        <ul class="dropdown-menu">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -220,10 +220,10 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
       <input type="text" class="form-control" aria-label="Text input with segmented button dropdown">
       <div class="input-group-btn">
         <button type="button" class="btn">Action</button>
-        <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown" data-cfw-dropdown-toggle="#inputGroupDropdown4">
+        <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-right" id="inputGroupDropdown4">
+        <ul class="dropdown-menu dropdown-menu-right">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -45,7 +45,7 @@ The most basic example of a `.navbar` is one that never expands, no matter the s
 
 <div class="cf-example">
   <nav class="navbar navbar-light bg-faded mb-1">
-      <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB0">
+      <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB0">
           <span aria-hidden="true">&#8801;</span>
       </button>
       <a href="#" class="navbar-brand ml-0_5">Never Expand</a>
@@ -67,7 +67,7 @@ The most basic example of a `.navbar` is one that never expands, no matter the s
 
   <nav class="navbar navbar-light bg-faded flex-between">
       <a href="#" class="navbar-brand">Never Expand</a>
-      <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB1">
+      <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB1">
           <span aria-hidden="true">&#8801;</span>
       </button>
 
@@ -88,7 +88,7 @@ The most basic example of a `.navbar` is one that never expands, no matter the s
 </div>
 {% highlight html %}
 <nav class="navbar navbar-light bg-faded">
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB0">
         <span aria-hidden="true">&#8801;</span>
     </button>
     <a href="#" class="navbar-brand ml-0_5">Never Expand</a>
@@ -110,7 +110,7 @@ The most basic example of a `.navbar` is one that never expands, no matter the s
 
 <nav class="navbar navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Never Expand</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB1">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB1">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -137,7 +137,7 @@ Be default, navbars start out collapsed, but when the target breakpoint is reach
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR0">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR0">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -166,7 +166,7 @@ With the `.navbar-brand` in the collapsing area.
 
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded">
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR1">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR1">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -210,7 +210,7 @@ Here's an example of some sub-components included in a default, light navbar:
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar0">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar0">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -288,7 +288,7 @@ Add `.active` directly to a `.nav-link`, to indicate a certain state, such as th
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <div class="navbar-brand">Navbar</div>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar1">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar1">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -316,7 +316,7 @@ And because we use classes for our navs, you can avoid the list-based approach e
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
  <div class="navbar-brand">Navbar</div>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar2">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar2">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -340,7 +340,7 @@ If a dropdown is displayed in a non-expanded navbar, they will display 'inline' 
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar3">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar3">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -444,7 +444,7 @@ You can also use utility classes to align navbar text to other navbar elements l
 {% example html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar6">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar6">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -481,7 +481,7 @@ Please refer to the [Accessiblity notes about disabled anchors]({{ site.baseurl 
 <div class="cf-example">
   <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between mb-1">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar7">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar7">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -502,7 +502,7 @@ Please refer to the [Accessiblity notes about disabled anchors]({{ site.baseurl 
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar8">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar8">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -524,7 +524,7 @@ Please refer to the [Accessiblity notes about disabled anchors]({{ site.baseurl 
 {% highlight html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar7">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar7">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -545,7 +545,7 @@ Please refer to the [Accessiblity notes about disabled anchors]({{ site.baseurl 
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar8">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar8">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -572,7 +572,7 @@ Place a visual separator between segments of the navbar.
 <div class="cf-example">
   <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between mb-1">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar9">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar9">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -589,7 +589,7 @@ Place a visual separator between segments of the navbar.
 
   <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar10">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar10">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -607,7 +607,7 @@ Place a visual separator between segments of the navbar.
 {% highlight html %}
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar9">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar9">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -624,7 +624,7 @@ Place a visual separator between segments of the navbar.
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between">
   <a href="#" class="navbar-brand">Navbar</a>
-  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar10">
+  <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar10">
     <span aria-hidden="true">&#8801;</span>
   </button>
 
@@ -646,7 +646,7 @@ Our [Collapse widget]({{ site.baseurl }}/widgets/collapse/) can also to toggle h
 
 {% example html %}
 <nav class="navbar navbar-light bg-faded">
-  <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar" aria-label="Toggle navigation">
+  <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-target="#exCollapsingNavbar" aria-label="Toggle navigation">
     <span aria-hidden="true">&#8801;</span>
   </button>
   <div class="collapse w-100 mt-0_5" id="exCollapsingNavbar">
@@ -667,7 +667,7 @@ Here are some examples to show what we mean.
 <div class="bd-example">
   <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between mb-1">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar11">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar11">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -691,7 +691,7 @@ Here are some examples to show what we mean.
   </nav>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary flex-between mb-1">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar12">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar12">
       <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -715,7 +715,7 @@ Here are some examples to show what we mean.
   </nav>
   <nav class="navbar navbar-expand-lg navbar-light flex-between mb-1" style="background-color: #e3f2fd;">
     <a href="#" class="navbar-brand">Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbar13">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbar13">
       <span aria-hidden="true">&#8801;</span>
     </button>
 

--- a/docs/components/navs.md
+++ b/docs/components/navs.md
@@ -280,8 +280,8 @@ For accessibility reasons, do not mix use of the [Tab widget]({{ site.baseurl }}
     <a href="#" class="nav-link active">Active</a>
   </li>
   <li class="nav-item dropdown">
-    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#navDropdown1">Dropdown</a>
-    <ul class="dropdown-menu" id="navDropdown1">
+    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+    <ul class="dropdown-menu">
       <li><a href="#" class="dropdown-item">Action</a></li>
       <li><a href="#" class="dropdown-item">Another action</a></li>
       <li><a href="#" class="dropdown-item">Something else here</a></li>
@@ -306,8 +306,8 @@ For accessibility reasons, do not mix use of the [Tab widget]({{ site.baseurl }}
     <a href="#" class="nav-link active">Active</a>
   </li>
   <li class="nav-item dropdown">
-    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#navDropdown2">Dropdown</a>
-    <ul class="dropdown-menu" id="navDropdown2">
+    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+    <ul class="dropdown-menu">
       <li><a href="#" class="dropdown-item">Action</a></li>
       <li><a href="#" class="dropdown-item">Another action</a></li>
       <li><a href="#" class="dropdown-item">Something else here</a></li>

--- a/docs/examples/navbar-fixed-top/index.html
+++ b/docs/examples/navbar-fixed-top/index.html
@@ -29,7 +29,7 @@ body {
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between fixed-top">
     <a href="#" class="navbar-brand">Static Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR3">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR3">
         <span aria-hidden="true">&#8801;</span>
     </button>
 

--- a/docs/examples/navbar-static-top/index.html
+++ b/docs/examples/navbar-static-top/index.html
@@ -25,7 +25,7 @@ body {
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-inverse flex-between">
     <a href="#" class="navbar-brand">Static Navbar</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR3">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR3">
         <span aria-hidden="true">&#8801;</span>
     </button>
 

--- a/docs/examples/navbars/index.html
+++ b/docs/examples/navbars/index.html
@@ -46,7 +46,7 @@
 <h2>Basic Navbars</h2>
 
 <nav class="navbar navbar-light bg-faded">
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB0">
         <span aria-hidden="true">&#8801;</span>
     </button>
     <a href="#" class="navbar-brand ml-0_5">Basic</a>
@@ -81,7 +81,7 @@
 
 <nav class="navbar navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Basic</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB1">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB1">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -117,7 +117,7 @@
 
 <nav class="navbar navbar-expand navbar-light bg-faded">
     <a href="#" class="navbar-brand">Expand Always</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -151,7 +151,7 @@
 
 <nav class="navbar navbar-expand-sm navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `sm`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR1">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR1">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -185,7 +185,7 @@
 
 <nav class="navbar navbar-expand-md navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `md`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR2">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR2">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -219,7 +219,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `lg`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR3">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR3">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -253,7 +253,7 @@
 
 <nav class="navbar navbar-expand-xl navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `xl`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR4">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR4">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -289,7 +289,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Justified</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarJ0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarJ0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -326,7 +326,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <div class="container">
         <a href="#" class="navbar-brand">Container</a>
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarC0">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarC0">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -362,7 +362,7 @@
 <h2>Centered Navbars</h2>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded">
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarCO0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarCO0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -392,7 +392,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded">
     <div class="container">
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarCO1">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarCO1">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -426,7 +426,7 @@
 
     <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
         <a href="#" class="navbar-brand">Expand at `lg`</a>
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarIC0">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarIC0">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -459,7 +459,7 @@
     </nav>
 
     <nav class="navbar navbar-expand-lg navbar-light bg-faded">
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarIC1">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarIC1">
             <span aria-hidden="true">&#8801;</span>
         </button>
 

--- a/docs/widgets/accordion.md
+++ b/docs/widgets/accordion.md
@@ -31,16 +31,16 @@ A simple accordion.
 
 {% example html %}
 <div data-cfw="accordion">
-    <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion0">Collapse Toggle #1</a></h4>
-    <div class="collapse" data-cfw-collapse-target="accordion0">
+    <h4><a href="#accordion0" data-cfw="collapse" class="open">Collapse Toggle #1</a></h4>
+    <div id="accordion0" class="collapse">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
     </div>
-    <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion1">Collapse Toggle #2</a></h4>
-    <div class="collapse" data-cfw-collapse-target="accordion1">
+    <h4><a href="#accordion1" data-cfw="collapse">Collapse Toggle #2</a></h4>
+    <div id="accordion1" class="collapse">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
     </div>
-    <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion2">Collapse Toggle #3</a></h4>
-    <div class="collapse" data-cfw-collapse-target="accordion2">
+    <h4><a href="#accordion2" data-cfw="collapse">Collapse Toggle #3</a></h4>
+    <div id="accordion2" class="collapse">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
     </div>
 </div>
@@ -54,9 +54,11 @@ Here some cards are used to add a bit of layout.
 <div data-cfw="accordion">
     <div class="card mb-0">
         <div class="card-header">
-            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card0">Collapse Toggle #1</a></h4>
+            <h4 class="mb-0">
+                <a href="#card0" data-cfw="collapse" class="open">Collapse Toggle #1</a>
+            </h4>
         </div>
-        <div class="collapse" data-cfw-collapse-target="card0">
+        <div id="card0" class="collapse">
             <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>
@@ -64,9 +66,11 @@ Here some cards are used to add a bit of layout.
     </div>
     <div class="card mb-0">
         <div class="card-header">
-            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card1">Collapse Toggle #2</a></h4>
+            <h4 class="mb-0">
+                <a href="#card1" data-cfw="collapse">Collapse Toggle #2</a>
+            </h4>
         </div>
-        <div class="collapse" data-cfw-collapse-target="card1">
+        <div id="card1" class="collapse">
             <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>
@@ -74,9 +78,11 @@ Here some cards are used to add a bit of layout.
     </div>
     <div class="card mb-0">
         <div class="card-header">
-            <h4 class="mb-0"><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="card2">Collapse Toggle #3</a></h4>
+            <h4 class="mb-0">
+                <a href="#card2" data-cfw="collapse">Collapse Toggle #3</a>
+            </h4>
         </div>
-        <div class="collapse" data-cfw-collapse-target="card2">
+        <div id="card2" class="collapse">
             <div class="card-body">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.
             </div>

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -20,8 +20,8 @@ Click the buttons below to show and hide another element via class changes.
 ### Basic
 
 {% example html %}
-<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-toggle="collapseEx1">Collapse <span class="caret"></span></button>
-<div class="collapse" data-cfw-collapse-target="collapseEx1">
+<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-target="#collapseEx1">Collapse <span class="caret"></span></button>
+<div id="collapseEx1" class="collapse">
     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem.</p>
 </div>
 {% endexample %}
@@ -29,12 +29,12 @@ Click the buttons below to show and hide another element via class changes.
 
 ### Multiple Triggers
 
-You can assign multiple triggers to control one collapse target, but you either need to use the `data-cfw-collapse-toggle` and matching `data-cfw-collapse-target` attributes, or matching `href` attributes with the associated `id`, so that the toggle and target states are all synchronised.
+You can assign multiple triggers to control one collapse target. It is required to use either the `data-cfw-collapse-target` or `href` attributes in order for all the control triggers, and target states to become synchronised.
 
 {% example html %}
-<a href="#" role="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-toggle="multi-collapse">Trigger 1 <span class="caret"></span></a>
-<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-toggle="multi-collapse">Trigger 2 <span class="caret"></span></button>
-<div data-cfw-collapse-target="multi-collapse">
+<a href="#" role="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-target="#multi-collapse">Trigger 1 <span class="caret"></span></a>
+<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-target="#multi-collapse">Trigger 2 <span class="caret"></span></button>
+<div id="multi-collapse">
     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
 </div>
 {% endexample %}
@@ -44,7 +44,7 @@ Using `id` and matching `href` attributes.
 {% example html %}
 <a href="#href-collapse" role="button" class="btn btn-outline-primary" data-cfw="collapse">ID Trigger 1 <span class="caret"></span></a>
 <a href="#href-collapse" role="button" class="btn btn-outline-primary" data-cfw="collapse">ID Trigger 2 <span class="caret"></span></a>
-<div id="href-collapse">
+<div id="href-collapse" class="collapse">
     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
 </div>
 {% endexample %}
@@ -55,8 +55,8 @@ Using `id` and matching `href` attributes.
 A horizontal variant of a collapse can be invoked by placing a class of `width` on the collapse target, or by using the data attribute `data-cfw-collapse-horizontal="true"` on the trigger.  A child container with a fixed dimension width (not a percentage) is needed for proper animation.
 
 {% example html %}
-<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-toggle="collapseEx2" data-cfw-collapse-horizontal="true">Collapse <span class="caret"></span></button>
-<div class="collapse width" data-cfw-collapse-target="collapseEx2">
+<button type="button" class="btn btn-outline-primary" data-cfw="collapse" data-cfw-collapse-target="#collapseEx2" data-cfw-collapse-horizontal="true">Collapse <span class="caret"></span></button>
+<div id="collapseEx2" class="collapse width" >
     <div style="width: 20em">
         <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem.</p>
     </div>
@@ -76,10 +76,9 @@ These classes can be found in `_animation.scss`.
 
 ### Via Data Attributes
 
-Add `data-cfw="collapse"` and a `data-cfw-collapse-toggle` with a selector (jQuery style) or string value to the toggle/trigger element to automatically assign control of a collapsible element.
-If using a string value, then assign a `data-cfw-collapse-target` attribute, with a matching value to the element to apply the collapse to.
+Add `data-cfw="collapse"` and a target selector through a `data-cfw-collapse-target` or `href` attribute to automatically assign control of a collapsible element.
 Be sure to add the class `collapse` to the collapsible element.
-If you'd like it to default open, add the additional class `open` to the toggle.
+If you'd like it to default open, add the additional class `open` to the trigger control.
 
 ### Via JavaScript
 
@@ -104,7 +103,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </thead>
 <tbody>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
         <td>Either the selector (jQuery style), or the string related to the target collapse having a <code>data-cfw-collapse-target</code> attribute.</td>
@@ -119,7 +118,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>follow</td>
         <td>boolean</td>
         <td>false</td>
-        <td>If browser focus should move when a collapse toggle is activated.</td>
+        <td>If browser focus should move when a collapse trigger is activated.</td>
     </tr>
     <tr>
         <td>horizontal</td>

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -106,7 +106,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>target</td>
         <td>string</td>
         <td>null</td>
-        <td>Either the selector (jQuery style), or the string related to the target collapse having a <code>data-cfw-collapse-target</code> attribute.</td>
+        <td>The selector (jQuery style) of the target collapse item.</td>
     </tr>
     <tr>
         <td>animate</td>

--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -98,9 +98,7 @@ We use this extra class to reduce the horizontal `padding` on either side of the
 {% example html %}
 <div class="btn-group">
   <button type="button" class="btn">Default</button>
-  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
-    <span class="sr-only">Toggle Dropdown</span>
-  </button>
+  <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown" aria-label="Toggle Dropdown"></button>
   <ul class="dropdown-menu">
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
@@ -370,14 +368,12 @@ Note: The `data-cfw="dropdown"` attribute is relied on for closing dropdown menu
 
 Add `data-cfw="dropdown"` to the dropdown toggle element, and the widget will automatically link to the sibling `.dropdown-menu` list element.
 
-Optionally, you can use a `data-cfw-dropdown-toggle` with a selector (jQuery style) or string value to then element to automatically assign control of a dropdown element.
-If using a string value, then assign a `data-cfw-dropdown-target` attribute, with a matching value to the element to apply the control to.
 Be sure to add the class `dropdown-menu` to the dropdown menu to ensure there is no flash of content at page load.
 
 {% highlight html %}
 <div class="dropdown">
-  <a href="#" role="button" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownExample">Dropdown trigger</a>
-  <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownExample">
+  <a href="#" role="button" data-cfw="dropdown">Dropdown trigger</a>
+  <ul class="dropdown-menu">
     ...
   </ul>
 </div>
@@ -406,7 +402,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </thead>
 <tbody>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
         <td>Either the selector (jQuery style), or the string related to the target dropdown having a <code>data-cfw-dropdown-target</code> attribute.</td>

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -432,7 +432,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>target</td>
         <td>string</td>
         <td>null</td>
-        <td>Either the selector (jQuery style), or the string related to the target tooltip having a `data-cfw-modal-target` attribute.</td>
+        <td>The selector (jQuery style) of the target modal.</td>
     </tr>
     <tr>
         <td>animate</td>

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -99,14 +99,14 @@ Toggle a modal via JavaScript by clicking the button below. It will slide down a
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalLive">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalLive">
         Launch demo modal
     </button>
 </div>
 
 {% highlight html %}
 <!-- Button trigger -->
-<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalLive">
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalLive">
     Launch demo modal
 </button>
 
@@ -165,14 +165,14 @@ When modals become too long for the user's viewport or device, they scroll indep
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalScroll">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScroll">
         Scrolling modal
     </button>
 </div>
 
 {% highlight html %}
 <!-- Button trigger -->
-<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalScroll">
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScroll">
     Scrolling modal
 </button>
 
@@ -244,7 +244,7 @@ To take advantage of the grid system within a modal, just nest `.container-fluid
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalGrid">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalGrid">
         Grid in a Modal
     </button>
 </div>
@@ -303,7 +303,7 @@ To take advantage of the grid system within a modal, just nest `.container-fluid
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalTips">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalTips">
         Launch demo modal
     </button>
 </div>
@@ -352,13 +352,13 @@ Modals have two optional sizes, provided by Figuration's base CSS, available via
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalLg">Large modal</button>
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalSm">Small modal</button>
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalLg">Large modal</button>
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSm">Small modal</button>
 </div>
 
 {% highlight html %}
 <!-- Large modal -->
-<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalLg">Large modal</button>
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalLg">Large modal</button>
 
 <div class="modal" id="modalLg">
     <div class="modal-dialog modal-lg">
@@ -369,7 +369,7 @@ Modals have two optional sizes, provided by Figuration's base CSS, available via
 </div>
 
 <!-- Small modal -->
-<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-toggle="#modalSm">Small modal</button>
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSm">Small modal</button>
 
 <div class="modal" id="modalSm">
     <div class="modal-dialog modal-sm">
@@ -386,10 +386,10 @@ The modal widget toggles your hidden content on demand, via data attributes or J
 
 ### Via Data Attributes
 
-Activate a modal without writing JavaScript. Set `data-cfw="modal"` on a controller element, like a button, along with a `data-cfw-modal-toggle="#foo"` or `href="#foo"` to target a specific modal to toggle.
+Activate a modal without writing JavaScript. Set `data-cfw="modal"` on a controller element, like a button, along with a `data-cfw-modal-target="#foo"` or `href="#foo"` to target a specific modal to toggle.
 
 {% highlight html %}
-<button type="button" data-cfw="modal" data-cfw-modal-toggle="#foo">Launch modal</button>
+<button type="button" data-cfw="modal" data-cfw-modal-target="#foo">Launch modal</button>
 {% endhighlight %}
 
 ### Via JavaScript
@@ -429,7 +429,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </thead>
 <tbody>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
         <td>Either the selector (jQuery style), or the string related to the target tooltip having a `data-cfw-modal-target` attribute.</td>

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -74,8 +74,8 @@ Toggle a modal via JavaScript by clicking the button below. It will slide down a
                 <h4>Tooltips in a modal</h4>
                 <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                 <h4>Collapse in a modal</h4>
-                <a href="#" role="button" class="btn btn-secondary" data-cfw="collapse" data-cfw-collapse-toggle="modal_collapse">Collapse<span class="caret"></span></a>
-                    <div data-cfw-collapse-target="modal_collapse">
+                <a href="#modal_collapse" role="button" class="btn btn-secondary" data-cfw="collapse">Collapse <span class="caret"></span></a>
+                    <div id="modal_collapse" class="collapse">
                         <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                     </div>
                 <hr />

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -143,7 +143,7 @@ $('#html-popover').CFW_Popover({
 Have a complex content that you would like to show in a popover, or one that is updated dynamically?  Create the popover and then link to it with the `toggle` option.
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-toggle="#popoverExample0" data-cfw-popover-placement="right">Show Popover</button>
+<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#popoverExample0" data-cfw-popover-placement="right">Show Popover</button>
 
 <div class="popover" id="popoverExample0">
     <h3 class="popover-header">Popover title</h3>
@@ -223,6 +223,8 @@ The popover widget, by default, generates content and markup on demand, and by d
 
 The required markup for a popover is only a `data-cfw="popover"` attribute and `title` or a `data-cfw-popover-content=""` on the HTML element you wish to have a popover. The generated markup of a popover is rather simple, though it does require a position (by default, set to top by the widget).
 
+If the popover item is already created, you can link to it using <code>data-cfw-popover-target="#somePopover"</code>, or href="#somePopover". The proper role and ARIA attributes will be automatically created to link the trigger and target elements.
+
 ### Via JavaScript
 
 Enable manually with:
@@ -260,10 +262,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </thead>
 <tbody>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
-        <td>Either the selector (jQuery style), or the string related to the target popover having a <code>data-cfw-popover-target</code> attribute.</td>
+        <td>The selector (jQuery style) of the target popover.</td>
     </tr>
     <tr>
         <td>animate</td>
@@ -356,16 +358,6 @@ function myPopoverAlign(tip, trigger) {
         <td>string</td>
         <td>'Close'</td>
         <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
-    </tr>
-    <tr>
-        <td>toggle</td>
-        <td>string</td>
-        <td>null</td>
-        <td>
-            <p>If the popover item is already created, you can link to it using <code>data-cfw-popover-toggle="somePopover"</code>.</p>
-            <p>The target popover item will then need the associated attribute <code>data-cfw-popover-target="somePopover"</code>.</p>
-            <p>The proper role and ARIA attributes will be automatically created to link the trigger and target elements.</p>
-        </td>
     </tr>
     <tr>
         <td>title</td>

--- a/docs/widgets/scrollspy.md
+++ b/docs/widgets/scrollspy.md
@@ -58,8 +58,8 @@ Scroll the area below the navbar and watch the active class change. The dropdown
         <li class="nav-item"><a href="#alpha" class="nav-link">Alpha</a></li>
         <li class="nav-item"><a href="#beta" class="nav-link">Beta</a></li>
         <li class="nav-item dropdown">
-            <a href="#" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownS">Dropdown</a>
-            <ul data-cfw-dropdown-target="dropdownS">
+            <a href="#" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+            <ul class="dropdown-menu">
                 <li><a href="#one" tabindex="-1">one</a></li>
                 <li><a href="#two" tabindex="-1">two</a></li>
                 <li class="dropdown-divider"></li>

--- a/docs/widgets/tab-responsive.md
+++ b/docs/widgets/tab-responsive.md
@@ -36,21 +36,21 @@ This example uses a breakpoint of 62em/992px.  Larger widths will see the tab st
             <li class="nav-item"><a href="#tabr2" class="nav-link" data-cfw="tab">Third Tab</a></li>
         </ul>
         <div class="tab-content">
-            <div class="tab-pane" id="tabr0">
-                <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr0_collapse">First Tab <span class="caret"></span></a></h4>
-                <div class="collapse" data-cfw-collapse-target="tabr0_collapse">
+            <div id="tabr0" class="tab-pane">
+                <h4><a href="#tabr0_collapse" data-cfw="collapse">First Tab <span class="caret"></span></a></h4>
+                <div  id="tabr0_collapse" class="collapse">
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean non nisi ipsum. Quisque feugiat, arcu in pulvinar varius; risus odio interdum diam; a hendrerit urna sem vitae enim. Aenean fermentum iaculis nibh sodales consectetur.</p>
                 </div>
             </div>
-            <div class="tab-pane" id="tabr1">
-                <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr1_collapse">Second Tab <span class="caret"></span></a></h4>
-                <div class="collapse" data-cfw-collapse-target="tabr1_collapse">
+            <div id="tabr1" class="tab-pane">
+                <h4><a href="#tabr1_collapse" data-cfw="collapse">Second Tab <span class="caret"></span></a></h4>
+                <div id="tabr1_collapse" class="collapse">
                     <p>Praesent tristique dolor quis condimentum lobortis. Phasellus accumsan lacus vitae quam elementum, non euismod urna adipiscing. Suspendisse sodales enim non sem consequat dictum. Ut sit amet elementum purus, mattis rhoncus elit.</p>
                 </div>
             </div>
-            <div class="tab-pane" id="tabr2">
-                <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr2_collapse">Third Tab <span class="caret"></span></a></h4>
-                <div class="collapse" data-cfw-collapse-target="tabr2_collapse">
+            <div id="tabr2" class="tab-pane">
+                <h4><a href="#tabr2_collapse" data-cfw="collapse">Third Tab <span class="caret"></span></a></h4>
+                <div id="tabr2_collapse" class="collapse">
                     <p>Nullam malesuada massa urna, non gravida odio scelerisque sit amet. Donec sit amet rutrum quam, vel faucibus ante. Sed iaculis aliquet tortor vel tristique? In ligula nisi, suscipit vel ipsum id; elementum iaculis dui.</p>
                 </div>
             </div>
@@ -66,21 +66,21 @@ This example uses a breakpoint of 62em/992px.  Larger widths will see the tab st
         <li class="nav-item"><a href="#tabr2" class="nav-link" data-cfw="tab">Third Tab</a></li>
     </ul>
     <div class="tab-content">
-        <div class="tab-pane" id="tabr0">
-            <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr0_collapse">First Tab <span class="caret"></span></a></h4>
-            <div class="collapse" data-cfw-collapse-target="tabr0_collapse">
+        <div id="tabr0" class="tab-pane">
+            <h4><a href="#tabr0_collapse" data-cfw="collapse">First Tab <span class="caret"></span></a></h4>
+            <div  id="tabr0_collapse" class="collapse">
                 ...
             </div>
         </div>
-        <div class="tab-pane" id="tabr1">
-            <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr1_collapse">Second Tab <span class="caret"></span></a></h4>
-            <div class="collapse" data-cfw-collapse-target="tabr1_collapse">
+        <div id="tabr1" class="tab-pane">
+            <h4><a href="#tabr1_collapse" data-cfw="collapse">Second Tab <span class="caret"></span></a></h4>
+            <div  id="tabr1_collapse" class="collapse">
                 ...
             </div>
         </div>
-        <div class="tab-pane" id="tabr2">
-            <h4><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr2_collapse">Third Tab <span class="caret"></span></a></h4>
-            <div class="collapse" data-cfw-collapse-target="tabr2_collapse">
+        <div id="tabr2" class="tab-pane">
+            <h4><a href="#tabr2_collapse" data-cfw="collapse">Third Tab <span class="caret"></span></a></h4>
+            <div  id="tabr2_collapse" class="collapse">
                 ...
             </div>
         </div>

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -153,6 +153,8 @@ The tooltip widget, by default, generates content and markup on demand, and by d
 
 The required markup for a tooltip is only a `data-cfw="tooltip"` attribute and `title` on the HTML element you wish to have a tooltip. The generated markup of a tooltip is rather simple, though it does require a position (by default, set to top by the widget).
 
+If the tooltip item is already created, you can link to it using <code>data-cfw-tooltip-target="#someTooltip"</code>, or href="#someTooltip". The proper role and ARIA attributes will be automatically created to link the trigger and target elements.
+
 ### Via JavaScript
 
 Enable manually with:
@@ -281,14 +283,10 @@ function myTipAlign(tip, trigger) {
         <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
     </tr>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
-        <td>
-            <p>If the tooltip item is already created, you can link to it using <code>data-cfw-tooltip-toggle="someTooltip"</code>.</p>
-            <p>The target tooltip item will then need the associated attribute <code>data-cfw-tooltip-target="someTooltip"</code>.</p>
-            <p>The proper role and ARIA attributes will be automatically created to link the trigger and target elements.</p>
-        </td>
+        <td>The selector (jQuery style) of the target tooltip.</td>
     </tr>
     <tr>
         <td>title</td>

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -21,7 +21,7 @@
     };
 
     CFW_Widget_Collapse.DEFAULTS = {
-        toggle     : null,
+        target     : null,
         animate    : true,  // If collapse targets should expand and contract
         follow     : false, // If browser focus should move when a collapse toggle is activated
         horizontal : false  // If collapse should transition horizontal (vertical is default)
@@ -30,31 +30,18 @@
     CFW_Widget_Collapse.prototype = {
 
         _init : function() {
-            // Get collapse group ID
-            var collapseID = this.settings.toggle;
-
-            // Find target by id/css selector
-            var $target = $(this.settings.toggle);
-            if (!$target.length) {
-                // Get target (box) items
-                $target = $('[data-cfw-collapse-target="' + collapseID + '"]');
-            }
-            if (!$target.length) {
-                collapseID = this.$element.attr('href');
-                $target = $(collapseID);
-            }
-            if (!$target.length) { return false; }
-            if ((collapseID === undefined) || (collapseID.length <= 0)) { return false; }
-            this.$target = $target;
+            var selector = this.$element.CFW_getSelectorFromChain('collapse', this.settings.target);
+            if (!selector) { return; }
+            this.$target = $(selector);
 
             this.$element.attr({
                 'data-cfw': 'collapse',
-                'data-cfw-collapse-toggle': collapseID
+                'data-cfw-collapse-target': selector
             });
 
             // Build trigger collection
-            this.$triggers = $('[data-cfw="collapse"][data-cfw-collapse-toggle="' + collapseID + '"],' +
-                '[data-cfw="collapse"][href="' + collapseID + '"]');
+            this.$triggers = $('[data-cfw="collapse"][data-cfw-collapse-target="' + selector + '"],' +
+                '[data-cfw="collapse"][href="' + selector + '"]');
 
             // Check for presence of trigger id - set if not present
             // var triggerID = this.$element.CFW_getID('cfw-collapse');
@@ -86,7 +73,7 @@
 
             // Bind click handler
             this.$element
-                .on('click.cfw.collapse.toggle', $.proxy(this.toggle, this))
+                .on('click.cfw.collapse', $.proxy(this.toggle, this))
                 .CFW_trigger('init.cfw.collapse');
         },
 

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -41,7 +41,7 @@
     };
 
     CFW_Widget_Dropdown.DEFAULTS = {
-        toggle   : null,
+        target   : null,
         delay    : 350,     // Delay for hiding menu (milliseconds)
         hover    : false,   // Enable hover style navigation
         backlink : false,   // Insert back links into submenus
@@ -51,15 +51,12 @@
 
     function getParent($node) {
         var $parent;
-        var selector = $node.attr('data-cfw-dropdown-target');
+        var selector = $node.CFW_getSelectorFromElement('dropdown');
         if (selector) {
-            $parent = $(selector);
+            $parent = $(selector).parent();
         }
-        if ($parent && $parent.length) {
-            return $parent;
-        } else {
-            return $node.parent();
-        }
+
+        return $parent || $node.parent();
     }
 
     function clearMenus(e) {
@@ -78,23 +75,9 @@
             var $selfRef = this;
 
             // Get target menu
-            var menuID = this.settings.toggle;
-            // if ((menuID === undefined) || (menuID.length <= 0)) { return false; }
+            var selector = this.$element.CFW_getSelectorFromChain('dropdown', this.settings.target);
+            var $target = $(selector);
 
-            // Find target by id/css selector
-            var $target = $(this.settings.toggle);
-            if (menuID !== undefined && !$target.length) {
-                $target = $('[data-cfw-dropdown-target="' + menuID + '"]');
-            }
-            // Target by href selector
-            if (!$target.length) {
-                var selector = this.$element.attr('href');
-                selector = selector && /#[]A-Za-z]/.test(selector);
-                if (selector) {
-                    $target = $(selector);
-                }
-                // $target = $(this.$element.attr('href'));
-            }
             // Target by sibling class
             if (!$target.length) {
                 $target = $(this.$element.siblings('.dropdown-menu')[0]);
@@ -111,7 +94,7 @@
             // Set tabindex=-1 so that sub-menu links can't receive keyboard focus from tabbing
 
             // Check for id on top level menu - set if not present
-            menuID = this.$target.CFW_getID('cfw-dropdown');
+            /* var menuID = */ this.$target.CFW_getID('cfw-dropdown');
             this.$target.attr({
                 'aria-hidden': 'true',
                 'aria-labelledby': this.instance

--- a/js/modal.js
+++ b/js/modal.js
@@ -27,7 +27,7 @@
     };
 
     CFW_Widget_Modal.DEFAULTS = {
-        toggle       : false,   // Target selector
+        target       : false,   // Target selector
         animate      : true,    // If modal windows should animate
         unlink       : false,   // If on hide to remove events and attributes from modal and trigger
         dispose      : false,   // If on hide to unlink, then remove modal from DOM
@@ -39,15 +39,9 @@
     CFW_Widget_Modal.prototype = {
 
         _init : function() {
-            // Find target by id/css selector - only pick first one found
-            var $findTarget = $(this.settings.toggle).eq(0);
-            if ($findTarget.length <= 0) {
-                // If not found by selector - find by 'toggle' data
-                var dataToggle = this.$element.attr('data-cfw-modal-toggle');
-                $findTarget = $('[data-cfw-modal-target="' + dataToggle + '"]');
-            }
-            if ($findTarget.length <= 0) { return false; }
-            this.$target = $findTarget;
+            var selector = this.$element.CFW_getSelectorFromChain('modal', this.settings.target);
+            if (!selector) { return; }
+            this.$target = $(selector);
             this.$dialog = this.$target.find('.modal-dialog');
 
             this.$element.attr('data-cfw', 'modal');
@@ -75,7 +69,7 @@
             this.$dialog.attr('role', 'document');
 
             // Bind click handler
-            this.$element.on('click.cfw.modal.toggle', $.proxy(this.toggle, this));
+            this.$element.on('click.cfw.modal', $.proxy(this.toggle, this));
 
             this.$target.data('cfw.modal', this);
 

--- a/js/player.js
+++ b/js/player.js
@@ -733,7 +733,7 @@
                     $selfRef.trackSet(num);
                 });
 
-                $captionElm.CFW_Dropdown({ toggle: '#' + menuID });
+                $captionElm.CFW_Dropdown({ target: '#' + menuID });
             }
 
             this.trackStatus();
@@ -871,7 +871,7 @@
                     });
                 }
 
-                $tsElm.CFW_Dropdown({ toggle: '#' + menuID });
+                $tsElm.CFW_Dropdown({ target: '#' + menuID });
             }
 
             // Show transcript if set

--- a/js/popover.js
+++ b/js/popover.js
@@ -52,7 +52,7 @@
         var $title = $tip.find('.popover-header');
         var $content = $tip.find('.popover-body');
 
-        if (!this.dataToggle) {
+        if (this.dynamicTip) {
             var title = this.getTitle();
             var content = this.getContent();
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -16,7 +16,6 @@
         this.$focusLast = null;
         this.instance = null;
         this.settings = null;
-        this.dataToggle = null;
         this.type = null;
         this.isDialog = false;
         this.follow = false;
@@ -37,7 +36,7 @@
     };
 
     CFW_Widget_Tooltip.DEFAULTS = {
-        toggle          : false,            // Target selector
+        target          : false,            // Target selector
         placement       : 'top',            // Where to locate tooltip (top/bottom/left/right/auto)
         trigger         : 'hover focus',    // How tooltip is triggered (click/hover/focus/manual)
         animate         : true,             // Should the tooltip fade in and out
@@ -70,19 +69,9 @@
 
             this.$element.attr('data-cfw', this.type);
 
-            // Find target by id/css selector - only pick first one found
-            var dataToggle;
-            var $findTarget = $(this.settings.toggle).eq(0);
-            if ($findTarget.length) {
-                dataToggle = this.settings.toggle;
-            } else {
-                // If not found by selector - find by 'toggle' data
-                dataToggle = this.$element.attr('data-cfw-' + this.type + '-toggle');
-                $findTarget = $('[data-cfw-' + this.type + '-target="' + dataToggle + '"]');
-            }
-            if ($findTarget.length) {
-                this.dataToggle = dataToggle;
-                this.$target = $findTarget;
+            var selector = this.$element.CFW_getSelectorFromChain(this.type, this.settings.target);
+            if (selector !== null) {
+                this.$target = $(selector);
             } else {
                 this.fixTitle();
             }
@@ -150,7 +139,7 @@
             var $tip = this.$target;
             var $inner = $tip.find('.tooltip-body');
 
-            if (!this.dataToggle) {
+            if (this.dynamicTip) {
                 var title = this.getTitle();
 
                 if (this.settings.html) {
@@ -503,7 +492,6 @@
             this.$focusLast = null;
             this.instance = null;
             this.settings = null;
-            this.dataToggle = null;
             this.type = null;
             this.isDialog = null;
             this.follow = null;

--- a/js/util.js
+++ b/js/util.js
@@ -157,6 +157,35 @@
         return parsedData;
     };
 
+    $.fn.CFW_getSelectorFromElement = function(name) {
+        var $node = $(this);
+        var selector = $node.attr('data-cfw-' + name + '-target');
+        if (!selector || selector === '#') {
+            selector = $node.attr('href') || '';
+        }
+
+        try {
+            const $selector = $(selector);
+            return $selector.length > 0 ? selector : null;
+        } catch(error) {
+            return null;
+        }
+    };
+
+    $.fn.CFW_getSelectorFromChain = function(name, setting) {
+        var $node = $(this);
+        if (!setting || setting === '#') {
+            return $node.CFW_getSelectorFromElement();
+        }
+
+        try {
+            const $setting = $(setting);
+            return $setting.length > 0 ? setting : null;
+        } catch(error) {
+            return null;
+        }
+    };
+
     $.fn.CFW_throttle = function(fn, threshhold, scope) {
         /* From: http://remysharp.com/2010/07/21/throttling-function-calls/ */
         if (threshhold === undefined) { threshhold = 250; }

--- a/js/util.js
+++ b/js/util.js
@@ -165,9 +165,9 @@
         }
 
         try {
-            const $selector = $(selector);
+            var $selector = $(selector);
             return $selector.length > 0 ? selector : null;
-        } catch(error) {
+        } catch (error) {
             return null;
         }
     };
@@ -179,9 +179,9 @@
         }
 
         try {
-            const $setting = $(setting);
+            var $setting = $(setting);
             return $setting.length > 0 ? setting : null;
-        } catch(error) {
+        } catch (error) {
             return null;
         }
     };

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -475,7 +475,7 @@ body {
                 <label>Volume slider<input type="text" /></label>
             </span>
             <div class="dropup dropleft" style="display: inline-block; position: relative;">
-                <button type="button" class="btn btn-default player-speed" data-cfw="dropdown" data-cfw-dropdown-toggle="#speed0" title="Playback speed" aria-label="Playback speed"><span class="fa fa-fw fa-sort"></span></button>
+                <button type="button" class="btn btn-default player-speed" data-cfw="dropdown" data-cfw-dropdown-target="#speed0" title="Playback speed" aria-label="Playback speed"><span class="fa fa-fw fa-sort"></span></button>
                 <ul class="dropdown" id="speed0" style="min-width: 75px; width: 75px; text-align: center;">
                     <li><a href="#" onclick="javascript:$(this).closest('[data-cfw]').CFW_Player('speed', 0.25); return false;">0.25&times;</a></li>
                     <li><a href="#" onclick="javascript:$(this).closest('[data-cfw]').CFW_Player('speed', 0.5); return false;">0.5&times;</a></li>

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3070,7 +3070,7 @@ Anchor variants:<br />
   </div>
 </div>
 <nav class="navbar navbar-light bg-faded mb-1">
-  <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar1" aria-label="Toggle navigation">
+  <button class="navbar-toggle" type="button" data-cfw="collapse" data-cfw-collapse-target="#exCollapsingNavbar1" aria-label="Toggle navigation">
     <span class="icon-menu" aria-hidden="true">&#8801;</span>
   </button>
 </nav>
@@ -3079,7 +3079,7 @@ Anchor variants:<br />
 <small>resize screen below 'md' breakpoint</small><br />
 <nav class="navbar navbar-light bg-faded mb-1">
   <a class="navbar-brand" href="#">Responsive navbar</a>
-  <button class="navbar-toggle d-lg-none float-right" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#exCollapsingNavbar2" aria-label="Toggle navigation">
+  <button class="navbar-toggle d-lg-none float-right" type="button" data-cfw="collapse" data-cfw-collapse-target="#exCollapsingNavbar2" aria-label="Toggle navigation">
     <span class="icon-menu" aria-hidden="true">&#8801;</span>
   </button>
   <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar2">

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1849,10 +1849,10 @@ Anchor variants:<br />
   <button type="button" class="btn btn-secondary">2</button>
 
   <div class="btn-group" role="group">
-    <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample0">
+    <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
       Dropdown
     </button>
-    <ul class="dropdown-menu" id="dropSample0">
+    <ul class="dropdown-menu">
       <li><a href="#">Dropdown link</a></li>
       <li><a href="#">Dropdown link</a></li>
     </ul>
@@ -1867,10 +1867,10 @@ Anchor variants:<br />
   <button type="button" class="btn">Top</button>
   <button type="button" class="btn">Middle</button>
   <div class="btn-group" role="group">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample1">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
       Dropdown
     </button>
-    <ul class="dropdown-menu" id="dropSample1">
+    <ul class="dropdown-menu">
       <li><a href="#">Dropdown link</a></li>
       <li><a href="#">Dropdown link</a></li>
     </ul>
@@ -1988,10 +1988,10 @@ Anchor variants:<br />
   <div class="col-lg-6">
     <div class="input-group">
       <div class="input-group-btn">
-        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample2">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu" id="dropSample2">
+        <ul class="dropdown-menu">
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
@@ -2006,10 +2006,10 @@ Anchor variants:<br />
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with dropdown button">
       <div class="input-group-btn">
-        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample3">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu dropdown-menu-right" id="dropSample3">
+        <ul class="dropdown-menu dropdown-menu-right">
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
@@ -2027,10 +2027,10 @@ Anchor variants:<br />
     <div class="input-group">
       <div class="input-group-btn">
         <button type="button" class="btn btn-secondary">Action</button>
-        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample4">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu" id="dropSample4">
+        <ul class="dropdown-menu">
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
@@ -2046,10 +2046,10 @@ Anchor variants:<br />
       <input type="text" class="form-control" aria-label="Text input with segmented button dropdown">
       <div class="input-group-btn">
         <button type="button" class="btn btn-secondary">Action</button>
-        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropSample5">
+        <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu" id="dropSample5">
+        <ul class="dropdown-menu">
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
@@ -2269,10 +2269,10 @@ Anchor variants:<br />
 <div class="dropdown-single">
     Using .caret:
     <div class="dropdown">
-      <button type="button" class="btn btn-danger" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownSingle0">
+      <button type="button" class="btn btn-danger" data-cfw="dropdown">
         Action <span class="caret" aria-hidden="true"></span>
       </button>
-      <ul class="dropdown-menu" id="dropdownSingle0">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Action</a></li>
         <li><a class="dropdown-item" href="#">Another action</a></li>
         <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -2284,10 +2284,10 @@ Anchor variants:<br />
 <div class="dropdown-single">
     Using .dropdown-toggle:
     <div class="btn-group">
-      <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownSingle1">
+      <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown">
         Action
       </button>
-      <ul class="dropdown-menu" id="dropdownSingle1">
+      <ul class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Action</a></li>
         <li><a class="dropdown-item" href="#">Another action</a></li>
         <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -2300,10 +2300,10 @@ Anchor variants:<br />
 <h3>Dropdown - split button</h3>
 <div class="btn-group">
   <button type="button" class="btn btn-danger">Action</button>
-  <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownSplit0">
+  <button type="button" class="btn btn-danger dropdown-toggle" data-cfw="dropdown">
     <span class="sr-only">Toggle Dropdown</span>
   </button>
-  <ul class="dropdown-menu" id="dropdownSplit0">
+  <ul class="dropdown-menu">
     <li><a class="dropdown-item" href="#">Action</a></li>
     <li><a class="dropdown-item" href="#">Another action</a></li>
     <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -2315,10 +2315,10 @@ Anchor variants:<br />
 <h3>Dropdown - Menu Alignment</h3>
 <div class="clearfix">
     <div class="btn-group">
-        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_3" data-cfw-dropdown-backlink=true>
+        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
             Default <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_3">
+        <ul class="dropdown-menu">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2374,10 +2374,10 @@ Anchor variants:<br />
     </div>
 
     <div class="btn-group dropup">
-        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_4">
+        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown">
             Drop Up <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_4">
+        <ul class="dropdown-menu">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2433,10 +2433,10 @@ Anchor variants:<br />
     </div>
 
     <div class="btn-group dropdown-menu-left" style="float: right;">
-        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_5" data-cfw-dropdown-backlink=true>
+        <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
             Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
-        <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_5">
+        <ul class="dropdown-menu">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -2494,10 +2494,10 @@ Anchor variants:<br />
 
 <h3>Dropdown - submenu alignment</h3>
 <div class="btn-group">
-    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub1" data-cfw-dropdown-backlink=true>
+    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Default<!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub1">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2544,10 +2544,10 @@ Anchor variants:<br />
 </div>
 
 <div class="btn-group dropdown-menu-right">
-    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub2" data-cfw-dropdown-backlink=true>
+    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Right <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub2">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2594,10 +2594,10 @@ Anchor variants:<br />
 </div>
 
 <div class="btn-group dropdown-menu-left" style="float: right;">
-    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownSub3" data-cfw-dropdown-backlink=true>
+    <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownSub3">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2646,10 +2646,10 @@ Anchor variants:<br />
 <h3>Dropup submenu alignment</h3>
 
 <div class="btn-group dropup">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dup" data-cfw-dropdown-backlink="true">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Dropup
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dup">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2697,10 +2697,10 @@ Anchor variants:<br />
 
 
 <div class="btn-group dropup dropdown-menu-right">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dupR" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
         Dropup Right
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dupR">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2747,10 +2747,10 @@ Anchor variants:<br />
 </div>
 
 <div class="btn-group dropup dropdown-menu-left">
-    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dupL" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
+    <button type="button" class="btn dropdown-toggle" data-cfw="dropdown data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
         Dropup Left
     </button>
-    <ul class="dropdown-menu" data-cfw-dropdown-target="dupL">
+    <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
         <li class="dropdown-menu-left">
@@ -2911,8 +2911,8 @@ Anchor variants:<br />
     <a class="nav-link active" href="#">Active</a>
   </li>
   <li class="nav-item dropdown">
-    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropNav1">Dropdown</a>
-    <ul class="dropdown-menu" id="dropNav1">
+    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+    <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Action</a></li>
       <li><a class="dropdown-item" href="#">Another action</a></li>
       <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -2934,8 +2934,8 @@ Anchor variants:<br />
     <a class="nav-link active" href="#">Active</a>
   </li>
   <li class="nav-item dropdown">
-    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropNav2">Dropdown</a>
-    <ul class="dropdown-menu" id="dropNav2">
+    <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+    <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="#">Action</a></li>
       <li><a class="dropdown-item" href="#">Another action</a></li>
       <li><a class="dropdown-item" href="#">Something else here</a></li>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -979,10 +979,10 @@ $(window).ready(function() {
 
             <!-- Single button -->
             <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_0">
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown">
                     Action
                 </button>
-                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_0">
+                <ul class="dropdown-menu">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#0-1">Action</a></li>
                     <li>
@@ -1070,10 +1070,10 @@ $(window).ready(function() {
 
             <!-- Single button - init through JS -->
             <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw-dropdown-toggle="dropdownTest_2" id="js_dropdown_2">
+                <button type="button" class="btn btn-default dropdown-toggle" id="js_dropdown_2">
                     JS init w/ back
                 </button>
-                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_2" class="slide1">
+                <ul class="dropdown-menu" class="slide1">
                     <li><a href="#2-1">Action</a></li>
                     <li>
                         <a href="#2-1">Another action with a really long entry</a>
@@ -1137,10 +1137,10 @@ $(window).ready(function() {
 
             <!-- Single button -->
             <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_3" data-cfw-dropdown-hover=true>
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-target="#dropdownTest_3" data-cfw-dropdown-hover="true">
                     Hover Activated
                 </button>
-                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_3">
+                <ul class="dropdown-menu" id="dropdownTest_3">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#3-1">Action</a></li>
                     <li>
@@ -1197,10 +1197,10 @@ $(window).ready(function() {
 
             <!-- Single button -->
             <div class="btn-group">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropdownTest_3b" data-cfw-dropdown-hover=true>
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-hover="true">
                     Hover Activated
                 </button>
-                <ul id="dropdownTest_3b">
+                <ul class="dropdown-menu">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a>
@@ -1212,7 +1212,7 @@ $(window).ready(function() {
 
             <!-- Via Selector -->
             <div class="btn-group">
-                <button type="button" class="btn btn-warning dropdown-toggle" data-cfw="dropdown" id="dropdownTest_sb"> <!-- data-cfw-dropdown-toggle="#dropdownTest_s">-->
+                <button type="button" class="btn btn-warning dropdown-toggle" data-cfw="dropdown" id="dropdownTest_sb"> <!-- data-cfw-dropdown-target="#dropdownTest_s">-->
                     via selector
                     <span class="sr-only">Toggle Dropdown</span>
                 </button>
@@ -1233,7 +1233,7 @@ $(window).ready(function() {
             </div>
             <script type="text/javascript">
                 $('#dropdownTest_sb').CFW_Dropdown({
-                    toggle: '#dropdownTest_s'
+                    target: '#dropdownTest_s'
                 });
             </script>
 
@@ -1242,10 +1242,10 @@ $(window).ready(function() {
 
             <!-- Single button -->
             <div class="btn-group dropup">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_4">
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-target="#dropdownTest_4">
                     Drop Up
                 </button>
-                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_4">
+                <ul class="dropdown-menu" id="dropdownTest_4">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#4-1">Action</a></li>
                     <li>
@@ -1303,10 +1303,10 @@ $(window).ready(function() {
 
             <!-- Single button -->
             <div class="btn-group dropdown-menu-left" style="float: right;">
-                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownTest_5" data-cfw-dropdown-backlink=true>
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-target="#dropdownTest_5" data-cfw-dropdown-backlink=true>
                     Drop Left
                 </button>
-                <ul class="dropdown-menu" data-cfw-dropdown-target="dropdownTest_5">
+                <ul class="dropdown-menu" id="dropdownTest_5">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#5-1">Action</a></li>
                     <li>
@@ -1372,8 +1372,8 @@ $(window).ready(function() {
                     <li class="nav-item"><a href="#alpha" class="nav-link">Alpha</a></li>
                     <li class="nav-item"><a href="#beta" class="nav-link">Beta</a></li>
                     <li class="nav-item dropdown">
-                        <a href="#" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="dropdownS">Dropdown</a>
-                        <ul data-cfw-dropdown-target="dropdownS">
+                        <a href="#dropdownS" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+                        <ul id="dropdownS">
                             <li><a href="#one" tabindex="-1">one</a></li>
                             <li><a href="#two" tabindex="-1">two</a></li>
                             <li class="dropdown-divider"></li>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -478,7 +478,7 @@ $(window).ready(function() {
             <h2 id="modal">Modal:</h2>
 
             <p>
-                <button type="button" class="btn btn-info" id="modal3t" data-cfw="modal" data-cfw-modal-toggle="#modal3" data-cfw-modal-backdrop="false">Modal: no backdrop</button>
+                <button type="button" class="btn btn-info" id="modal3t" data-cfw="modal" data-cfw-modal-target="#modal3" data-cfw-modal-backdrop="false">Modal: no backdrop</button>
             </p>
             <div class="modal" id="modal3">
                 <div class="modal-dialog modal-sm">
@@ -495,8 +495,8 @@ $(window).ready(function() {
             </div><!-- /.modal -->
 
             <p>
-                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-toggle="#modal1">Launch demo modal</button>
-                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-toggle="#modal2">Launch modal - end of body</button>
+                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modal1">Launch demo modal</button>
+                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modal2">Launch modal - end of body</button>
             </p>
             <!-- Modal -->
             <div class="modal" id="modal1">
@@ -541,7 +541,7 @@ $(window).ready(function() {
             <strong>Reusing a Modal</strong>
             <br />
             <p>
-                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-toggle="#modal0" id="modal0_0">Launch demo modal (0)</button>
+                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modal0" id="modal0_0">Launch demo modal (0)</button>
                 <button type="button" class="btn btn-info" id="modal0_1">Launch demo modal (1)</button>
                 <br />
                 <a href="#" onclick="javascript: modalLinkTest0(); return false;">Unlink 0 - Link 1</a> |
@@ -587,7 +587,7 @@ $(window).ready(function() {
 
             <strong>Dynamic Content Load</strong>
             <p>
-                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-toggle="#modal4">Modal</button>
+                <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modal4">Modal</button>
             </p>
             <div class="modal" id="modal4">
                 <div class="modal-dialog">

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -118,7 +118,7 @@ $(window).ready(function() {
         display: none;
         visibility: hidden;
     }
-    .cfw-example-tabResponsive div[data-cfw-collapse-target] {
+    .cfw-example-tabResponsive .collapse {
         display: block;
         visibility: visible;
     }
@@ -514,8 +514,8 @@ $(window).ready(function() {
                             <h4>Tooltips in a modal</h4>
                             <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                             <h4>Collapse in a modal</h4>
-                            <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="modal_collapse">Collapse<span class="caret"></span></button>
-                                <div data-cfw-collapse-target="modal_collapse">
+                            <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#modal_collapse">Collapse<span class="caret"></span></button>
+                                <div id="modal_collapse">
                                     <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                                 </div>
                             <hr />
@@ -618,31 +618,31 @@ $(window).ready(function() {
 
             <h2 id="accordion">Accordion:</h2>
 
-            <div class="" data-cfw="accordion">
+            <div data-cfw="accordion">
                 <div>
-                    <a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion_0" class="open">
+                    <a href="#" data-cfw="collapse" data-cfw-collapse-target="#accordion_0" class="open">
                         Accordion_0
                         <span class="caret"></span>
                     </a>
-                    <div data-cfw-collapse-target="accordion_0">
+                    <div id="accordion_0">
                          <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
                     </div>
                 </div>
                 <div>
-                    <a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion_1">
+                    <a href="#" data-cfw="collapse" data-cfw-collapse-target="#accordion_1">
                         Accordion_1
                         <span class="caret"></span>
                     </a>
-                    <div data-cfw-collapse-target="accordion_1">
+                    <div id="accordion_1">
                          <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
                     </div>
                 </div>
                 <div>
-                    <a href="#" data-cfw="collapse" data-cfw-collapse-toggle="accordion_2">
+                    <a href="#" data-cfw="collapse" data-cfw-collapse-target="#accordion_2">
                         Accordion_2
                         <span class="caret"></span>
                     </a>
-                    <div data-cfw-collapse-target="accordion_2">
+                    <div id="accordion_2">
                          <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
                     </div>
                 </div>
@@ -927,14 +927,14 @@ $(window).ready(function() {
                         </div>
                     </div>
                     <div class="tab-pane" id="tabr1">
-                        <h3><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr1_collapse">Second Tab <span class="caret"></span></a></h3>
-                        <div data-cfw-collapse-target="tabr1_collapse">
+                        <h3><a href="#" data-cfw="collapse" data-cfw-collapse-target="#tabr1_collapse">Second Tab <span class="caret"></span></a></h3>
+                        <div id="tabr1_collapse">
                             <p>Praesent tristique dolor quis condimentum lobortis. Phasellus accumsan lacus vitae quam elementum, non euismod urna adipiscing. Suspendisse sodales enim non sem consequat dictum. Ut sit amet elementum purus, mattis rhoncus elit.</p>
                         </div>
                     </div>
                     <div class="tab-pane" id="tabr2">
-                        <h3><a href="#" data-cfw="collapse" data-cfw-collapse-toggle="tabr2_collapse">Third Tab <span class="caret"></span></a></h3>
-                        <div data-cfw-collapse-target="tabr2_collapse">
+                        <h3><a href="#" data-cfw="collapse" data-cfw-collapse-target="#tabr2_collapse">Third Tab <span class="caret"></span></a></h3>
+                        <div id="tabr2_collapse">
                             <p>Nullam malesuada massa urna, non gravida odio scelerisque sit amet. Donec sit amet rutrum quam, vel faucibus ante. Sed iaculis aliquet tortor vel tristique? In ligula nisi, suscipit vel ipsum id; elementum iaculis dui.</p>
                         </div>
                     </div>
@@ -1427,23 +1427,23 @@ $(window).ready(function() {
             <div class="well">
                 <label>
                     Toggle Collapse
-                    <input type="checkbox" data-cfw="collapse" data-cfw-collapse-toggle="#collapseCheck">
-                <label>
+                    <input type="checkbox" data-cfw="collapse" data-cfw-collapse-target="#collapseCheck2">
+                </label>
                 <div id="collapseCheck" class="collapse">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
             </div>
             <div class="well">
                 <h3>Multiple Triggers - One Target</h3>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="multi-collapse">Trigger 1 <span class="caret"></span></button>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="multi-collapse">Trigger 2 <span class="caret"></span></button>
-                <div data-cfw-collapse-target="multi-collapse">
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#multi-collapse">Trigger 1 <span class="caret"></span></button>
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#multi-collapse">Trigger 2 <span class="caret"></span></button>
+                <div id="multi-collapse">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
             </div>
             <div class="well">
                 <h3>Horizontal Collapse Test</h3>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="#collapseH" data-cfw-collapse-horizontal=true>Collapse <span class="caret"></span></button>
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#collapseH" data-cfw-collapse-horizontal=true>Collapse <span class="caret"></span></button>
                 <br />
                 <div id="collapseH" class="collapse">
                     <div style="width: 500px;">
@@ -1453,32 +1453,32 @@ $(window).ready(function() {
             </div>
             <div class="well">
                 <h3>Collapse Test</h3>
-                <button type="button" id="coll_1" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="collapseTest">Collapse <span class="caret"></span></button>
-                <!-- <button type="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="collapseTest">Collapse</button> -->
+                <button type="button" id="coll_1" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target=".collapseTest">Collapse <span class="caret"></span></button>
+                <!-- <button type="button" class="open" data-cfw="collapse" data-cfw-collapse-target=".collapseTest">Collapse</button> -->
                 <a href="#" onclick="$('#coll_1').CFW_Collapse('show', false); return false;">Show</a>
                 <a href="#" onclick="$('#coll_1').CFW_Collapse('toggle'); return false;">Toggle</a>
                 <br />
-                <div data-cfw-collapse-target="collapseTest">
+                <div class="collapseTest">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
-                <div data-cfw-collapse-target="collapseTest">
+                <div class="collapseTest">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
             </div>
             <div class="well">
                 <h3>Collapse Test</h3>
-                <button type="button" id="coll_2" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="collapseTest_1">Collapse <span class="caret"></span></button>
-                <!-- <button type="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="collapseTest_1">Collapse</button> -->
+                <button type="button" id="coll_2" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#collapseTest_1">Collapse <span class="caret"></span></button>
+                <!-- <button type="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#collapseTest_1">Collapse</button> -->
                 <br />
-                <div data-cfw-collapse-target="collapseTest_1">
+                <div id="collapseTest_1">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="collapseTest_3" data-cfw-collapse-animate=false>Collapse (No Animation) <span class="caret"></span></button>
-                <div data-cfw-collapse-target="collapseTest_3">
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#collapseTest_3" data-cfw-collapse-animate=false>Collapse (No Animation) <span class="caret"></span></button>
+                <div id="collapseTest_3">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
                 <br />
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="#collapseTest_4">Collapse (via selector) <span class="caret"></span></button>
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#collapseTest_4">Collapse (via selector) <span class="caret"></span></button>
                 <div id="collapseTest_4">
                     <p>Fusce vel posuere nulla. Cras urna enim, tristique a diam quis, suscipit euismod ante. Praesent fringilla tincidunt augue facilisis condimentum. Nam eget congue nisl. Sed hendrerit, arcu convallis gravida scelerisque, purus lectus scelerisque enim, nec gravida sapien diam eget sem. In sed sem et diam condimentum malesuada? Nam cursus venenatis posuere. Praesent id purus turpis. Curabitur pretium arcu nec diam interdum, id elementum sapien ultricies. Fusce ornare magna et risus rhoncus; eu consectetur sem vulputate.</p>
                 </div>
@@ -1489,7 +1489,7 @@ $(window).ready(function() {
                 </div>
                 <script type="text/javascript">
                     $('#collapseTest_5_trigger').CFW_Collapse({
-                     toggle: '#collapseTest_5'
+                     target: '#collapseTest_5'
                     });
                 </script>
                 <br />
@@ -1680,7 +1680,7 @@ $(window).ready(function() {
                 <h4>Tooltips in a modal</h4>
                 <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                 <h4>Collapse in a modal</h4>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-toggle="modal_collapse">Collapse<span class="caret"></span></button>
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#modal_collapse">Collapse<span class="caret"></span></button>
                     <div data-cfw-collapse-target="modal_collapse">
                         <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                     </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -572,7 +572,7 @@ $(window).ready(function() {
                 function modalLinkTest0() {
                     $('#modal0_0').CFW_Modal('unlink');
                     $('#modal0_1').CFW_Modal({
-                        toggle: '#modal0'
+                        target: '#modal0'
                     });
                     $('#modal0').CFW_Modal('show');
                 }
@@ -702,10 +702,10 @@ $(window).ready(function() {
             <br />
             --
             <br />
-            <button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-toggle="pop_1" id="pop_1" title="click me">Popover Click</button>
+            <button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#pop_1p" id="pop_1" title="click me">Popover Click</button>
             <a href="#" onclick="$('#pop_1').CFW_Popover('hide', true); return false;">Force Close</a> -
             <a href="#" onclick="$('#pop_1').CFW_Popover('hide'); return false;">Normal Close</a>
-            <div class="popover" data-cfw-popover-target="pop_1">
+            <div class="popover" id="pop_1p">
                 <h3 class="popover-header">Popover top</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
@@ -714,8 +714,8 @@ $(window).ready(function() {
                 <div class="popover-arrow"></div>
             </div>
             --
-            <button type="button" class="btn btn-info" data-cfw-popover-toggle="pop_2" id="pop_2">Popover Hover/focus</button>
-            <div class="popover" data-cfw-popover-target="pop_2">
+            <button type="button" class="btn btn-info" data-cfw-popover-target="#pop_2p" id="pop_2">Popover Hover/focus</button>
+            <div class="popover" id="pop_2p">
                 <h3 class="popover-header">Popover top</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
@@ -723,9 +723,9 @@ $(window).ready(function() {
                 <div class="popover-arrow"></div>
             </div>
             <br />
-            <button type="button" class="btn btn-info" data-cfw-popover-toggle="pop_3" id="pop_3">Popover Hover/focus</button>
+            <button type="button" class="btn btn-info" data-cfw-popover-target="#pop_3p" id="pop_3">Popover Hover/focus</button>
             &lt;- preventDefault() - should not show popover
-            <div class="popover" data-cfw-popover-target="pop_3">
+            <div class="popover" id="pop_3p">
                 <h3 class="popover-header">Popover top</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
@@ -734,7 +734,7 @@ $(window).ready(function() {
             </div>
             <button type="button" class="btn btn-info" data-cfw="popover" id="pop_4" title="Yay, you clicked me!" data-cfw-popover-content="blah">Popover Click</button>
             <br />
-            <!--<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-toggle="#pop_5p" id="pop_5">Popover from selector</button>-->
+            <!--<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#pop_5p" id="pop_5">Popover from selector</button>-->
             <button type="button" class="btn btn-info" id="pop_5">Popover from selector</button>
             <a href="#" onclick="$('#pop_5p').CFW_Popover('hide');return false;">Close by calling on popover</a>
             <div class="popover" id="pop_5p">
@@ -746,8 +746,8 @@ $(window).ready(function() {
                 <div class="popover-arrow"></div>
             </div>
             <br />
-            <button type="button" class="btn btn-info" id="pop_7t" data-cfw="popover" data-cfw-popover-toggle="#pop_7">Popover from selector</button>
-            <div class="popover" id="pop_7">
+            <button type="button" class="btn btn-info" id="pop_7t" data-cfw="popover" data-cfw-popover-target="#pop_7p">Popover from selector</button>
+            <div class="popover" id="pop_7p">
                 <h3 class="popover-header">Popover selector</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
@@ -788,7 +788,7 @@ $(window).ready(function() {
                     return e.preventDefault();
                 });
                 $('#pop_5').CFW_Popover({
-                    toggle: '#pop_5p',
+                    target: '#pop_5p',
                     placement: 'bottom'
                 });
 
@@ -799,7 +799,7 @@ $(window).ready(function() {
             <strong>Reusing a Popover</strong>
             <br />
             <p>
-                <button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-toggle="#popR" data-cfw-popover-trigger=click id="pop0_0" data-cfw-popover-drag=true>Popover reuse (0)</button>
+                <button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#popR" data-cfw-popover-trigger=click id="pop0_0" data-cfw-popover-drag=true>Popover reuse (0)</button>
                 <button type="button" class="btn btn-info" id="pop0_1" data-cfw-popover-drag=true>Popover reuse (1)</button>
                 <br />
                 <a href="#" onclick="javascript: popLinkTest0(); return false;">Unlink 0 - Link 1</a> |
@@ -820,7 +820,7 @@ $(window).ready(function() {
                 function popLinkTest0() {
                     $('#pop0_0').parent().one('afterUnlink.cfw.popover', function() {
                         $('#pop0_1').CFW_Popover({
-                            toggle: '#popR',
+                            target: '#popR',
                             trigger: 'click',
                             activate: true
                         });
@@ -1680,8 +1680,8 @@ $(window).ready(function() {
                 <h4>Tooltips in a modal</h4>
                 <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                 <h4>Collapse in a modal</h4>
-                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#modal_collapse">Collapse<span class="caret"></span></button>
-                    <div data-cfw-collapse-target="modal_collapse">
+                <button type="button" class="btn btn-default" data-cfw="collapse" data-cfw-collapse-target="#modal_collapse2">Collapse<span class="caret"></span></button>
+                    <div id="modal_collapse2">
                         <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                     </div>
                 <hr />

--- a/test/js/unit/collapse.js
+++ b/test/js/unit/collapse.js
@@ -18,7 +18,7 @@ $(function() {
 
     QUnit.test('should show a collapsed element (no transition)', function(assert) {
         assert.expect(2);
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').css('transition', 'none').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
         $trigger.CFW_Collapse('show');
@@ -29,7 +29,7 @@ $(function() {
     QUnit.test('should show a collapsed element (with transition)', function(assert) {
         assert.expect(2);
         var done = assert.async();
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').css('transition', '.05s').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
         $trigger
@@ -44,7 +44,7 @@ $(function() {
     QUnit.test('should hide a collapsed element (no transition)', function(assert) {
         assert.expect(2);
         var done = assert.async();
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').css('transition', 'none').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
         $trigger
@@ -62,7 +62,7 @@ $(function() {
     QUnit.test('should hide a collapsed element (with transition)', function(assert) {
         assert.expect(2);
         var done = assert.async();
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').css('transition', '.05s').appendTo('#qunit-fixture');
         $trigger.CFW_Collapse();
         $trigger
@@ -81,7 +81,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -101,7 +101,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" style="height: 0px" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -120,7 +120,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -135,7 +135,7 @@ $(function() {
 
     QUnit.test('should add "in" class to target when collapse trigger has "open" class', function(assert) {
         assert.expect(1);
-        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger.CFW_Collapse();
@@ -146,7 +146,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -163,8 +163,8 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger0 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $trigger1 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger0 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
+        var $trigger1 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
@@ -183,8 +183,8 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger0 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $trigger1 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger0 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
+        var $trigger1 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
@@ -203,7 +203,7 @@ $(function() {
         assert.expect(0);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -220,7 +220,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target =  */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -237,7 +237,7 @@ $(function() {
         assert.expect(0);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -254,7 +254,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -271,8 +271,8 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger0 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $trigger1 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger0 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
+        var $trigger1 = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger0
@@ -291,8 +291,8 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger0 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
-        var $trigger1 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger0 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
+        var $trigger1 = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger0
@@ -311,7 +311,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" class="open" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse in" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -328,7 +328,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<a role="button" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         var $target = $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger
@@ -345,7 +345,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<input type="checkbox" data-cfw="collapse" data-cfw-collapse-toggle="#test" />').appendTo('#qunit-fixture');
+        var $trigger = $('<input type="checkbox" data-cfw="collapse" data-cfw-collapse-target="#test" />').appendTo('#qunit-fixture');
         /* var $target = */ $('<div id="test" class="collapse" />').appendTo('#qunit-fixture');
 
         $trigger

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -20,7 +20,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target.on('beforeShow.cfw.modal', function() {
@@ -35,7 +35,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -56,7 +56,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').css('transition', 'none').appendTo('#qunit-fixture');
 
         $target
@@ -72,7 +72,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').css('transition', '.05s').appendTo('#qunit-fixture');
 
         $target
@@ -88,7 +88,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').css('transition', 'none').appendTo('#qunit-fixture');
 
         $target
@@ -108,7 +108,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').css('transition', '.05s').appendTo('#qunit-fixture');
 
         $target
@@ -128,7 +128,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -148,7 +148,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal"><span class="close" data-cfw-dismiss="modal" /></div>').appendTo('#qunit-fixture');
 
         $target
@@ -169,7 +169,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal" data-cfw-modal-backdrop="false">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal" data-cfw-modal-backdrop="false">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -190,7 +190,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -212,7 +212,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -234,7 +234,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal" data-cfw-modal-backdrop="static">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal" data-cfw-modal-backdrop="static">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -252,7 +252,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal" data-cfw-modal-backdrop="false">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal" data-cfw-modal-backdrop="false">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -270,7 +270,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal"><div class="contents"></div>').appendTo('#qunit-fixture');
 
         $target
@@ -294,7 +294,7 @@ $(function() {
 
         var triggered;
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -316,7 +316,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal"><span class="close" data-cfw-dismiss="modal" /></div>').appendTo('#qunit-fixture');
 
         $target
@@ -345,7 +345,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -371,7 +371,7 @@ $(function() {
 
         $body.css('padding-right', originalPadding);
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -397,7 +397,7 @@ $(function() {
 
         $body.css('padding-right', originalBodyPad);
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -422,7 +422,7 @@ $(function() {
         var $body = $(document.body);
         var $style = $('<style>body { padding-right: 42px; }</style>').appendTo('head');
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -445,7 +445,7 @@ $(function() {
         var $element = $('<div class="fixed-top"></div>').appendTo('#qunit-fixture');
         var originalPadding = $element.css('padding-right');
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -474,7 +474,7 @@ $(function() {
 
         $body.css('color', 'red');
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target
@@ -500,7 +500,7 @@ $(function() {
 
         $body.css('padding-right', '5%');
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var $target = $('<div class="modal" id="modal" />').appendTo('#qunit-fixture');
 
         $target

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -251,7 +251,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var template = '<div id="modal" class="modal">' +
             '<div class="modal-dialog">' +
             '<div class="modal-content">' +

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -1258,7 +1258,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
 
-        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-toggle="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
         var template = '<div id="modal" class="modal">' +
             '<div class="modal-dialog">' +
             '<div class="modal-content">' +

--- a/test/visual/flexbox-button.html
+++ b/test/visual/flexbox-button.html
@@ -48,10 +48,10 @@
         <button type="button" class="btn">Button</button>
         <button type="button" class="btn">Button</button>
             <div class="btn-group" role="group">
-                <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop0">
+                <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
                 Dropdown
             </button>
-            <ul class="dropdown-menu" id="btnGroupVerticalDrop0">
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
             </ul>
@@ -59,28 +59,28 @@
         <button type="button" class="btn">Button</button>
         <button type="button" class="btn">Button</button>
         <div class="btn-group" role="group">
-            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop1">
+            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
                 Dropdown
             </button>
-            <ul class="dropdown-menu" id="btnGroupVerticalDrop1">
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
             </ul>
         </div>
         <div class="btn-group" role="group">
-            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop3">
+            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
                 Dropdown
             </button>
-            <ul class="dropdown-menu" id="btnGroupVerticalDrop3">
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
             </ul>
         </div>
         <div class="btn-group" role="group">
-            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupVerticalDrop4">
+            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
                 Dropdown
             </button>
-            <ul class="dropdown-menu" id="btnGroupVerticalDrop4">
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
             </ul>
@@ -123,10 +123,10 @@
         <button type="button" class="btn">2</button>
 
         <div class="btn-group" role="group">
-            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#btnGroupDrop1">
+            <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
                 Dropdown
             </button>
-            <ul class="dropdown-menu" id="btnGroupDrop1">
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
                 <li><a class="dropdown-item" href="#">Dropdown link</a></li>
             </ul>

--- a/test/visual/flexbox-nav.html
+++ b/test/visual/flexbox-nav.html
@@ -133,8 +133,8 @@
             <a class="nav-link active" href="#">Active</a>
         </li>
         <li class="nav-item dropdown">
-            <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropNav1">Dropdown</a>
-            <ul class="dropdown-menu" id="dropNav1">
+            <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Action</a></li>
                 <li><a class="dropdown-item" href="#">Another action</a></li>
                 <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -157,8 +157,8 @@
             <a class="nav-link active" href="#">Active</a>
         </li>
         <li class="nav-item dropdown">
-            <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-toggle="#dropNav1">Dropdown</a>
-            <ul class="dropdown-menu" id="dropNav1">
+            <a href="#" role="button" class="nav-link dropdown-toggle" data-cfw="dropdown">Dropdown</a>
+            <ul class="dropdown-menu">
                 <li><a class="dropdown-item" href="#">Action</a></li>
                 <li><a class="dropdown-item" href="#">Another action</a></li>
                 <li><a class="dropdown-item" href="#">Something else here</a></li>

--- a/test/visual/flexbox-navbar.html
+++ b/test/visual/flexbox-navbar.html
@@ -25,7 +25,7 @@
 <h2>Basic Navbars</h2>
 
 <nav class="navbar navbar-light bg-faded">
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB0">
         <span aria-hidden="true">&#8801;</span>
     </button>
     <a href="#" class="navbar-brand ml-0_5">Basic</a>
@@ -60,7 +60,7 @@
 
 <nav class="navbar navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Basic</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarB1">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarB1">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -96,7 +96,7 @@
 
 <nav class="navbar navbar-expand navbar-light bg-faded">
     <a href="#" class="navbar-brand">Expand Always</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -130,7 +130,7 @@
 
 <nav class="navbar navbar-expand-sm navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `sm`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR1">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR1">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -164,7 +164,7 @@
 
 <nav class="navbar navbar-expand-md navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `md`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR2">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR2">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -198,7 +198,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `lg`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR3">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR3">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -232,7 +232,7 @@
 
 <nav class="navbar navbar-expand-xl navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Expand at `xl`</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarR4">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarR4">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -268,7 +268,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <a href="#" class="navbar-brand">Justified</a>
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarJ0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarJ0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -305,7 +305,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
     <div class="container">
         <a href="#" class="navbar-brand">Container</a>
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarC0">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarC0">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -341,7 +341,7 @@
 <h2>Centered Navbars</h2>
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded">
-    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarCO0">
+    <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarCO0">
         <span aria-hidden="true">&#8801;</span>
     </button>
 
@@ -371,7 +371,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-light bg-faded">
     <div class="container">
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarCO1">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarCO1">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -405,7 +405,7 @@
 
     <nav class="navbar navbar-expand-lg navbar-light bg-faded flex-between">
         <a href="#" class="navbar-brand">Expand at `lg`</a>
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarIC0">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarIC0">
             <span aria-hidden="true">&#8801;</span>
         </button>
 
@@ -438,7 +438,7 @@
     </nav>
 
     <nav class="navbar navbar-expand-lg navbar-light bg-faded">
-        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-toggle="#navbarIC1">
+        <button class="navbar-toggle collapsed" type="button" data-cfw="collapse" data-cfw-collapse-target="#navbarIC1">
             <span aria-hidden="true">&#8801;</span>
         </button>
 


### PR DESCRIPTION
Main goal of this PR is to overhaul the `toggle` and `target` options on some of the widgets.

- Remove the funky `data-cfw-*-toggle` and `data-cfw-*-target` pairing.
- Remove the use of `toggle` as an option, and replace with `target` where needed.
- Improve handling of using target options to better support the use of `data-cfw-*-target` and `href` for target designation through the use of selectors with new utility functions.
- You might still be able to do target designation using a data attribute selector if needed, but I have not tested this explicitly.

There may be a few items missed due to the size of scope, so if you see anything wrong feel free to file an issue.