### PR TITLE
Dropdown: Add support for inputs

### DIFF
--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -28,7 +28,9 @@ For accessibility reasons, do not mix use of the [Tab widget]({{ site.baseurl }}
 
 ## Overview
 
-The Dropdown widget in Figuration is primarily designed for menus and navigation.  Not a container for forms or editable content, such as a login or registration.  You might want to consider using the [Popover widget]({{ site.baseurl }}/widgets/popover/) instead, or reworking the workflow or interface design.
+Wrap the dropdown's toggle (your button or link) and the dropdown menu within `.dropdown`, or another element that declares `position: relative;`. Dropdowns can be triggered from `<a>` or `<button>` elements.
+
+Because of the support for nested dropdown menus, it is currently **required to use a `ul` element** to build your dropdown menus.
 
 ## Examples
 
@@ -63,8 +65,6 @@ Here is a static example showing the dropdown layout and content pieces.
 ### Basic Dropdown
 
 Wrap the dropdown's trigger and the dropdown menu within `.dropdown`, or another element that declares `position: relative;`. Then, add the menu's HTML.
-
-Because of the support for nested dropdown menus, it is currently **required to use a `ul` element** to build your dropdown menus.
 
 {% example html %}
 <div class="dropdown">
@@ -201,6 +201,31 @@ Add `.active` to the `li` item in the dropdown to show a visual emphasis.
 </ul>
 {% endexample %}
 
+### Submenus
+
+You can nest submenus by adding a nested list along side it's toggle.
+
+{% example html %}
+<div class="dropdown">
+        <button type="button" class="btn btn-info dropdown-toggle" data-cfw="dropdown">
+            Dropdown
+        </button>
+        <ul class="dropdown-menu">
+            <li class="dropdown-header">Sample Header</li>
+            <li><a href="#">Action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+            <li><a href="#">Another action</a></li>
+        </ul>
+    </div>
+
+{% endexample %}
+
 ### 'Back' Menu Items
 
 Using the [`backlink` option](#options), you can have 'back' menu items automatically inserted into all submenus.  These links will close the current submenu and move focus back onto the parent menu item.  This can be useful if the parent menu/submenu item is being hidden, or obscured by the current submenu.
@@ -232,6 +257,96 @@ Using the [`backlink` option](#options), you can have 'back' menu items automati
     </ul>
 </div>
 {% endexample %}
+
+### Special Items
+
+The Dropdown widget in Figuration is primarily designed for menus and navigation, not a container for forms or editable content, such as a login or registration.  You might want to consider using the [Popover widget]({{ site.baseurl }}/widgets/popover/) instead, or reworking the workflow or interface design.
+
+However, there is some support for handling `<input>` and `<textarea>` items within the parent `.dropdown` container, and within the menu itself.  Each of these special items require the use of the `.dropdown-item` helper class, when inside the menu, to adjust their layout and become available to the dropdown menu keyboard navigation.
+
+#### Buttons
+
+You can optionally use `<button>` elements in your dropdowns instead of just `<a>`s.
+
+{% example html %}
+<div class="dropdown">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+    Dropdown
+  </button>
+  <ul class="dropdown-menu">
+    <li><button type="button" class="dropdown-item">Regular button</button></li>
+    <li><button type="button" class="dropdown-item active">Active button</button></li>
+    <li><button type="button" class="dropdown-item">Another button</button></li>
+    <li class="dropdown-divider"></li>
+    <li><button type="button" class="dropdown-item disabled">Disabled button</button></li>
+    <li><button type="button" class="dropdown-item" disabled>Disabled button</button></li>
+  </ul>
+</div>
+{% endexample %}
+
+#### Checkbox and Radio Inputs
+
+Checkbox and radio inputs are allowed, but only **one per menu item**.
+
+{% example html %}
+<div class="dropdown">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+    Dropdown
+  </button>
+  <ul class="dropdown-menu">
+    <li><label class="dropdown-item form-check-label"><input type="checkbox" class="form-check-input"> Checkbox 1</label></li>
+    <li><label class="dropdown-item form-check-label"><input type="checkbox" class="form-check-input"> Checkbox 2</label></li>
+    <li><label class="dropdown-item form-check-label"><input type="checkbox" class="form-check-input"> Checkbox 3</label></li>
+  </ul>
+</div>
+{% endexample %}
+
+{% example html %}
+<div class="dropdown">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+    Dropdown
+  </button>
+  <ul class="dropdown-menu">
+    <li><label class="dropdown-item form-check-label"><input type="radio" name="dropradio" class="form-check-input"> Radio 1</label></li>
+    <li><label class="dropdown-item form-check-label"><input type="radio" name="dropradio" class="form-check-input"> Radio 2</label></li>
+    <li><label class="dropdown-item form-check-label"><input type="radio" name="dropradio" class="form-check-input"> Radio 3</label></li>
+  </ul>
+</div>
+{% endexample %}
+
+#### Textual Inputs
+
+Add `<input type="text">` or `textarea` items to your dropdown menu.  Other types of [textual inputs]({{ site.baseurl }}/content/forms/#textual-inputs) have not been tested, and may cause issues.  Again, use only **one per menu item**.
+
+Since keyboard navigation needs to change once you enter one of these elements, for ease of editing, they use the <kbd>tab</kbd> key to navigate out.
+
+{% example html %}
+<div class="dropdown">
+  <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+    Dropdown
+  </button>
+  <ul class="dropdown-menu">
+    <li><a href="#">Action</a></li>
+    <li>
+      <label class="dropdown-item">
+        <span class="sr-only">Example input</span>
+        <input type="text" class="form-control" placeholder="text input"/>
+      </label>
+    </li>
+    <li><a href="#">Action</a></li>
+    <li>
+      <label class="dropdown-item">
+        <span class="sr-only">Example textarea</span>
+        <textarea class="form-control" placeholder="textarea"></textarea>
+      </label>
+    </li>
+    <li><a href="#">Action</a></li>
+  </ul>
+</div>
+{% endexample %}
+
+
+
 
 ## Variants
 
@@ -537,6 +652,7 @@ The dropdown widget provided by Figuration is intended be generic and apply to a
     </dt>
     <dd>
         Closes the currently focused menu, and moves focus to the next focusable items in the document.
+        If current focus is on an input or textarea in the menu, the focus moves to the next focusable item in the menu.
     </dd>
     <dt>
         <kbd>enter</kbd>
@@ -556,17 +672,21 @@ The dropdown widget provided by Figuration is intended be generic and apply to a
     </dt>
     <dd>
         Moves focus to the previous or next item in the menu list.
+        If current focus is in a textarea, the text caret will move accordingly.
+        If current focus is on a checkbox or radio input, moves focus to the previous or next item in the menu list.
     </dd>
     <dt>
         <kbd title="right arrow" aria-label="right arrow"><span class="fa fa-arrow-right" aria-hidden="true"></span></kbd>
     </dt>
     <dd>
         Opens the submenu if one exists.
+        If current focus is in a text input or textarea, the text caret will move accordingly.
     </dd>
     <dt>
         <kbd title="left arrow" aria-label="left arrow"><span class="fa fa-arrow-left" aria-hidden="true"></span></kbd>
     </dt>
     <dd>
         Closes the currently focused submenu, and returns focus back to the triggering element.  If there are no submenus open, focus will be returned to the main trigger.
+        If current focus is in a text input or textarea, the text caret will move accordingly.
     </dd>
 </dl>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -57,6 +57,12 @@
     function clearMenus(e) {
         // Ignore right-click
         if (e && e.which === 3) { return; }
+
+        // Ignore clicks into input areas
+        if (e && e.type === 'click' && /input|textarea/i.test(e.target.tagName)) {
+            return;
+        }
+
         // Find currently open menu root
         $('[data-cfw="dropdown"]').each(function() {
             var $parent = getParent($(this));
@@ -85,9 +91,6 @@
             // Check for presence of trigger id - set if not present
             this.instance = this.$element.CFW_getID('cfw-dropdown');
 
-            // Top Level: add ARIA/roles and define all sub-menu links as menuitem (unless 'disabled')
-            // Set tabindex=-1 so that sub-menu links can't receive keyboard focus from tabbing
-
             // Check for id on top level menu - set if not present
             /* var menuID = */ this.$target.CFW_getID('cfw-dropdown');
             this.$target.attr({
@@ -95,6 +98,8 @@
                 'aria-labelledby': this.instance
             })
             .addClass(this.c.isMenu);
+
+            // Set tabindex=-1 so that sub-menu links can't receive keyboard focus from tabbing
             $('a', this.$target).attr('tabIndex', -1).not('.disabled, :disabled');
 
             // Set ARIA on trigger
@@ -402,16 +407,29 @@
         },
 
         _actionsKeydown : function(e, node) {
+            var isInput = /input|textarea/i.test(e.target.tagName);
+            var isCheck = isInput && /checkbox|radio/i.test($(e.target).prop('type'));
+
             // 37-left, 38-up, 39-right, 40-down, 27-esc, 32-space, 9-tab
-            if (!/(37|38|39|40|27|32|9)/.test(e.which)) { return; }
+            if (!/^(37|38|39|40|27|32|9)$/.test(e.which)) { return; }
+            // Ignore space in inputs
+            if (isInput && e.which == 32) { return; }
+            // Ignore arrows in inputs, except for checkbox/radio
+            if (isInput && !isCheck && /^(37|38|39|40)$/.test(e.which)) { return; }
 
             var $node = $(node);
             var $items = null;
 
             // Close menu when tab pressed, move to next item
             if (e.which == 9) {
-                clearMenus();
-                return;
+                // Emulate arrow up/down if input
+                if (isInput) {
+                    e.which = (e.shiftKey) ? 38 : 40;
+                } else {
+                    clearMenus();
+                    this.$element.trigger('focus');
+                    return;
+                }
             }
 
             e.stopPropagation();
@@ -449,11 +467,15 @@
                     return;
                 }
 
-                $items = $parent.children('li').children('a:not(.disabled):visible');
+                $items = $parent.children('li').find('a, .dropdown-item, input, textarea');
+                $items = $items.filter(':not(.disabled, :disabled):not(:has(input)):not(:has(textarea)):visible');
                 if (!$items.length) { return; }
 
                 // Find current focused menu item
                 var index = $items.index(e.target);
+                if (index < 0 && isCheck) {
+                    index = $items.index($(e.target).closest('.dropdown-item')[0]);
+                }
 
                 if (e.which == 38 && index > 0)                 { index--;   } // up
                 if (e.which == 40 && index < $items.length - 1) { index++;   } // down
@@ -477,7 +499,8 @@
 
                 if (e.which == 39 && subHidden) {
                     this.showMenu(null, $eTarget, $subMenuElm);
-                    $items = $subMenuElm.children('li').children('a:not(.disabled):visible');
+                    $items = $subMenuElm.children('li').find('a, .dropdown-item, input, textarea');
+                    $items = $items.filter(':not(.disabled, :disabled):not(:has(input)):not(:has(textarea)):visible');
                     $items.eq(0).trigger('focus');
                     return;
                 }

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -713,6 +713,7 @@ $dropdown-back-spacer-x:        .375rem !default;
 
 $dropdown-toggle-margin-x:      .25rem !default;
 
+$dropdown-form-check-input-margin-x: .25rem !default;
 
 // Navs
 // =====

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -64,15 +64,24 @@
 }
 
 // Links within a dropdown menu
-//Because we support nested dropdown, force list usage not the `.dropdown-item` syntax
-.dropdown-menu a {
+// Because we support nested dropdowns, it is currently required to use a
+// list for semantic markup, but we include a `.dropdown-item`
+// for non-anchor items
+// 1- `<button>`s require some overrides
+.dropdown-menu a,
+.dropdown-item {
     display: block;
+    width: 100%; // 1
     padding: $dropdown-item-padding-y $dropdown-item-padding-x;
+    margin: 0;
     clear: both;
     font-weight: $font-weight-normal;
     color: $dropdown-link-color;
+    text-align: inherit; // 1
     text-decoration: none;
     white-space: nowrap; // prevent links from randomly breaking onto new lines
+    background: none; // 1
+    border: 0; // 1
 
     &.active {
         color: $dropdown-link-active-color;
@@ -87,12 +96,21 @@
         outline: 0;
     }
 
-    &.disabled {
+    &.disabled,
+    &:disabled {
         color: $dropdown-link-disabled-color;
         text-decoration: none;
         cursor: $cursor-disabled;
         background-color: $dropdown-link-disabled-bg;
         background-image: none; // Remove CSS gradient
+    }
+}
+
+.dropdown-item {
+    &.form-check-label {
+        .form-check-input {
+            margin-left: $dropdown-form-check-input-margin-x - $form-check-input-gutter;
+        }
     }
 }
 
@@ -106,7 +124,8 @@
         @include border-radius($dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-border-radius);
     }
 
-    > a {
+    > a,
+    > .dropdown-item {
         &::after {
             position: absolute;
             top: 50%;
@@ -148,11 +167,6 @@
                 border-bottom: 0;
             }
         }
-    }
-
-    // Remove the outline when :focus is triggered
-    > a {
-        outline: 0;
     }
 }
 
@@ -273,7 +287,8 @@
         margin-left: -($border-width * 2);
         @include border-radius($dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius);
     }
-    > a {
+    > a
+    > .dropdown-item {
         &::after {
             right: auto;
             left: $dropdown-caret-spacer-x;

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1012,6 +1012,34 @@ $(window).ready(function() {
 
             <h2 id="dropdown">Dropdown:</h2>
 
+            <div class="btn-group mr-1 mb-1">
+                <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown">
+                    Has Inputs
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a href="#">Action</a></li>
+                    <li><label class="dropdown-item form-check-label"><input type="checkbox" class="form-check-input"> Checkbox</label></li>
+                    <li><a href="#">Action</a></li>
+                    <li><label class="dropdown-item form-check-label"><input type="radio" name="dropradio" class="form-check-input"> Radio</label></li>
+                    <li><label class="dropdown-item form-check-label"><input type="radio" name="dropradio" class="form-check-input"> Radio</label></li>
+                    <li><a href="#">Action</a></li>
+                    <li><div class="dropdown-item"><input type="text" placeholder="text input"/></div></li>
+                    <li><div class="dropdown-item"><textarea placeholder="textarea"></textarea></div></li>
+                    <li><a href="#">Action</a></li>
+                    <li><button class="dropdown-item" type="button">Button</button></li>
+                </ul>
+            </div>
+
+            <div class="btn-group mb-1">
+                <input type="text"  data-cfw="dropdown" placeholder="click me" />
+                <ul class="dropdown-menu">
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Action</a></li>
+                </ul>
+            </div>
+            <br />
+
             <!-- Single button -->
             <div class="btn-group">
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown">

--- a/test/js/unit/dropdown.js
+++ b/test/js/unit/dropdown.js
@@ -152,6 +152,87 @@ $(function() {
         assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"open" class removed');
     });
 
+    QUnit.test('should remove "open" class if tabbing from trigger', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">'
+            + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
+            + '<ul class="dropdown-menu">'
+            + '<li><a href="#">Menu link</a></li>'
+            + '</ul>'
+            + '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"show" class added on click');
+                var e = $.Event('keydown', { which: 9 }); // Tab
+                $dropdown.trigger(e);
+            })
+            .on('afterHide.cfw.dropdown', function() {
+                assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"show" class removed');
+                done();
+            })
+            .trigger('click');
+    });
+
+    QUnit.test('should remove "open" class if tabbing from menu anchor', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">'
+            + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
+            + '<ul class="dropdown-menu">'
+            + '<li><a href="#">Menu link</a></li>'
+            + '</ul>'
+            + '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"show" class added on click');
+                var $menuItem = $dropdown.parent().find('a');
+                $menuItem.trigger('focus');
+                assert.ok($(document.activeElement).is($menuItem), 'menu item is focused');
+                var e = $.Event('keydown', { which: 9 }); // Tab
+                $menuItem.trigger(e);
+            })
+            .on('afterHide.cfw.dropdown', function() {
+                assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"show" class removed');
+                done();
+            })
+            .trigger('click');
+    });
+
+    QUnit.test('should remove "open" class if tabbing from menu item', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">'
+            + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
+            + '<ul class="dropdown-menu">'
+            + '<li><button class="dropdown-item" type="button">Action</button></li>'
+            + '</ul>'
+            + '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok($dropdown.parent('.dropdown').hasClass('open'), '"show" class added on click');
+                var $menuItem = $dropdown.parent().find('button');
+                $menuItem.trigger('focus');
+                assert.ok($(document.activeElement).is($menuItem), 'menu item is focused');
+                var e = $.Event('keydown', { which: 9 }); // Tab
+                $menuItem.trigger(e);
+            })
+            .on('afterHide.cfw.dropdown', function() {
+                assert.ok(!$dropdown.parent('.dropdown').hasClass('open'), '"show" class removed');
+                done();
+            })
+            .trigger('click');
+    });
+
     QUnit.test('should remove "open" class if body is clicked, with multiple dropdowns', function(assert) {
         assert.expect(7);
         var dropdownHTML = '<div class="dropdown">'
@@ -311,4 +392,63 @@ $(function() {
             .trigger('click');
     });
 
+    QUnit.test('should ignore keyboard events in <input> and <textarea>', function(assert) {
+        assert.expect(5);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">'
+            + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
+            + '<ul class="dropdown-menu">'
+            + '<li><input id="input" /></a></li>'
+            + '<li><textarea id="textarea"></textarea></a></li>'
+            + '</ul>'
+            + '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        var $input = $('#input');
+        var $textarea = $('#textarea');
+
+        $dropdown
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok(true, 'menu opened');
+                $input.trigger('focus');
+                assert.ok($(document.activeElement).is($input), 'input focused');
+                $input.trigger($.Event('keydown', { which: 40 }));
+                assert.ok($(document.activeElement).is($input), 'input still focused');
+                $textarea.trigger('focus');
+                assert.ok($(document.activeElement).is($textarea), 'textarea focused');
+                $textarea.trigger($.Event('keydown', { which: 38 }));
+                assert.ok($(document.activeElement).is($textarea), 'textarea still focused');
+                done();
+            });
+        $dropdown.trigger('click');
+    });
+
+    QUnit.test('should not close menu if clicking on <input type="text"> or <textarea>', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">'
+            + '<button type="button" class="btn dropdown-toggle" data-cfw="dropdown">Dropdown</button>'
+            + '<ul class="dropdown-menu">'
+            + '<li><input id="input" /></a></li>'
+            + '<li><textarea id="textarea"></textarea></a></li>'
+            + '</ul>'
+            + '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        var $input = $('#input');
+        var $textarea = $('#textarea');
+
+        $dropdown
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok(true, 'menu opened');
+                $input.trigger('click');
+                assert.ok($dropdown.parent('.dropdown').hasClass('open'), 'menu still open');
+                $textarea.trigger('click');
+                assert.ok($dropdown.parent('.dropdown').hasClass('open'), 'menu still open');
+                done();
+            });
+        $dropdown.trigger('click');
+    });
 });


### PR DESCRIPTION
Adds support for `input` and `textarea` within `.dropdown` and `.dropdown-menu`.

- Added `.dropwdown-item` helper class for layout, and for `button` styling.
- Implements adjustments to keyboard navigation to handle the `input` and `textarea` additions.
- Only supports **one** input type per menu item.
- Additional unit tests.

Keyboard navigation was modified so that textual inputs use `tab` key to move out of input field.  Arrow keys are suppressed for these items to keep default text caret movement.

Checkbox and radio inputs allow for arrow key navigation just like normal menu items.
