### PR TITLE
v3 - Right-to-left support

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -129,6 +129,7 @@ linters:
     min_properties: 2
     separate_groups: false
     order:
+      - direction
       - position
       - top
       - right

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -237,7 +237,7 @@ module.exports = function(grunt) {
                 },
                 expand: true,
                 cwd: 'dist/css',
-                src: ['*.css', '!*.min.css'],
+                src: ['*.css', '!*.min.css', '!*-rtl.css'],
                 dest: 'dist/css',
                 ext: '-rtl.css'
             },
@@ -250,7 +250,7 @@ module.exports = function(grunt) {
                 },
                 expand: true,
                 cwd: 'docs/assets/css',
-                src: ['*.css', '!*.min.css, !*-rtl.css'],
+                src: ['*.css', '!*.min.css', '!*-rtl.css'],
                 dest: 'docs/assets/css',
                 ext: '-rtl.css'
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,9 +229,6 @@ module.exports = function(grunt) {
 
         rtlcss: {
             core: {
-                map: {
-                    inline: false
-                },
                 opts: {
                     clean: false
                 },
@@ -242,9 +239,6 @@ module.exports = function(grunt) {
                 ext: '-rtl.css'
             },
             docs: {
-                map: {
-                    inline: false
-                },
                 opts: {
                     clean: false
                 },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,7 +81,8 @@ module.exports = function(grunt) {
         // ==========
         clean: {
             dist: 'dist',
-            docs: 'docs/dist'
+            docs: 'docs/dist',
+            docscss: 'docs/assets/css'
         },
 
         jshint: {
@@ -226,6 +227,35 @@ module.exports = function(grunt) {
             }
         },
 
+        rtlcss: {
+            core: {
+                map: {
+                    inline: false
+                },
+                opts: {
+                    clean: false
+                },
+                expand: true,
+                cwd: 'dist/css',
+                src: ['*.css', '!*.min.css'],
+                dest: 'dist/css',
+                ext: '-rtl.css'
+            },
+            docs: {
+                map: {
+                    inline: false
+                },
+                opts: {
+                    clean: false
+                },
+                expand: true,
+                cwd: 'docs/assets/css',
+                src: ['*.css', '!*.min.css, !*-rtl.css'],
+                dest: 'docs/assets/css',
+                ext: '-rtl.css'
+            }
+        },
+
         cssmin: {
             options: {
                 specialComments: '*',
@@ -365,7 +395,7 @@ module.exports = function(grunt) {
     grunt.registerTask('test-js', jsTestTasks);
 
     // CSS distribution
-    grunt.registerTask('dist-css', ['sass:core', 'postcss:core', 'cssmin:core']);
+    grunt.registerTask('dist-css', ['sass:core', 'postcss:core', 'rtlcss:core', 'cssmin:core']);
 
     // JS distribution
     grunt.registerTask('dist-js', ['concat', 'uglify:core']);
@@ -376,10 +406,10 @@ module.exports = function(grunt) {
     // Docs tasks
     grunt.registerTask('docs-test-html', ['jekyll:docs', 'htmllint:docs']);
     grunt.registerTask('docs-test-css', ['scsslint:docs']);
-    grunt.registerTask('docs-dist-css', ['sass:docs', 'postcss:docs', 'cssmin:docs']);
+    grunt.registerTask('docs-dist-css', ['sass:docs', 'postcss:docs', 'rtlcss:docs', 'cssmin:docs']);
     grunt.registerTask('docs-test-js', ['jscs:docs']);
     grunt.registerTask('docs-dist-js', ['uglify:docs']);
-    grunt.registerTask('docs', ['docs-test-css', 'docs-dist-css', 'docs-test-js', 'docs-dist-js', 'clean:docs', 'copy:docs']);
+    grunt.registerTask('docs', ['docs-test-css', 'clean:docscss', 'docs-dist-css', 'docs-test-js', 'docs-dist-js', 'clean:docs', 'copy:docs']);
     grunt.registerTask('docs-github', ['jekyll:github']);
 
 };

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ cdn:
   css_hash:     "sha384-ACNrRRrJ23mqMnFATScevwMr7rvWO3WrwlPU8bIefw2nsxMpEeGEaxH8UkMOhCMV"
   js:           https://cdn.jsdelivr.net/npm/figuration@3.0.0-beta.1/dist/js/figuration.min.js
   js_hash:      "sha384-Ioldl5vu4smctTKIGE8osHgTrlKihivvJg763NMr1kUObc6lOBKZIH1yPFpvYyVa"
+  css_rtl:      https://cdn.jsdelivr.net/npm/figuration@3.0.0-beta.1/dist/css/figuration-rtl.min.css
+  css_rtl_hash: ""
   jquery:       https://code.jquery.com/jquery-3.2.1.min.js
   jquery_hash:  "sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
   fontawe:      https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -4,6 +4,7 @@
             Current version: {{ site.current_version }}
         </p>
         <ul class="footer-links d-inline-block d-sm-block mx-auto mx-sm-0">
+            <li><a href="{{ site.baseurl }}/about/overview/">About</a></li>
             <li><a href="https://github.com/cast-org/figuration">GitHub Project</a></li>
             <li><a href="https://github.com/cast-org/figuration/issues">Issues</a></li>
             <li><a href="https://twitter.com/figuration_org">Twitter</a></li>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -17,9 +17,9 @@
 
 <!-- Core CSS -->
 {% if site.github %}
-  <link href="{{ site.baseurl }}/dist/css/figuration.min.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/dist/css/figuration.min.css" rel="stylesheet" id="cssCore">
 {% else %}
-  <link href="{{ site.baseurl }}/dist/css/figuration.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/dist/css/figuration.css" rel="stylesheet" id="cssCore">
 {% endif %}
 
 <!-- Algolia DocSearch CSS -->
@@ -29,9 +29,9 @@
 
 <!-- Docs CSS -->
 {% if site.github %}
-  <link href="{{ site.baseurl }}/assets/css/docs.min.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/assets/css/docs.min.css" rel="stylesheet" id="cssDocs">
 {% else %}
-  <link href="{{ site.baseurl }}/assets/css/docs.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/assets/css/docs.css" rel="stylesheet" id="cssDocs">
 {% endif %}
 
 <!-- jQuery -->

--- a/docs/_includes/icons/cog.svg
+++ b/docs/_includes/icons/cog.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" focusable="false" {% if include.class %} class="{{ include.class }}"{% endif %} {% if include.width %} class="{{ include.width }}"{% endif %} {% if include.height %} class="{{ include.height }}"{% endif %}>
+  <title>Settings</title>
+  <path fill="currentColor" d="M3.5 0l-.5 1.19c-.1.03-.19.08-.28.13l-1.19-.5-.72.72.5 1.19c-.05.1-.09.18-.13.28l-1.19.5v1l1.19.5c.04.1.08.18.13.28l-.5 1.19.72.72 1.19-.5c.09.04.18.09.28.13l.5 1.19h1l.5-1.19c.09-.04.19-.08.28-.13l1.19.5.72-.72-.5-1.19c.04-.09.09-.19.13-.28l1.19-.5v-1l-1.19-.5c-.03-.09-.08-.19-.13-.28l.5-1.19-.72-.72-1.19.5c-.09-.04-.19-.09-.28-.13l-.5-1.19h-1zm.5 2.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5-1.5-.67-1.5-1.5.67-1.5 1.5-1.5z"/>
+</svg>

--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -34,14 +34,24 @@
 
     <ul class="navbar-nav ml-auto cf-header-social">
         <li class="nav-item">
-            <a href="{{ site.twitter }}" class="nav-link" aria-label="Twitter">
+            <a href="{{ site.twitter }}" class="nav-link" aria-label="Twitter" title="Twitter">
                 {% include icons/twitter.svg class="cf-header-icon" %}
             </a>
         </li>
         <li class="nav-item">
-            <a href="{{ site.repo }}" class="nav-link" aria-label="Github">
+            <a href="{{ site.repo }}" class="nav-link" aria-label="Github" title="GitHub">
                 {% include icons/github.svg class="cf-header-icon" %}
             </a>
+        </li>
+        <li class="nav-item dropdown dropdown-menu-left">
+            <a href="#" role="button" class="nav-link" aria-label="Settings" title="Settings" data-cfw="dropdown">
+                {% include icons/cog.svg class="cf-header-icon" %}
+            </a>
+            <ul class="dropdown-menu">
+                <li class="dropdown-header">Direction</li>
+                <li><button type="button" class="dropdown-item" id="dir-ltr">Left to right <span aria-hidden="true">(LTR)</span></button></li>
+                <li><button type="button" class="dropdown-item" id="dir-rtl">Right to left <span aria-hidden="true">(RTL)</span></button></li>
+            </ul>
         </li>
         {% if site.github %}
         <li class="nav-item">

--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -6,7 +6,7 @@
     <button class="navbar-toggle flex-first mr-0_5" type="button" data-cfw="collapse" data-cfw-collapse-target="#cf-topnav" aria-label="Toggle navigation">
         <span class="cf-header-menu" aria-hidden="true">&#8801;</span>
     </button>
-    <div class="navbar-collapse collapse flex-last flex-lg-unordered" id="cf-topnav">
+    <div class="navbar-collapse collapse flex-last flex-lg-unordered flex-lg-shrink text-nowrap" id="cf-topnav">
         <ul class="navbar-nav">
             <li class="nav-item">
                 <a href="{{ site.baseurl }}/get-started/quick-start/" class="nav-link {% if page.group == "get-started" %}active{% endif %}">Get Started{% if page.group == "get-started" %} <span class="sr-only">(current section)</span>{% endif %}</a>
@@ -25,9 +25,6 @@
             </li>
             <li class="nav-item">
                 <a href="{{ site.baseurl }}/widgets/overview/" class="nav-link {% if page.group == "widgets" %}active{% endif %}">Widgets{% if page.group == "widgets" %} <span class="sr-only">(current section)</span>{% endif %}</a>
-            </li>
-            <li class="nav-item">
-                <a href="{{ site.baseurl }}/about/overview/" class="nav-link {% if page.group == "about" %}active{% endif %}">About{% if page.group == "about" %} <span class="sr-only">(current section)</span>{% endif %}</a>
             </li>
         </ul>
     </div>
@@ -49,8 +46,8 @@
             </a>
             <ul class="dropdown-menu">
                 <li class="dropdown-header">Direction</li>
-                <li><button type="button" class="dropdown-item" id="dir-ltr">Left to right <span aria-hidden="true">(LTR)</span></button></li>
-                <li><button type="button" class="dropdown-item" id="dir-rtl">Right to left <span aria-hidden="true">(RTL)</span></button></li>
+                <li><button type="button" class="dropdown-item" id="dir-ltr">Left-to-right</button></li>
+                <li><button type="button" class="dropdown-item" id="dir-rtl">Right-to-left</button></li>
             </ul>
         </li>
         {% if site.github %}

--- a/docs/_includes/nav-main.html
+++ b/docs/_includes/nav-main.html
@@ -40,7 +40,7 @@
                 {% include icons/github.svg class="cf-header-icon" %}
             </a>
         </li>
-        <li class="nav-item dropdown dropdown-menu-left">
+        <li class="nav-item dropdown dropdown-menu-reverse">
             <a href="#" role="button" class="nav-link" aria-label="Settings" title="Settings" data-cfw="dropdown">
                 {% include icons/cog.svg class="cf-header-icon" %}
             </a>

--- a/docs/assets/js/src/docs.js
+++ b/docs/assets/js/src/docs.js
@@ -130,20 +130,24 @@ function sectionToc() {
 
 function docsDirection() {
     function fileRename(id, filename) {
-        var re = /^(.*\/)?[^\/]+\.(css|min\.css)$/i;
-        var rep_str = '$1' + filename + '.$2';
         var $node = $('#' + id);
         var path = $node.attr('href');
+        var isMin = (path.indexOf('.min.css') >= 0) ? true : false;
+        var re = /^(.*\/)?[^\/]+\.(css)$/i;
+        var rep_str = '$1' + filename;
         path = path.replace(re, rep_str);
+        path += (isMin) ? '.min.css' : '.css';
         $node.attr('href', path);
     }
 
-    function setLTR() {
+    function setLTR(doReset) {
         $('#dir-ltr').closest('ul').find('.active').removeClass('active').removeAttr('aria-current');
         $('#dir-ltr').addClass('active').attr('aria-current', 'true');
         $('html').removeAttr('dir');
-        fileRename('cssCore', 'figuration');
-        fileRename('cssDocs', 'docs');
+        if (doReset) {
+            fileRename('cssCore', 'figuration');
+            fileRename('cssDocs', 'docs');
+        }
         document.cookie = 'docsDir=';
     }
 
@@ -175,7 +179,7 @@ function docsDirection() {
 
     $('#dir-ltr').on('click', function(e) {
         e.preventDefault();
-        setLTR();
+        setLTR(true);
     });
     $('#dir-rtl').on('click', function(e) {
         e.preventDefault();
@@ -187,7 +191,7 @@ function docsDirection() {
     if (getCookie('docsDir') === 'rtl') {
         setRTL();
     } else {
-        setLTR();
+        setLTR(false);
     }
 
 }

--- a/docs/assets/js/src/docs.js
+++ b/docs/assets/js/src/docs.js
@@ -157,10 +157,10 @@ function docsDirection() {
     }
 
     function getCookie(cname) {
-        var name = cname + "=";
+        var name = cname + '=';
         var decodedCookie = decodeURIComponent(document.cookie);
         var ca = decodedCookie.split(';');
-        for(var i = 0; i <ca.length; i++) {
+        for (var i = 0; i < ca.length; i++) {
             var c = ca[i];
             while (c.charAt(0) == ' ') {
                 c = c.substring(1);
@@ -169,7 +169,7 @@ function docsDirection() {
                 return c.substring(name.length, c.length);
             }
         }
-        return "";
+        return '';
     }
 
 

--- a/docs/assets/js/src/docs.js
+++ b/docs/assets/js/src/docs.js
@@ -128,6 +128,70 @@ function sectionToc() {
     });
 }
 
+function docsDirection() {
+    function fileRename(id, filename) {
+        var re = /^(.*\/)?[^\/]+\.(css|min\.css)$/i;
+        var rep_str = '$1' + filename + '.$2';
+        var $node = $('#' + id);
+        var path = $node.attr('href');
+        path = path.replace(re, rep_str);
+        $node.attr('href', path);
+    }
+
+    function setLTR() {
+        $('#dir-ltr').closest('ul').find('.active').removeClass('active').removeAttr('aria-current');
+        $('#dir-ltr').addClass('active').attr('aria-current', 'true');
+        $('html').removeAttr('dir');
+        fileRename('cssCore', 'figuration');
+        fileRename('cssDocs', 'docs');
+        document.cookie = 'docsDir=';
+    }
+
+    function setRTL() {
+        $('#dir-rtl').closest('ul').find('.active').removeClass('active').removeAttr('aria-current');
+        $('#dir-rtl').addClass('active').attr('aria-current', 'true');
+        $('html').attr('dir', 'rtl');
+        fileRename('cssCore', 'figuration-rtl');
+        fileRename('cssDocs', 'docs-rtl');
+        document.cookie = 'docsDir=rtl';
+    }
+
+    function getCookie(cname) {
+        var name = cname + "=";
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for(var i = 0; i <ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return "";
+    }
+
+
+    $('#dir-ltr').on('click', function(e) {
+        e.preventDefault();
+        setLTR();
+    });
+    $('#dir-rtl').on('click', function(e) {
+        e.preventDefault();
+        setRTL();
+    });
+
+    // Check on load
+    var settings = document.cookie;
+    if (getCookie('docsDir') === 'rtl') {
+        setRTL();
+    } else {
+        setLTR();
+    }
+
+}
+
 // Direction for player dropdown menus
 $(document, '[data-cfw="player"]').on('ready.cfw.player', function(e) {
     $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropdown-menu-left');
@@ -140,6 +204,7 @@ $(window).ready(function() {
     topLinkAffix();
     paletteHex();
     sectionToc();
+    docsDirection();
 
     // Indeterminate checkbox example
     $('.cf-example-indeterminate [type="checkbox"]').prop('indeterminate', true);

--- a/docs/assets/js/src/docs.js
+++ b/docs/assets/js/src/docs.js
@@ -91,7 +91,7 @@ function paletteHex() {
         $items.each(function() {
             $this = $(this);
             color = rgb2hex($this.css('background-color'));
-            $this.append('<span class="float-right">' + color + '</span>');
+            $this.append('<span class="float-end">' + color + '</span>');
         });
     }
 }
@@ -198,8 +198,8 @@ function docsDirection() {
 
 // Direction for player dropdown menus
 $(document, '[data-cfw="player"]').on('ready.cfw.player', function(e) {
-    $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropdown-menu-left');
-    $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropdown-menu-left');
+    $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropdown-menu-reverse');
+    $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropdown-menu-reverse');
 });
 
 $(window).ready(function() {

--- a/docs/assets/scss/_search.scss
+++ b/docs/assets/scss/_search.scss
@@ -13,7 +13,11 @@
     clear: both;
 
     @media (max-width: 66em) {
-        width: 7.5rem;
+        width: 10rem;
+    }
+
+    @include media-breakpoint-down(xs) {
+        width: 5.5rem;
     }
 
     &::before {

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -224,7 +224,7 @@ $docs-color: #246;
     position: relative;
     z-index: 2;
     display: block;
-    float: right;
+    float: right #{"/*rtl:ignore*/"};
     line-height: 1;
 
     + .highlight {
@@ -238,7 +238,7 @@ $docs-color: #246;
 .btn-clipboard {
     position: absolute;
     top: 0;
-    right: 0;
+    right: 0 #{"/*rtl:ignore*/"};
 }
 
 // TOC
@@ -425,9 +425,12 @@ h4 {
     border: 1px solid #e1e1e8;
     border-radius: .25rem;
 
+    // Use SASS interpolation syntax, for passing comment as string
     pre {
+        direction: ltr #{"/*rtl:ignore*/"};
         padding: 1.65rem 1rem .5rem;
         margin: 0;
+        text-align: left #{"/*rtl:ignore*/"};
         background-color: transparent;
         border: 0;
     }

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -94,6 +94,11 @@ $docs-color: #246;
         padding-right: .5rem;
         padding-left: .5rem;
     }
+
+    .dropdown-menu {
+        position: absolute !important;
+        float: left !important;
+    }
 }
 
 .cf-header-menu {
@@ -155,6 +160,7 @@ $docs-color: #246;
 
     .logo-home {
         display: block;
+        width: 100%;
         margin: 0 auto;
         filter: drop-shadow(0 0 7px rgba(255,255,255,.15));
     }

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -327,7 +327,7 @@ You can quickly change the text alignment of any card---in its entirety or speci
   </div>
 </div>
 
-<div class="card text-right" style="width: 20rem;">
+<div class="card text-end" style="width: 20rem;">
   <div class="card-body">
     <h4 class="card-title">Special title treatment</h4>
     <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
@@ -826,7 +826,7 @@ Responsive variants are available with the class syntax of `.card-columns{-break
   <div class="card">
     <img class="card-img img-fluid" data-src="holder.js/100px260/" alt="Card image">
   </div>
-  <div class="card text-right">
+  <div class="card text-end">
     <div class="card-body">
       <blockquote class="blockquote">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>

--- a/docs/components/input-group.md
+++ b/docs/components/input-group.md
@@ -176,11 +176,11 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
   <div class="col-lg-6">
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with dropdown button">
-      <div class="input-group-btn">
+      <div class="input-group-btn dropdown-menu-reverse">
         <button type="button" class="btn dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu dropdown-menu-right">
+        <ul class="dropdown-menu">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>
@@ -218,12 +218,12 @@ Buttons in input groups must wrapped in a `.input-group-btn` for proper alignmen
   <div class="col-lg-6">
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with segmented button dropdown">
-      <div class="input-group-btn">
+      <div class="input-group-btn dropdown-menu-reverse">
         <button type="button" class="btn">Action</button>
         <button type="button" class="btn dropdown-toggle dropdown-toggle-split" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-right">
+        <ul class="dropdown-menu">
           <li><a class="dropdown-item" href="#">Action</a></li>
           <li><a class="dropdown-item" href="#">Another action</a></li>
           <li><a class="dropdown-item" href="#">Something else here</a></li>

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -693,7 +693,7 @@ Here are some examples to show what we mean.
           <a href="#" class="nav-link disabled" tabindex="-1">Disabled</a>
         </li>
       </ul>
-      <form class="form-inline float-right">
+      <form class="form-inline float-end">
         <input class="form-control mr-0_25" type="text" placeholder="Search" aria-label="Search">
         <button class="btn btn-secondary" type="submit">Search</button>
       </form>
@@ -717,7 +717,7 @@ Here are some examples to show what we mean.
           <a href="#" class="nav-link disabled" tabindex="-1">Disabled</a>
         </li>
       </ul>
-      <form class="form-inline float-right">
+      <form class="form-inline float-end">
         <input class="form-control mr-0_25" type="text" placeholder="Search" aria-label="Search">
         <button class="btn btn-secondary" type="submit">Search</button>
       </form>
@@ -741,7 +741,7 @@ Here are some examples to show what we mean.
           <a href="#" class="nav-link disabled" tabindex="-1">Disabled</a>
         </li>
       </ul>
-      <form class="form-inline float-right">
+      <form class="form-inline float-end">
         <input class="form-control mr-0_25" type="text" placeholder="Search" aria-label="Search">
         <button class="btn btn-outline-primary" type="submit">Search</button>
       </form>

--- a/docs/content/figures.md
+++ b/docs/content/figures.md
@@ -20,6 +20,6 @@ Aligning the figure's caption is easy with our [text utilities]({{ site.baseurl 
 {% example html %}
 <figure class="figure">
   <img data-src="holder.js/400x300" class="figure-img img-fluid radius" alt="A generic square placeholder image with rounded corners in a figure.">
-  <figcaption class="figure-caption text-right">A caption for the above image.</figcaption>
+  <figcaption class="figure-caption text-end">A caption for the above image.</figcaption>
 </figure>
 {% endexample %}

--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -391,8 +391,8 @@ Be sure to add `.form-control-label` to your `<label>`s as well so they're verti
     </div>
     <div class="form-group row">
       <fieldset class="w-100 clearfix">
-        <legend class="col-sm-2 float-sm-left form-control-legend">Radios</legend>
-        <div class="col-sm-10 float-sm-left">
+        <legend class="col-sm-2 float-sm-start form-control-legend">Radios</legend>
+        <div class="col-sm-10 float-sm-start">
           <div class="form-check">
             <label class="form-check-label">
               <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
@@ -416,8 +416,8 @@ Be sure to add `.form-control-label` to your `<label>`s as well so they're verti
     </div>
     <div class="form-group row">
       <fieldset class="w-100 clearfix">
-        <legend class="col-sm-2 float-sm-left form-control-legend">Checkbox</legend>
-        <div class="col-sm-10 float-sm-left">
+        <legend class="col-sm-2 float-sm-start form-control-legend">Checkbox</legend>
+        <div class="col-sm-10 float-sm-start">
           <div class="form-check">
             <label class="form-check-label">
               <input class="form-check-input" type="checkbox"> Check me out

--- a/docs/content/images.md
+++ b/docs/content/images.md
@@ -50,13 +50,13 @@ You might also want to check the [border utilites]({{ site.baseurl }}/utilities/
 Align images with the [helper float classes]({{ site.baseurl }}/utilities/floating/) or [text alignment classes]({{ site.baseurl }}/utilities/typography/#text-alignment). `block`-level images can be centered using [the `.mx-auto` margin utility class]({{ site.baseurl }}/utilities/spacing/#horizontal-centering).
 
 <div class="cf-example clearfix">
-  <img data-src="holder.js/200x200" class="radius float-left" alt="A generic square placeholder image with rounded corners">
-  <img data-src="holder.js/200x200" class="radius float-right" alt="A generic square placeholder image with rounded corners">
+  <img data-src="holder.js/200x200" class="radius float-start" alt="A generic square placeholder image with rounded corners">
+  <img data-src="holder.js/200x200" class="radius float-end" alt="A generic square placeholder image with rounded corners">
 </div>
 
 {% highlight html %}
-<img src="..." class="radius float-left" alt="...">
-<img src="..." class="radius float-right" alt="...">
+<img src="..." class="radius float-start" alt="...">
+<img src="..." class="radius float-end" alt="...">
 {% endhighlight %}
 
 <div class="cf-example clearfix">

--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -144,7 +144,7 @@ Use [text alignment utilities]({{ site.baseurl }}/utilities/typography/#text-ali
 {% endexample %}
 
 {% example html %}
-<blockquote class="blockquote text-right">
+<blockquote class="blockquote text-end">
   <p class="mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite title="Source Title">Source Title</cite></footer>
 </blockquote>

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -58,6 +58,48 @@ Essentially something like this:
 
 That should be all you need for overall page requirements. Visit the [Layout docs]({{ site.baseurl }}/layout/overview/) to begin building out your content and components.
 
+## Right-to-left Support
+
+Working with a language that reads from right to left? Use the `rtl` version of the Figuration CSS.  The markup and classes are the same between the `ltr` and `rtl` versions of Figuration.
+
+**Pro Tip!** We have included a way to preview layout, component, and widget behavior with the documentation.  Use the **settings** menu in the top navbar to change between text directions.
+
+The steps needed to switch from `ltr` to `rtl` mode are:
+- Add the `dir="rtl"` attribute to the `<html>` tag.
+- Update the `lang` attribute on the `<html>` tag to match the language being used.
+    - Refer to this [list of language codes](https://www.loc.gov/standards/iso639-2/php/code_list.php) provided by the US Library of Congress to find the one you require.
+    {% highlight html %}
+    <!-- This example is for a right-to-left Arabic layout -->
+    <html lang="ar" dir="rtl">
+    {% endhighlight %}
+- Load the `rtl` version of the Figuration CSS.  Load this **in place of** the default Figuration CSS.
+    {% highlight html %}
+    <!-- Figuration RTL CSS -->
+    <link rel="stylesheet" href="{{ site.cdn.css_rtl }}" integrity="{{ site.cdn.css_rtl_hash }}" crossorigin="anonymous">
+    {% endhighlight %}
+
+When complete, the basic template for a right-to-left markup should look like the following example.
+{% highlight html %}
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Figuration RTL CSS -->
+    <link rel="stylesheet" href="{{ site.cdn.css_rtl }}" integrity="{{ site.cdn.css_rtl_hash }}" crossorigin="anonymous">
+
+    <!-- jQuery and Figuration JS -->
+    <script src="{{ site.cdn.jquery }}" integrity="{{ site.cdn.jquery_hash }}" crossorigin="anonymous"></script>
+    <script src="{{ site.cdn.js }}" integrity="{{ site.cdn.js_hash }}" crossorigin="anonymous"></script>
+  </head>
+  <body>
+    <h1>Hello, world!</h1>
+  </body>
+</html>
+{% endhighlight %}
+
 ## Important Markup
 
 Figuration depends a handful of important global styles and settings that you'll need to be aware of when using it, all of which are almost exclusively geared towards the *normalization* of cross browser styles.

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,13 +18,13 @@ title: CAST Figuration - A feature rich, responsive, mobile first, accessible, f
                     <img src="{{ site.baseurl }}/assets/brand/figuration-solid.svg" class="logo-home ing-fluid" alt="" aria-hidden="true" />
                 </div>
                 <div class="w-100 d-md-none"></div>
-                <div class="col col-sm-9 col-md-7 col-lg-6 mx-auto mx-md-0 text-center text-md-left">
+                <div class="col col-sm-9 col-md-7 col-lg-6 mx-auto mx-md-0 text-center text-md-start">
                     <h1>CAST Figuration</h1>
                     <p class="lead">
                         A feature rich, responsive, mobile first, accessible, front-end framework.
                     </p>
 
-                    <div class="row text-center text-md-left">
+                    <div class="row text-center text-md-start">
                         <div class="col col-md-auto">
                             <a href="{{ site.baseurl }}/get-started/download/" class="btn btn-lg btn-start" onclick="ga('send', 'event', 'Homepage', 'Download', 'Download {{ site.current_version }}');">Download</a>
                         </div>
@@ -90,7 +90,7 @@ title: CAST Figuration - A feature rich, responsive, mobile first, accessible, f
     </div>
 
     <div class="container container-divider pt-2 mt-2">
-        <div class="row text-center text-md-left">
+        <div class="row text-center text-md-start">
             <div class="col-12 col-md-6">
                 <h2>Get Started Now</h2>
                 <p>Quickly get up and running with Figuration by including the compiled CSS and JS in your document. Add the following CDN links in the <code>&lt;head&gt;</code> of your HTML document.</p>
@@ -108,7 +108,7 @@ title: CAST Figuration - A feature rich, responsive, mobile first, accessible, f
     </div>
 
     <div class="container container-divider pt-2 mt-2">
-        <div class="row text-center text-md-left">
+        <div class="row text-center text-md-start">
             <div class="col-12 col-md-6">
                 <h2>Flexbox Enabled</h2>
                 <p>Many of Figuration's components, but not all, are built using flexbox.  This means enhanced layout and alignment control, but it does come at the cost of not being able to support older browsers.</p>
@@ -126,7 +126,7 @@ title: CAST Figuration - A feature rich, responsive, mobile first, accessible, f
     </div>
 
     <div class="container container-divider pt-2 mt-2">
-        <div class="row text-center text-md-left">
+        <div class="row text-center text-md-start">
             <div class="col-12 col-sm-6 col-lg-4">
                 <h2>Browser Support</h2>
                 <p>Most current browers are supported.  Additional details can be found on the <a href="{{ site.baseurl }}//get-started/browsers-devices/">Browsers &amp; Devices page</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@ title: CAST Figuration - A feature rich, responsive, mobile first, accessible, f
         <div class="container">
             <div class="splash-home row flex-md-center flex-md-items-center pb-2 mb-2">
                 <div class="col-6 col-sm-4 col-xl-3 mx-auto mx-md-0">
-                    <img src="{{ site.baseurl }}/assets/brand/figuration-solid.svg" class="logo-home ing-fluid" alt="" aria-hidden="true" />
+                    <img src="{{ site.baseurl }}/assets/brand/figuration-solid.svg" class="logo-home img-fluid" alt="" aria-hidden="true" />
                 </div>
                 <div class="w-100 d-md-none"></div>
                 <div class="col col-sm-9 col-md-7 col-lg-6 mx-auto mx-md-0 text-center text-md-start">

--- a/docs/layout/overview.md
+++ b/docs/layout/overview.md
@@ -191,11 +191,11 @@ The only special case is where there are `*-up` or `*-down` variants for certain
 A quick example using some of Figuration's [Typography utility classes]({{ site.baseurl }}/utilities/typography).
 
 {% example html %}
-<p class="text-right">Right aligned text on all viewport sizes. (<strong>No <code>xs</code> class designation!</strong>)</p>
-<p class="text-sm-right">Right aligned text on viewports sized SM (small) or wider.</p>
-<p class="text-md-right">Right aligned text on viewports sized MD (medium) or wider.</p>
-<p class="text-lg-right">Right aligned text on viewports sized LG (large) or wider.</p>
-<p class="text-xl-right">Right aligned text on viewports sized XL (extra-large) or wider.</p>
+<p class="text-end">Right aligned text on all viewport sizes. (<strong>No <code>xs</code> class designation!</strong>)</p>
+<p class="text-sm-end">Right aligned text on viewports sized SM (small) or wider.</p>
+<p class="text-md-end">Right aligned text on viewports sized MD (medium) or wider.</p>
+<p class="text-lg-end">Right aligned text on viewports sized LG (large) or wider.</p>
+<p class="text-xl-end">Right aligned text on viewports sized XL (extra-large) or wider.</p>
 {% endexample %}
 
 ## Z-index

--- a/docs/utilities/clearfix.md
+++ b/docs/utilities/clearfix.md
@@ -33,26 +33,26 @@ The following example shows how the clearfix can be used. Without the clearfix t
 <div class="cf-example">
     <strong>With <code>.clearfix</code></strong>
     <div class="bg-info clearfix mb-1">
-        <button class="btn float-left">Button floated left</button>
-        <button class="btn float-right">Button floated right</button>
+        <button class="btn float-start">Button floated to start</button>
+        <button class="btn float-end">Button floated to end</button>
     </div>
 
     <strong>Without <code>.clearfix</code></strong>
     <div class="bg-info">
-        <button class="btn float-left">Button floated left</button>
-        <button class="btn float-right">Button floated right</button>
+        <button class="btn float-start">Button floated to start</button>
+        <button class="btn float-end">Button floated to end</button>
     </div>
 </div>
 {% highlight html %}
     <!-- With .clearfix -->
     <div class="bg-info clearfix">
-        <button class="btn float-left">Button floated left</button>
-        <button class="btn float-right">Button floated right</button>
+        <button class="btn float-start">Button floated to start</button>
+        <button class="btn float-end">Button floated to end</button>
     </div>
 
     <!-- Without .clearfix -->
     <div class="bg-info">
-        <button class="btn float-left">Button floated left</button>
-        <button class="btn float-right">Button floated right</button>
+        <button class="btn float-start">Button floated to start</button>
+        <button class="btn float-end">Button floated to end</button>
     </div>
 {% endhighlight %}

--- a/docs/utilities/floating.md
+++ b/docs/utilities/floating.md
@@ -4,26 +4,28 @@ title: Floating
 group: utilities
 ---
 
-These utility classes float an element to the left or right, or disable floating, based on the current viewport size using the [CSS `float` property](https://developer.mozilla.org/en-US/docs/Web/CSS/float). `!important` is included to avoid specificity issues. These use the same viewport width breakpoints as the grid system.
+These utility classes float an element to the enable or disable floating, based on the current viewport size using the [CSS `float` property](https://developer.mozilla.org/en-US/docs/Web/CSS/float).
+
+Instead of using `left/right` designators, the float utilities use `start/end` designators to match up with the [flexbox utilities]({{ site.baseurl }}/utilities/flexbox/).
 
 {% example html %}
-<div class="float-left">Float left on all viewport sizes</div><br>
-<div class="float-right">Float right on all viewport sizes</div><br>
+<div class="float-start">Float start aligned on all viewport sizes</div><br>
+<div class="float-end">Float end aligned on all viewport sizes</div><br>
 <div class="float-none">Don't float on all viewport sizes</div><br>
 
-<div class="float-sm-right">Float right on viewports sized SM (small) or wider</div><br>
-<div class="float-md-right">Float right on viewports sized MD (medium) or wider</div><br>
-<div class="float-lg-right">Float right on viewports sized LG (large) or wider</div><br>
-<div class="float-xl-right">Float right on viewports sized XL (extra-large) or wider</div><br>
+<div class="float-sm-end">Float end aligned on viewports sized SM (small) or wider</div><br>
+<div class="float-md-end">Float end aligned on viewports sized MD (medium) or wider</div><br>
+<div class="float-lg-end">Float end aligned on viewports sized LG (large) or wider</div><br>
+<div class="float-xl-end">Float end aligned on viewports sized XL (extra-large) or wider</div><br>
 {% endexample %}
 
 {% highlight scss %}
 // Related simple non-responsive mixins
 .element {
-  @include float-left;
+  @include float-start;
 }
 .another-element {
-  @include float-right;
+  @include float-end;
 }
 .unfloated-element {
   @include float-none;

--- a/docs/utilities/typography.md
+++ b/docs/utilities/typography.md
@@ -22,15 +22,17 @@ Easily realign text to components with text alignment classes.
 
 For left, right, and center alignment, responsive classes are available that use the same viewport width breakpoints as the grid system.  Please refer to how our [breakpoint nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) is used.
 
-{% example html %}
-<p class="text-left">Left aligned text on all viewport sizes.</p>
-<p class="text-center">Center aligned text on all viewport sizes.</p>
-<p class="text-right">Right aligned text on all viewport sizes.</p>
+Instead of using `left/right` designators, the text alignment utilities use `start/end` designators to match up with the [flexbox utilities]({{ site.baseurl }}/utilities/flexbox/).
 
-<p class="text-sm-right">Right aligned text on viewports sized SM (small) or wider.</p>
-<p class="text-md-right">Right aligned text on viewports sized MD (medium) or wider.</p>
-<p class="text-lg-right">Right aligned text on viewports sized LG (large) or wider.</p>
-<p class="text-xl-right">Right aligned text on viewports sized XL (extra-large) or wider.</p>
+{% example html %}
+<p class="text-start">Start aligned text on all viewport sizes.</p>
+<p class="text-center">Center aligned text on all viewport sizes.</p>
+<p class="text-end">End aligned text on all viewport sizes.</p>
+
+<p class="text-sm-end">End aligned text on viewports sized SM (small) or wider.</p>
+<p class="text-md-end">End aligned text on viewports sized MD (medium) or wider.</p>
+<p class="text-lg-end">End aligned text on viewports sized LG (large) or wider.</p>
+<p class="text-xl-end">End aligned text on viewports sized XL (extra-large) or wider.</p>
 {% endexample %}
 
 ## Text Wrap and Truncate

--- a/docs/utilities/vertical-alignment.md
+++ b/docs/utilities/vertical-alignment.md
@@ -63,7 +63,7 @@ Slightly more complex uses, such as being able to align items in a row, become q
         <a href="#">View more in teacher's guide</a> |
         <a href="#">Common Core alignment</a>
     </div>
-    <div class="d-table-cell valign-bottom text-right">
+    <div class="d-table-cell valign-bottom text-end">
         <button type="button" class="btn btn-primary btn-lg">Continue</button>
     </div>
 </div>

--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -399,14 +399,16 @@ Trigger dropdown menus above elements by adding `.dropup` to the parent element.
 
 ### Menu Alignment
 
-By default, a dropdown menu is automatically positioned 100% from the top and along the left side of its parent.  While submenu items are aligned 100% to the left and to the top of its parent.
+By default, a dropdown menu is automatically positioned 100% from the top and aligned to the left side of its parent.  While submenu items are aligned 100% from the left and to the top of its parent.
 
-Add `.dropdown-menu-left` to a `.dropdown-menu` to right align the dropdown menu, this will also make all submenus open to the left side.  This can also be combined with `.dropup`.
+Add `.dropdown-menu-reverse` to a `.dropdown-menu` to align the dropdown menu to the right side of the parent. This will also make all submenus open out to the left side.  This can also be combined with `.dropup`.
+
+**Heads up!** When using the right-to-left, `rtl`, variant of Figuration all horizontal directions will be reversed.  Meaning left becomes right, and vice-versa.
 
 {% example html %}
-<div class="dropdown dropdown-menu-left float-right">
+<div class="dropdown dropdown-menu-reverse float-end">
     <button type="button" class="btn btn-primary dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
-        Drop Left
+        Reverse Dropdown
     </button>
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
@@ -436,7 +438,7 @@ Add `.dropdown-menu-left` to a `.dropdown-menu` to right align the dropdown menu
 
 ### Submenu Alignment
 
-The menu alignment class of `.dropdown-menu-left` will also work with submenu items, and you can use the available `.dropdown-menu-right` to switch submenu directions if needed.  Simply place either class on the `li` parent of the submenu list.
+The menu alignment class of `.dropdown-menu-reverse` will also work with submenu items, and you can use the available `.dropdown-menu-forward` to switch submenu directions if needed.  Simply place either class on the `li` parent of the submenu list.
 
 {% example html %}
 <div class="dropdown">
@@ -446,18 +448,18 @@ The menu alignment class of `.dropdown-menu-left` will also work with submenu it
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
-            <a href="#">Left menu</a>
+        <li class="dropdown-menu-reverse">
+            <a href="#">Reverse menu</a>
             <ul>
-                <li class="dropdown-menu-left">
-                    <a href="#">Left menu</a>
+                <li class="dropdown-menu-reverse">
+                    <a href="#">Reverse menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
-                    <a href="#">Right menu</a>
+                <li class="dropdown-menu-forward">
+                    <a href="#">Forward menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
@@ -465,18 +467,18 @@ The menu alignment class of `.dropdown-menu-left` will also work with submenu it
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
-            <a href="#">Right menu</a>
+        <li class="dropdown-menu-forward">
+            <a href="#">Forward menu</a>
             <ul>
-                <li class="dropdown-menu-left">
-                    <a href="#">Left menu</a>
+                <li class="dropdown-menu-reverse">
+                    <a href="#">Reverse menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
-                    <a href="#">Right menu</a>
+                <li class="dropdown-menu-forward">
+                    <a href="#">Forward menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -36,7 +36,9 @@ Important notes about using the popover widget:
 
 ### Static Popover
 
-Four options are available: top, right, bottom, and left aligned.
+Four options are available: top, forward( right), bottom, and reverse (left) aligned.
+
+**Heads up!** When using the right-to-left, `rtl`, variant of Figuration all horizontal directions will be reversed.  Meaning left becomes right, and vice-versa.
 
 <div class="cf-example cf-example-bottom cf-example-popover">
     <div class="popover top">
@@ -47,8 +49,8 @@ Four options are available: top, right, bottom, and left aligned.
         <div class="popover-arrow"></div>
     </div>
 
-    <div class="popover right">
-        <h3 class="popover-header">Popover right</h3>
+    <div class="popover forward">
+        <h3 class="popover-header">Forward popover</h3>
         <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
@@ -63,8 +65,8 @@ Four options are available: top, right, bottom, and left aligned.
         <div class="popover-arrow"></div>
     </div>
 
-    <div class="popover left">
-        <h3 class="popover-header">Popover left</h3>
+    <div class="popover reverse">
+        <h3 class="popover-header">Reverse popover</h3>
         <div class="popover-body">
             <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
         </div>
@@ -79,29 +81,29 @@ Four options are available: top, right, bottom, and left aligned.
   Popover on top
 </button>
 
-<button type="button" class="btn" data-cfw="popover" data-cfw-popover-container="body" data-cfw-popover-placement="right" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-  Popover on right
+<button type="button" class="btn" data-cfw="popover" data-cfw-popover-container="body" data-cfw-popover-placement="forward" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+  Forward popover
 </button>
 
 <button type="button" class="btn" data-cfw="popover" data-cfw-popover-container="body" data-cfw-popover-placement="bottom" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
   Popover on bottom
 </button>
 
-<button type="button" class="btn" data-cfw="popover" data-cfw-popover-container="body" data-cfw-popover-placement="left" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-  Popover on left
+<button type="button" class="btn" data-cfw="popover" data-cfw-popover-container="body" data-cfw-popover-placement="reverse" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+  Reverse popover
 </button>
 {% endexample %}
 
 ### Default Toggle Example
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="popover" title="Click Popover Example" data-cfw-popover-content="Click the trigger or close button to close me." data-cfw-popover-placement="right">Click to toggle popover</button>
+<button type="button" class="btn btn-info" data-cfw="popover" title="Click Popover Example" data-cfw-popover-content="Click the trigger or close button to close me." data-cfw-popover-placement="forward">Click to toggle popover</button>
 {% endexample %}
 
 ### Hover Example
 
 {% example html %}
-<button type="button" class="btn btn-info" id="cf-example-hover-popover" data-cfw="popover" title="Hover Popover Example" data-cfw-popover-content="Stop hovering over the trigger or the popover to auto-close." data-cfw-popover-placement="right" data-cfw-popover-trigger="hover focus">Hover/focus to show popover</button>
+<button type="button" class="btn btn-info" id="cf-example-hover-popover" data-cfw="popover" title="Hover Popover Example" data-cfw-popover-content="Stop hovering over the trigger or the popover to auto-close." data-cfw-popover-placement="forward" data-cfw-popover-trigger="hover focus">Hover/focus to show popover</button>
 {% endexample %}
 
 <script>
@@ -115,13 +117,13 @@ Four options are available: top, right, bottom, and left aligned.
 Allow users to move popovers around the screen by enabling the `drag` option.  Drag support mouse, keyboard (with arrow keys), and touch movement.
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="popover" title="Draggable Popover Example" data-cfw-popover-content="Click the trigger or close link to close me." data-cfw-popover-placement="right" data-cfw-popover-drag="true">Draggable popover</button>
+<button type="button" class="btn btn-info" data-cfw="popover" title="Draggable Popover Example" data-cfw-popover-content="Click the trigger or close link to close me." data-cfw-popover-placement="forward" data-cfw-popover-drag="true">Draggable popover</button>
 {% endexample %}
 
 ### Popover with HTML
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-html="true" data-cfw-popover-placement="right" data-cfw-popover-content="<em>Popover</em> <u>with</u> <b>HTML</b>" title="<em>Popover</em> <u>with</u> <b>HTML</b>">Popover with HTML</button>
+<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-html="true" data-cfw-popover-placement="forward" data-cfw-popover-content="<em>Popover</em> <u>with</u> <b>HTML</b>" title="<em>Popover</em> <u>with</u> <b>HTML</b>">Popover with HTML</button>
 {% endexample %}
 
 If using more complex HTML, using a data attribute might not be optimal.  A better option would be to use the Javascript options, or with a pre-generated popover, as shown in the following example.
@@ -140,10 +142,10 @@ $('#html-popover').CFW_Popover({
 
 ### Pre-generated Popover
 
-Have a complex content that you would like to show in a popover, or one that is updated dynamically?  Create the popover and then link to it with the `toggle` option.
+Have a complex content that you would like to show in a popover, or one that is updated dynamically?  Create the popover and then link to it with the `target` option.
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#popoverExample0" data-cfw-popover-placement="right">Show Popover</button>
+<button type="button" class="btn btn-info" data-cfw="popover" data-cfw-popover-target="#popoverExample0" data-cfw-popover-placement="forward">Show Popover</button>
 
 <div class="popover" id="popoverExample0">
     <h3 class="popover-header">Popover title</h3>
@@ -190,7 +192,7 @@ Keep popovers in their place with the `viewport` option.
 
     <button class="btn btn-info popover-viewport-right" title="This should be shifted down">Shift Down</button>
 
-    <button class="btn btn-info float-right popover-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
+    <button class="btn btn-info float-end popover-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
 
     <button class="btn btn-info popover-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
 
@@ -198,7 +200,7 @@ Keep popovers in their place with the `viewport` option.
 </div>
 <script>
     $('.popover-viewport-right').CFW_Popover({
-        placement: 'right',
+        placement: 'forward',
         viewport: '#viewport-popover',
         padding: 2
     });
@@ -249,7 +251,7 @@ Draggable popovers will force the following settings:
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-popover`, as in `data-cfw-popover-placement="right"`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-popover`, as in `data-cfw-popover-placement="forward"`.
 
 <table class="table table-scroll table-bordered table-striped">
 <thead>
@@ -280,9 +282,9 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>
             <p>
                 <strong>string:</strong><br />
-                How to position the popover - top | bottom | left | right | auto.
+                How to position the popover - top | bottom | reverse | forward | auto.
                 <br />
-                When "auto" is specified, it will dynamically reorient the popover. For example, if placement is "auto left", the popover will display to the left when possible, otherwise it will display right.
+                When "auto" is specified, it will dynamically reorient the popover. For example, if placement is "auto reverse", the popover will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
             </p>
             <p>
                 <strong>object:</strong><br />
@@ -425,7 +427,7 @@ Activates a popover on a given element. Accepts an optional options `object`.
 
 {% highlight js %}
 $('#myPopover').CFW_Popover({
-    placement: 'right'
+    placement: 'forward'
 });
 {% endhighlight %}
 

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -23,7 +23,9 @@ Important notes about using the tooltip widget:
 
 ### Static Tooltip
 
-Four options are available: top, right, bottom, and left aligned.
+Four options are available: top, forward (right), bottom, and reverse (left) aligned.
+
+**Heads up!** When using the right-to-left, `rtl`, variant of Figuration all horizontal directions will be reversed.  Meaning left becomes right, and vice-versa.
 
 <div class="cf-example cf-example-bottom cf-example-tooltip">
     <div class="tooltip top" role="tooltip">
@@ -33,9 +35,9 @@ Four options are available: top, right, bottom, and left aligned.
         <div class="tooltip-arrow"></div>
     </div>
 
-    <div class="tooltip right" role="tooltip">
+    <div class="tooltip forward" role="tooltip">
         <div class="tooltip-body">
-            Tooltip on the right
+            Forward tooltip
         </div>
         <div class="tooltip-arrow"></div>
     </div>
@@ -47,9 +49,9 @@ Four options are available: top, right, bottom, and left aligned.
         <div class="tooltip-arrow"></div>
     </div>
 
-    <div class="tooltip left" role="tooltip">
+    <div class="tooltip reverse" role="tooltip">
         <div class="tooltip-body">
-            Tooltip on the left
+            Reverse tooltip
         </div>
         <div class="tooltip-arrow"></div>
     </div>
@@ -62,16 +64,16 @@ Four options are available: top, right, bottom, and left aligned.
     Tooltip on top
 </button>
 
-<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="right" title="Tooltip on right">
-    Tooltip on right
+<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="forward" title="Forward tooltip">
+    Forward tooltip
 </button>
 
 <button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="bottom" title="Tooltip on bottom">
     Tooltip on bottom
 </button>
 
-<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="left" title="Tooltip on left">
-    Tooltip on left
+<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-container="body" data-cfw-tooltip-placement="reverse" title="Reverse tooltip">
+    Reverse tooltip
 </button>
 {% endexample %}
 
@@ -92,13 +94,13 @@ Four options are available: top, right, bottom, and left aligned.
 ### Toggle Example
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="tooltip" title="Click the trigger or close button to close me." data-cfw-tooltip-placement="right" data-cfw-tooltip-trigger="click">Click to toggle tooltip</button>
+<button type="button" class="btn btn-info" data-cfw="tooltip" title="Click the trigger or close button to close me." data-cfw-tooltip-placement="forward" data-cfw-tooltip-trigger="click">Click to toggle tooltip</button>
 {% endexample %}
 
 ### Tooltip with HTML
 
 {% example html %}
-<button type="button" class="btn btn-info" data-cfw="tooltip" data-cfw-tooltip-html="true" data-cfw-tooltip-placement="right" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">Tooltip with HTML</button>
+<button type="button" class="btn btn-info" data-cfw="tooltip" data-cfw-tooltip-html="true" data-cfw-tooltip-placement="forward" title="<em>Tooltip</em> <u>with</u> <b>HTML</b>">Tooltip with HTML</button>
 {% endexample %}
 
 When using more complex HTML, using a data attribute might not be optimal.  A better option would be to use the Javascript options.
@@ -109,7 +111,7 @@ When using more complex HTML, using a data attribute might not be optimal.  A be
 <script>
 $('#html-tooltip').CFW_Tooltip({
     html: true,
-    placement: 'right',
+    placement: 'forward',
     title: '<span aria-hidden="true">&middot;</span> <em>Tooltip</em> <u>with</u> <b>HTML</b>'
 });
 </script>
@@ -127,13 +129,13 @@ Keep tooltips in their place with the `viewport` option.
 
     <button type="button" class="btn btn-default tooltip-viewport-right" title="This should be shifted down">Shift Down</button>
 
-    <button type="button" class="btn btn-default float-right tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
+    <button type="button" class="btn btn-default float-end tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
 
     <button type="button" class="btn btn-default tooltip-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
 </div>
 <script>
     $('.tooltip-viewport-right').CFW_Tooltip({
-        placement: 'right',
+        placement: 'forward',
         viewport: '#viewport-tooltip',
         padding: 2
     });
@@ -169,7 +171,7 @@ Any element with a data attribute of `data-cfw-dismiss="tooltip"` within the too
 
 ### Options
 
-Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tooltip`, as in `data-cfw-tooltip-placement="right"`.
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tooltip`, as in `data-cfw-tooltip-placement="forward"`.
 
 <table class="table table-scroll table-bordered table-striped">
 <thead>
@@ -182,10 +184,10 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
 </thead>
 <tbody>
     <tr>
-        <td>toggle</td>
+        <td>target</td>
         <td>string</td>
         <td>null</td>
-        <td>Either the selector (jQuery style), or the string related to the target tooltip having a <code>data-cfw-tooltip-target</code> attribute.</td>
+        <td>The selector (jQuery style) of the target popover.</td>
     </tr>
     <tr>
         <td>animate</td>
@@ -200,9 +202,9 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>
             <p>
                 <strong>string:</strong><br />
-                How to position the tooltip - top | bottom | left | right | auto.
+                How to position the tooltip - top | bottom | reverse | forward| auto.
                 <br />
-                When "auto" is specified, it will dynamically reorient the tooltip. For example, if placement is "auto left", the tooltip will display to the left when possible, otherwise it will display right.
+                When "auto" is specified, it will dynamically reorient the tooltip. For example, if placement is "auto reverse", the tooltip will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
             </p>
             <p>
                 <strong>object:</strong><br />
@@ -324,7 +326,7 @@ Activates a tooltip on a given element. Accepts an optional options `object`.
 
 {% highlight js %}
 $('#myTooltip').CFW_Tooltip({
-    placement: 'right'
+    placement: 'forward'
 });
 {% endhighlight %}
 

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -111,8 +111,8 @@
             if (this.settings.backlink && this.settings.backtop) {
                 var $backTop = $('<li class="' + this.c.backLink + '"><a href="#">' + this.settings.backtext + '</a></li>')
                     .prependTo(this.$target);
-                if (this.$target.hasClass('dropdown-menu-left')) {
-                    $backTop.addClass('dropdown-back-left');
+                if (this.$target.hasClass('dropdown-menu-reverse')) {
+                    $backTop.addClass('dropdown-back-reverse');
                 }
             }
 
@@ -123,18 +123,18 @@
                 var subLinkID = $subLink.CFW_getID('cfw-dropdown');
                 // var subMenuID = $subMenu.CFW_getID('cfw-dropdown');
 
-                var $dirNode = $subMenu.closest('.dropdown-menu-left, .dropdown-menu-right');
-                if ($dirNode.hasClass('dropdown-menu-left')) {
-                    $subMenu.closest('li').addClass('dropdown-subalign-left');
+                var $dirNode = $subMenu.closest('.dropdown-menu-reverse, .dropdown-menu-forward');
+                if ($dirNode.hasClass('dropdown-menu-reverse')) {
+                    $subMenu.closest('li').addClass('dropdown-subalign-reverse');
                 } else {
-                    $subMenu.closest('li').addClass('dropdown-subalign-right');
+                    $subMenu.closest('li').addClass('dropdown-subalign-forward');
                 }
 
                 if ($selfRef.settings.backlink) {
                     var $backElm = $('<li class="' + $selfRef.c.backLink + '"><a href="#">' + $selfRef.settings.backtext + '</a></li>')
                         .prependTo($subMenu);
-                    if ($dirNode.hasClass('dropdown-menu-left')) {
-                        $backElm.addClass('dropdown-back-left');
+                    if ($dirNode.hasClass('dropdown-menu-reverse')) {
+                        $backElm.addClass('dropdown-back-reverse');
                     }
                 }
 
@@ -581,24 +581,8 @@
         }
     };
 
-    /*
-    $.fn.redraw = function(){
-        $(this).each(function(){
-            var redraw = this.offsetHeight;
-        });
-    };
-    */
-    // Force [lte IE 10] to redraw to correct layout
-    // Also force Edge reflow - using bad UA test and method
-    // TODO: Need to revisit this to find better options
-    // Note: Parent element must be visible in order to redraw
     $.fn.redraw = function() {
-        // if ((document.documentMode || 100) <= 10) {
-        if (document.documentMode !== undefined){
-            return this.hide(0, function() {$(this).show(); $(this).css('display', ''); });
-        } else if (/Edge\/\d+/.test(navigator.userAgent)) {
-            $(this).css('list-style', 'none').css('list-style', '');
-        }
+        return this.offsetHeight;
     };
 
     function Plugin(option) {

--- a/js/modal.js
+++ b/js/modal.js
@@ -17,6 +17,7 @@
         this.$focusLast = null;
         this.isShown = null;
         this.scrollbarWidth = 0;
+        this.scrollbarSide = 'right';
         this.fixedContent = '.fixed-top, .fixed-botton, .is-fixed';
         this.ignoreBackdropClick = false;
 
@@ -296,6 +297,7 @@
         checkScrollbar : function() {
             this.bodyIsOverflowing = document.body.clientWidth < window.innerWidth;
             this.scrollbarWidth = $.CFW_measureScrollbar();
+            this.scrollbarSide =  $('html').CFW_getScrollbarSide();
         },
 
         setScrollbar : function() {
@@ -305,45 +307,45 @@
                 // Update fixed element padding
                 $(this.fixedContent).each(function() {
                     var $this = $(this);
-                    $this.data('cfw.padding-right', this.style.paddingRight || '');
-                    var padding = parseFloat($this.css('padding-right') || 0);
-                    $this.css('padding-right', padding + $selfRef.scrollbarWidth);
+                    if ($selfRef.scrollbarSide === 'left') {
+                        $this.data('cfw.padding-dim', this.style.paddingLeft || '');
+                    } else {
+                        $this.data('cfw.padding-dim', this.style.paddingRight || '');
+                    }
+                    var padding = parseFloat($this.css('padding-' + $selfRef.scrollbarSide) || 0);
+                    $this.css('padding-' + $selfRef.scrollbarSide, padding + $selfRef.scrollbarWidth);
                 });
 
                 // Update body padding
-                this.$body.data('cfw.padding-right', document.body.style.paddingRight || '');
-                var padding = parseFloat(this.$body.css('padding-right') || 0);
-                this.$body.css('padding-right', padding + this.scrollbarWidth);
+                if (this.scrollbarSide === 'left') {
+                    this.$body.data('cfw.padding-dim', document.body.style.paddingLeft || '');
+                } else {
+                    this.$body.data('cfw.padding-dim', document.body.style.paddingRight || '');
+                }
+                var padding = parseFloat(this.$body.css('padding-' + this.scrollbarSide) || 0);
+                this.$body.css('padding-' + this.scrollbarSide, padding + this.scrollbarWidth);
             }
             this.$target.CFW_trigger('scrollbarSet.cfw.modal');
         },
 
         resetScrollbar : function() {
+            var $selfRef = this;
+
             // Restore fixed element padding
             $(this.fixedContent).each(function() {
                 var $this = $(this);
-                var padding = $this.data('cfw.padding-right');
-                $this.css('padding-right', padding);
-                $this.removeData('cfw.padding-right');
+                var padding = $this.data('cfw.padding-dim');
+                $this.css('padding-' + $selfRef.scrollbarSide, padding);
+                $this.removeData('cfw.padding-dim');
             });
 
             // Restore body padding
-            var padding = this.$body.data('cfw.padding-right');
+            var padding = this.$body.data('cfw.padding-dim');
             if (typeof padding !== undefined) {
-                this.$body.css('padding-right', padding);
-                this.$body.removeData('cfw.padding-right');
+                this.$body.css('padding-' + this.scrollbarSide, padding);
+                this.$body.removeData('cfw.padding-dim');
             }
             this.$target.CFW_trigger('scrollbarReset.cfw.modal');
-        },
-
-        measureScrollbar : function() {
-            var $body = $(document.body);
-            var scrollDiv = document.createElement('div');
-            scrollDiv.className = 'modal-scrollbar-measure';
-            $body.append(scrollDiv);
-            var scrollbarWidth = scrollDiv.getBoundingClientRect().width - scrollDiv.clientWidth;
-            $body[0].removeChild(scrollDiv);
-            return scrollbarWidth;
         },
 
         backdrop : function(callback) {
@@ -424,6 +426,7 @@
             this.$focusLast = null;
             this.isShown = null;
             this.scrollbarWidth = null;
+            this.scrollbarSide = null;
             this.fixedContent = null;
             this.ignoreBackdropClick = null;
             this.settings = null;

--- a/js/popover.js
+++ b/js/popover.js
@@ -20,7 +20,7 @@
     };
 
     CFW_Widget_Popover.DEFAULTS = $.extend({}, $.fn.CFW_Tooltip.Constructor.DEFAULTS, {
-        placement   : 'top',        // Where to locate popover (top/bottom/left/right/auto)
+        placement   : 'top',        // Where to locate popover (top/bottom/reverse(left)/forward(right)/auto)
         trigger     : 'click',      // How popover is triggered (click/hover/focus/manual)
         content     : '',           // Content text/html to be inserted
         drag        : false,        // If the popover should be draggable
@@ -88,7 +88,7 @@
             this.enableDrag();
         }
 
-        $tip.removeClass('fade in top bottom left right');
+        $tip.removeClass('fade in top bottom reverse forward');
 
         if (!$title.html()) { $title.hide(); }
 

--- a/js/util.js
+++ b/js/util.js
@@ -266,6 +266,37 @@
         }
     };
 
+    $.fn.CFW_getScrollbarSide = function() {
+        // Unable to detect side when 0-width scrollbars (such as mobile)
+        // are found.  So we use 'right` side as default (more common case).
+
+        // Hacky support for IE/Edge and their placment of scrollbar on window
+        // for 'rtl' mode.
+        var $node = $(this);
+
+        if ($node.is($('html'))) {
+            var browser = {
+                msedge: /edge\/\d+/i.test(navigator.userAgent),
+                msie: /(msie|trident)/i.test(navigator.userAgent)
+            };
+            var directionVal = window.getComputedStyle($node[0], null).getPropertyValue('direction').toLowerCase();
+            if ((directionVal) === 'rtl' && (browser.msedge || browser.msie)) {
+                return 'left';
+            }
+            return 'right';
+        } else {
+            var scrollDiv = document.createElement('div');
+            scrollDiv.setAttribute('style', 'overflow-y: scroll;');
+            var scrollP = document.createElement('p');
+            $(scrollDiv).append(scrollP);
+            $node.append(scrollDiv);
+            var scrollWidth = $.CFW_measureScrollbar();
+            var posLeft = scrollP.getBoundingClientRect().left;
+            $node[0].removeChild(scrollDiv);
+            return (posLeft < scrollWidth) ? 'right' : 'left';
+        }
+    };
+
     $.CFW_throttle = function(fn, threshhold, scope) {
         /* From: http://remysharp.com/2010/07/21/throttling-function-calls/ */
         if (threshhold === undefined) { threshhold = 250; }

--- a/js/util.js
+++ b/js/util.js
@@ -280,7 +280,7 @@
                 msie: /(msie|trident)/i.test(navigator.userAgent)
             };
             var directionVal = window.getComputedStyle($node[0], null).getPropertyValue('direction').toLowerCase();
-            if ((directionVal) === 'rtl' && (browser.msedge || browser.msie)) {
+            if ((directionVal === 'rtl') && (browser.msedge || browser.msie)) {
                 return 'left';
             }
             return 'right';

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-jekyll": "^0.4.4",
     "grunt-jscs": "~3.0.1",
     "grunt-postcss": "^0.8.0",
+    "grunt-rtlcss": "^2.0.1",
     "grunt-sass": "^2.0.0",
     "grunt-saucelabs": "^9.0.0",
     "grunt-scss-lint": "^0.5.0",

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -677,7 +677,7 @@ $divider-spacer:        ($spacer / 2) !default;
 // =====
 $dropdown-min-width:            10rem !default;
 $dropdown-padding-y:            .3125rem !default;
-$dropdown-margin-top:           .125rem !default;
+$dropdown-spacer:               .125rem !default;
 $dropdown-bg:                   $white !default;
 $dropdown-border-color:         $uibase-300 !default;
 $dropdown-border-width:         $border-width !default;

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -51,7 +51,7 @@
     float: left;
     min-width: $dropdown-min-width;
     padding: $dropdown-padding-y 0;
-    margin: $dropdown-margin-top 0 0; // override default ul
+    margin: $dropdown-spacer 0 0; // override default ul
     font-size: $font-size-base;
     color: $body-color;
     text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
@@ -119,8 +119,7 @@
     > .dropdown-menu {
         top: 0;
         left: 100%;
-        //margin-top: -($dropdown-margin-top + $dropdown-padding-y - $border-width);
-        margin-top: calc(-#{($dropdown-margin-top + $dropdown-padding-y)} + #{$border-width});
+        margin-top: calc(-#{($dropdown-spacer + $dropdown-padding-y)} + #{$border-width});
         @include border-radius($dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-border-radius);
     }
 
@@ -218,7 +217,7 @@
         top: auto;
         bottom: 100%;
         margin-top: 0;
-        margin-bottom: $dropdown-margin-top;
+        margin-bottom: $dropdown-spacer;
         @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
     }
 
@@ -227,7 +226,7 @@
             top: auto;
             bottom: 0;
             margin-top: 0;
-            margin-bottom: calc(-#{($dropdown-margin-top + $dropdown-padding-y)} + #{$border-width});
+            margin-bottom: calc(-#{($dropdown-spacer + $dropdown-padding-y)} + #{$border-width});
             @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
         }
     }

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -252,10 +252,10 @@
     }
 }
 
-// Change back caret direction for left facing menus
-// The `.dropdown-back-left` class is added automatically by the dropdown.js widget
+// Change back caret direction for reverse facing menus
+// The `.dropdown-back-reverse` class is added automatically by the dropdown.js widget
 // This removes the need for overly convoluted CSS rules
-.dropdown-back-left {
+.dropdown-back-reverse {
     > a::before {
         right: $dropdown-back-spacer-x;
         left: auto;
@@ -265,7 +265,7 @@
 }
 
 // Allow for menus to go left - aligning to right side of the control
-.dropdown-menu-left {
+.dropdown-menu-reverse {
     .dropdown-menu {
         right: 0;
         left: auto;
@@ -276,7 +276,7 @@
 // Submenu alignment
 // The `.dropdown-subalign-*` classes are added automatically by the dropdown.js widget
 // This removes the need for overly convoluted CSS rules
-.dropdown-subalign-right {
+.dropdown-subalign-forward {
     > .dropdown-menu {
         right: auto;
         left: 100%;
@@ -286,7 +286,7 @@
     }
 }
 
-.dropdown-subalign-left {
+.dropdown-subalign-reverse {
     > .dropdown-menu {
         right: 100%;
         left: auto;
@@ -294,7 +294,7 @@
         margin-left: -($border-width * 2);
         @include border-radius($dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius $dropdown-border-radius);
     }
-    > a
+    > a,
     > .dropdown-item {
         &::after {
             right: auto;
@@ -311,17 +311,17 @@
 
 // Dropup corner overrides
 .dropup {
-    &.dropdown-menu-left {
+    &.dropdown-menu-reverse {
         .dropdown-menu {
             @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius);
         }
     }
-    .dropdown-subalign-right {
+    .dropdown-subalign-forward {
         > .dropdown-menu {
             @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius);
         }
     }
-    .dropdown-subalign-left {
+    .dropdown-subalign-reverse {
         > .dropdown-menu {
             @include border-radius($dropdown-border-radius $dropdown-border-radius $dropdown-attach-border-radius $dropdown-border-radius);
         }

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -11,6 +11,7 @@
 
 // Container that the modal scrolls within
 .modal {
+    direction: ltr #{"/*rtl:ignore*/"};
     position: fixed;
     top: 0;
     right: 0;
@@ -43,6 +44,7 @@
 
 // Shell div to position the modal with bottom padding
 .modal-dialog {
+    direction: ltr;
     position: relative;
     width: auto;
     margin: $modal-dialog-margin;

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -1,7 +1,5 @@
 .popover {
     position: absolute;
-    top: 0;
-    left: 0;
     z-index: $zindex-popover;
     display: none;
     max-width: $popover-max-width;
@@ -36,8 +34,8 @@
             }
         }
     }
-    &.right {
-        margin-left: $popover-arrow-width;
+    &.forward {
+        margin-left: $popover-arrow-width #{"/*rtl:"}-$popover-arrow-width#{"*/"};
 
         .popover-arrow {
             top: 50%;
@@ -59,7 +57,7 @@
 
         .popover-arrow {
             top: -$popover-arrow-outer-width;
-            left: 50%;
+            left: 50% #{"/*rtl:ignore*/"};
             margin-left: -$popover-arrow-outer-width;
             border-top-width: 0;
             border-bottom-color: $popover-arrow-outer-color;
@@ -72,8 +70,8 @@
             }
         }
     }
-    &.left {
-        margin-left: -$popover-arrow-width;
+    &.reverse {
+        margin-left: -$popover-arrow-width #{"/*rtl:"}$popover-arrow-width#{"*/"};
 
         .popover-arrow {
             top: 50%;

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -17,17 +17,17 @@
         padding: $tooltip-arrow-width 0;
         margin-top: -$tooltip-margin;
     }
-    &.right {
+    &.forward {
         padding: 0 $tooltip-arrow-width;
-        margin-left: $tooltip-margin;
+        margin-left: $tooltip-margin #{"/*rtl:"}-$tooltip-margin#{"*/"};
     }
     &.bottom {
         padding: $tooltip-arrow-width 0;
         margin-top: $tooltip-margin;
     }
-    &.left {
+    &.reverse {
         padding: 0 $tooltip-arrow-width;
-        margin-left: -$tooltip-margin;
+        margin-left: -$tooltip-margin #{"/*rtl:"}$tooltip-margin#{"*/"};
     }
 }
 
@@ -52,19 +52,19 @@
 .tooltip {
     &.top .tooltip-arrow {
         bottom: 0;
-        left: 50%;
+        left: 50% #{"/*rtl:ignore*/"};
         margin-left: -$tooltip-arrow-width;
         border-width: $tooltip-arrow-width $tooltip-arrow-width 0;
         border-top-color: $tooltip-arrow-color;
     }
-    &.right .tooltip-arrow {
+    &.forward .tooltip-arrow {
         top: 50%;
         left: 0;
         margin-top: -$tooltip-arrow-width;
         border-width: $tooltip-arrow-width $tooltip-arrow-width $tooltip-arrow-width 0;
         border-right-color: $tooltip-arrow-color;
     }
-    &.left .tooltip-arrow {
+    &.reverse .tooltip-arrow {
         top: 50%;
         right: 0;
         margin-top: -$tooltip-arrow-width;
@@ -73,7 +73,7 @@
     }
     &.bottom .tooltip-arrow {
         top: 0;
-        left: 50%;
+        left: 50% #{"/*rtl:ignore*/"};
         margin-left: -$tooltip-arrow-width;
         border-width: 0 $tooltip-arrow-width $tooltip-arrow-width;
         border-bottom-color: $tooltip-arrow-color;

--- a/scss/mixins/_float.scss
+++ b/scss/mixins/_float.scss
@@ -1,9 +1,9 @@
 // scss-lint:disable ImportantRule
 
-@mixin float-left {
+@mixin float-start {
     float: left !important;
 }
-@mixin float-right {
+@mixin float-end {
     float: right !important;
 }
 @mixin float-none {

--- a/scss/utilities/_float.scss
+++ b/scss/utilities/_float.scss
@@ -2,11 +2,11 @@
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {
-        .float#{$bprule}-left {
-            @include float-left;
+        .float#{$bprule}-start {
+            @include float-start;
         }
-        .float#{$bprule}-right {
-            @include float-right;
+        .float#{$bprule}-end {
+            @include float-end;
         }
         .float#{$bprule}-none {
             @include float-none;

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -9,8 +9,8 @@
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {
-        .text#{$bprule}-left    { text-align: left !important; }
-        .text#{$bprule}-right   { text-align: right !important; }
+        .text#{$bprule}-start    { text-align: left !important; }
+        .text#{$bprule}-end   { text-align: right !important; }
         .text#{$bprule}-center  { text-align: center !important; }
     }
 }

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -28,8 +28,8 @@ function myLog(item) {
 
 // Direction for player dropdown menus
 $(document, '[data-cfw="player"]').on('ready.cfw.player', function(e) {
-    $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropdown-menu-left');
-    $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropdown-menu-left');
+    $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropdown-menu-reverse');
+    $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropdown-menu-reverse');
 });
 </script>
 

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -396,7 +396,7 @@ Holder.addTheme("gray", {
   <footer class="blockquote-footer">Someone famous in <cite>Source Title</cite></footer>
 </blockquote>
 
-<blockquote class="blockquote text-right">
+<blockquote class="blockquote text-end">
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
   <footer class="blockquote-footer">Someone famous in <cite>Source Title</cite></footer>
 </blockquote>
@@ -431,7 +431,7 @@ Showing a <kbd>kdb sample</kbd>
 
 <figure class="figure">
   <img data-src="holder.js/300x200" class="figure-img img-fluid radius-a" alt="A square placeholder image with rounded corners in a figure.">
-  <figcaption class="figure-caption text-right">A caption for the above image.</figcaption>
+  <figcaption class="figure-caption text-end">A caption for the above image.</figcaption>
 </figure>
 
 <figure class="figure">
@@ -999,8 +999,8 @@ Showing a <kbd>kdb sample</kbd>
   </div>
   <div class="form-group row">
       <fieldset class="w-100 clearfix">
-        <legend class="col-sm-2 float-sm-left form-control-legend">Radios</legend>
-        <div class="col-sm-10 float-sm-left">
+        <legend class="col-sm-2 float-sm-start form-control-legend">Radios</legend>
+        <div class="col-sm-10 float-sm-start">
           <div class="form-check">
             <label class="form-check-label">
               <input class="form-check-input" type="radio" name="gridRadios" id="gridRadios1" value="option1" checked>
@@ -1024,8 +1024,8 @@ Showing a <kbd>kdb sample</kbd>
     </div>
     <div class="form-group row">
       <fieldset class="w-100 clearfix">
-        <legend class="col-sm-2 float-sm-left form-control-legend">Checkbox</legend>
-        <div class="col-sm-10 float-sm-left">
+        <legend class="col-sm-2 float-sm-start form-control-legend">Checkbox</legend>
+        <div class="col-sm-10 float-sm-start">
           <div class="form-check">
             <label class="form-check-label">
               <input class="form-check-input" type="checkbox"> Check me out
@@ -1244,7 +1244,7 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Select sizing test</h3>
 <div class="select-sizing">
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-xs">Test</button>
       </div>
       <fieldset class="form-group col-md-5">
@@ -1263,7 +1263,7 @@ Showing a <kbd>kdb sample</kbd>
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-sm">Test</button>
       </div>
       <fieldset class="form-group col-md-5">
@@ -1282,7 +1282,7 @@ Showing a <kbd>kdb sample</kbd>
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary">Test</button>
       </div>
       <fieldset class="form-group col-md-5">
@@ -1301,7 +1301,7 @@ Showing a <kbd>kdb sample</kbd>
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-lg">Test</button>
       </div>
       <fieldset class="form-group col-md-5">
@@ -1320,7 +1320,7 @@ Showing a <kbd>kdb sample</kbd>
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-xl">Test</button>
       </div>
       <fieldset class="form-group col-md-5">
@@ -1716,15 +1716,15 @@ Anchor variants:<br />
 <h3>List group with badges</h3>
 <ul class="list-group">
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">14</span>
+    <span class="badge badge-pill float-end">14</span>
     Cras justo odio
   </li>
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">2</span>
+    <span class="badge badge-pill float-end">2</span>
     Dapibus ac facilisis in
   </li>
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">1</span>
+    <span class="badge badge-pill float-end">1</span>
     Morbi leo risus
   </li>
 </ul>
@@ -3089,7 +3089,7 @@ Anchor variants:<br />
 <small>resize screen below 'md' breakpoint</small><br />
 <nav class="navbar navbar-light bg-faded mb-1">
   <a class="navbar-brand" href="#">Responsive navbar</a>
-  <button class="navbar-toggle d-lg-none float-right" type="button" data-cfw="collapse" data-cfw-collapse-target="#exCollapsingNavbar2" aria-label="Toggle navigation">
+  <button class="navbar-toggle d-lg-none float-end" type="button" data-cfw="collapse" data-cfw-collapse-target="#exCollapsingNavbar2" aria-label="Toggle navigation">
     <span class="icon-menu" aria-hidden="true">&#8801;</span>
   </button>
   <div class="collapse navbar-toggleable-md" id="exCollapsingNavbar2">
@@ -3469,7 +3469,7 @@ Anchor variants:<br />
       </div>
     </div>
 
-    <div class="card text-right">
+    <div class="card text-end">
       <div class="card-body">
         <h4 class="card-title">Special title treatment</h4>
         <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
@@ -3844,7 +3844,7 @@ Anchor variants:<br />
   <div class="card">
     <img class="card-img img-fluid" data-src="holder.js/100px200" alt="Card image" />
   </div>
-  <div class="card text-right">
+  <div class="card text-end">
     <div class="card-body">
       <blockquote class="blockquote">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -3962,13 +3962,13 @@ Anchor variants:<br />
 <button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="top" title="Tooltip on top">
   Tooltip on top
 </button>
-<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="right" title="Tooltip on right">
+<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="forward" title="Tooltip forward">
   Tooltip on right
 </button>
 <button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="bottom" title="Tooltip on bottom">
   Tooltip on bottom
 </button>
-<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="left" title="Tooltip on left">
+<button type="button" class="btn" data-cfw="tooltip" data-cfw-tooltip-placement="reverse" title="Tooltip reverse">
   Tooltip on left
 </button>
 </p>
@@ -3983,8 +3983,8 @@ Anchor variants:<br />
     <div class="popover-arrow"></div>
   </div>
 
-  <div class="popover right">
-    <h3 class="popover-header">Popover right</h3>
+  <div class="popover forward">
+    <h3 class="popover-header">Popover forward</h3>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
@@ -3999,8 +3999,8 @@ Anchor variants:<br />
     <div class="popover-arrow"></div>
   </div>
 
-  <div class="popover left">
-    <h3 class="popover-header">Popover left</h3>
+  <div class="popover reverse">
+    <h3 class="popover-header">Popover reverse</h3>
     <div class="popover-body">
       <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
     </div>
@@ -4016,7 +4016,7 @@ Anchor variants:<br />
   Popover on top
 </button>
 
-<button type="button" class="btn" data-cfw-popover-container="body" data-cfw="popover" data-cfw-popover-placement="right" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+<button type="button" class="btn" data-cfw-popover-container="body" data-cfw="popover" data-cfw-popover-placement="forward" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
   Popover on right
 </button>
 
@@ -4024,7 +4024,7 @@ Anchor variants:<br />
   Popover on bottom
 </button>
 
-<button type="button" class="btn" data-cfw-popover-container="body" data-cfw="popover" data-cfw-popover-placement="left" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+<button type="button" class="btn" data-cfw-popover-container="body" data-cfw="popover" data-cfw-popover-placement="reverse" data-cfw-popover-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
   Popover on left
 </button>
 </p>

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -2015,11 +2015,11 @@ Anchor variants:<br />
   <div class="col-lg-6">
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with dropdown button">
-      <div class="input-group-btn">
+      <div class="input-group-btn dropdown-menu-reverse">
         <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           Action
         </button>
-        <ul class="dropdown-menu dropdown-menu-right">
+        <ul class="dropdown-menu">
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
           <li><a href="#">Something else here</a></li>
@@ -2054,7 +2054,7 @@ Anchor variants:<br />
   <div class="col-lg-6">
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with segmented button dropdown">
-      <div class="input-group-btn">
+      <div class="input-group-btn dropdown-menu-reverse">
         <button type="button" class="btn btn-secondary">Action</button>
         <button type="button" class="btn btn-secondary dropdown-toggle" data-cfw="dropdown">
           <span class="sr-only">Toggle Dropdown</span>
@@ -2442,7 +2442,7 @@ Anchor variants:<br />
         </ul>
     </div>
 
-    <div class="btn-group dropdown-menu-left" style="float: right;">
+    <div class="btn-group dropdown-menu-reverse" style="float: right;">
         <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
             Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
         </button>
@@ -2510,17 +2510,17 @@ Anchor variants:<br />
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2529,17 +2529,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2553,24 +2553,24 @@ Anchor variants:<br />
     </ul>
 </div>
 
-<div class="btn-group dropdown-menu-right">
+<div class="btn-group dropdown-menu-forward">
     <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Right <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2579,17 +2579,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2603,24 +2603,24 @@ Anchor variants:<br />
     </ul>
 </div>
 
-<div class="btn-group dropdown-menu-left" style="float: right;">
+<div class="btn-group dropdown-menu-reverse" style="float: right;">
     <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Left <!-- <span class="caret" aria-hidden="true"></span> -->
     </button>
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2629,17 +2629,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2662,17 +2662,17 @@ Anchor variants:<br />
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2681,17 +2681,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2706,24 +2706,24 @@ Anchor variants:<br />
 </div>
 
 
-<div class="btn-group dropup dropdown-menu-right">
+<div class="btn-group dropup dropdown-menu-forward">
     <button type="button" class="btn dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
         Dropup Right
     </button>
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2732,17 +2732,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2756,24 +2756,24 @@ Anchor variants:<br />
     </ul>
 </div>
 
-<div class="btn-group dropup dropdown-menu-left">
+<div class="btn-group dropup dropdown-menu-reverse">
     <button type="button" class="btn dropdown-toggle" data-cfw="dropdown data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
         Dropup Left
     </button>
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-left">
+        <li class="dropdown-menu-reverse">
             <a href="#">Left menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
@@ -2782,17 +2782,17 @@ Anchor variants:<br />
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-right">
+        <li class="dropdown-menu-forward">
             <a href="#">Right menu</a>
             <ul>
-                <li class="dropdown-menu-left">
+                <li class="dropdown-menu-reverse">
                     <a href="#">Left menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-right">
+                <li class="dropdown-menu-forward">
                     <a href="#">Right menu</a>
                     <ul>
                         <li><a href="#">Action</a></li>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -175,6 +175,7 @@ $(window).ready(function() {
 </header>
 
 <main>
+
 <div class="container">
     <div class="row">
 
@@ -543,6 +544,9 @@ $(window).ready(function() {
             <hr />
 
             <h2 id="modal">Modal:</h2>
+            <p>
+                <button type="button" onclick="javascript:console.log($('html').CFW_getScrollbarSide()); return false;">Scrollbar check</button>
+            </p>
 
             <p>
                 <button type="button" class="btn btn-info" id="modal3t" data-cfw="modal" data-cfw-modal-target="#modal3" data-cfw-modal-backdrop="false">Modal: no backdrop</button>
@@ -759,7 +763,7 @@ $(window).ready(function() {
             </script>
 
 
-            <p>
+            <div class="mb-1">
                 <button type="button" class="btn btn-info" id="pop_manual" data-cfw="popover" data-cfw-popover-trigger="manual" data-cfw-popover-target="#popman" data-cfw-popover-drag=true>Popover Manual</button>
                 <a href="#" role="button" onclick="$('#pop_manual').CFW_Popover('show'); return false;">Show</a>
                 <a href="#" role="button" onclick="$('#pop_manual').CFW_Popover('hide'); return false;">Hide</a>
@@ -773,7 +777,7 @@ $(window).ready(function() {
                     </div>
                     <div class="popover-arrow"></div>
                 </div>
-            </p>
+            </div>
 
             <button type="button" class="btn btn-info" id="pop_6" title="Yay, you clicked me!" data-cfw-popover-content="blah">Popover Custom Placement</button>
             <script type="text/javascript">

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1469,9 +1469,9 @@ $(window).ready(function() {
             </div>
 
             <!-- Single button -->
-            <div class="btn-group dropdown-menu-left" style="float: right;">
+            <div class="btn-group dropdown-menu-reverse" style="float: right;">
                 <button type="button" class="btn btn-default dropdown-toggle" data-cfw="dropdown" data-cfw-dropdown-target="#dropdownTest_5" data-cfw-dropdown-backlink=true>
-                    Drop Left
+                    Reverse Dropdown
                 </button>
                 <ul class="dropdown-menu" id="dropdownTest_5">
                     <li class="dropdown-header">Dropdown header</li>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -732,7 +732,7 @@ $(window).ready(function() {
                 <button class="btn btn-default popover-viewport-bottom" title="This should be shifted to the right">Shift Right</button>
                 <button class="btn btn-default popover-viewport-right" title="This should be shifted down">Shift Down</button>
 
-                <button class="btn btn-default float-right popover-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
+                <button class="btn btn-default float-end popover-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
 
                 <button class="btn btn-default popover-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
 
@@ -954,7 +954,7 @@ $(window).ready(function() {
                 <button class="btn btn-default tooltip-viewport-bottom" title="This should be shifted to the right">Shift Right</button>
                 <button class="btn btn-default tooltip-viewport-right" title="This should be shifted down">Shift Down</button>
 
-                <button class="btn btn-default float-right tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
+                <button class="btn btn-default float-end tooltip-viewport-bottom" title="This should be shifted to the left">Shift Left</button>
 
                 <button class="btn btn-default tooltip-viewport-right btn-bottom" title="This should be shifted up">Shift Up</button>
             </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="en-us">
+<html lang="en-us" dir="rtl">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 <title>Figuration Widget Tests</title>
 
-<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
+<!--<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" /> -->
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration-rtl.css" />
 
 <!--[if lt IE 10]>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.24/MutationObserver.min.js" integrity="sha384-8HHYYRe45k4Xq40fi/cZaaby4FJgnOOVmnRzX3OWtwpfiUPfx7tnK2QkDPuIRGm0" crossorigin="anonymous"></script>
@@ -581,7 +582,7 @@ $(window).ready(function() {
                             <h4>Text in a modal</h4>
                             <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
                             <h4>Popover in a modal</h4>
-                            <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="right">button</button> should trigger a popover on click.</p>
+                            <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
                             <h4>Tooltips in a modal</h4>
                             <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                             <h4>Collapse in a modal</h4>
@@ -745,7 +746,7 @@ $(window).ready(function() {
             <script type="text/javascript">
                 $('.popover-viewport-right').CFW_Popover({
                     //trigger: 'hover',
-                    placement: 'right',
+                    placement: 'forward',
                     viewport: '#viewport-popover',
                     padding: 2
                 });
@@ -943,7 +944,7 @@ $(window).ready(function() {
 
             <strong>Activated Popover:</strong>
             <br />
-            <button type="button" class="btn btn-warning" data-cfw="popover" data-cfw-popover-title="Automatically shown" data-cfw-popover-content="Nifty eh!" data-cfw-popover-placement="right" data-cfw-popover-show=true>Auto show popover</button>
+            <button type="button" class="btn btn-warning" data-cfw="popover" data-cfw-popover-title="Automatically shown" data-cfw-popover-content="Nifty eh!" data-cfw-popover-placement="forward" data-cfw-popover-show=true>Auto show popover</button>
 
             <hr />
 
@@ -964,7 +965,7 @@ $(window).ready(function() {
             </div>
             <script type="text/javascript">
                 $('.tooltip-viewport-right').CFW_Tooltip({
-                    placement: 'right',
+                    placement: 'forward',
                     viewport: '#viewport-tooltip',
                     padding: 2
                 });
@@ -982,16 +983,16 @@ $(window).ready(function() {
                 <input type="text" placeholder="click me" title="I have some type of information." id="tip_1" />
                 <br />
                 <label for="tip_2">Something:</label>
-                <input type="text" placeholder="what?" title="I also have information." id="tip_2" data-cfw="tooltip" data-cfw-tooltip-placement="right auto" />
+                <input type="text" placeholder="what?" title="I also have information." id="tip_2" data-cfw="tooltip" data-cfw-tooltip-placement="forward auto" />
                 <br />
                 <label for="tip_3">A counter:</label>
-                <input type="text" placeholder="hover to count++" id="tip_3" data-cfw-tooltip-placement="right auto" />
+                <input type="text" placeholder="hover to count++" id="tip_3" data-cfw-tooltip-placement="forward auto" />
             </form>
             <br />
             <script type="text/javascript">
                 $('#tip_1').CFW_Tooltip({
                     trigger : 'click',
-                    placement: 'auto right'
+                    placement: 'auto forward'
                 });
 
                 var tipCount = 1;
@@ -999,7 +1000,7 @@ $(window).ready(function() {
                     return 'Count: ' + (tipCount++);
                 }
                 $('#tip_3').CFW_Tooltip({
-                    placement: 'auto right',
+                    placement: 'auto forward',
                     title: tipCounter
                 });
             </script>
@@ -1007,7 +1008,7 @@ $(window).ready(function() {
 
             <strong>Activated Tooltip:</strong>
             <br />
-            <button type="button" class="btn btn-warning" data-cfw="tooltip" data-cfw-tooltip-title="Automatically shown" data-cfw-tooltip-placement="right" data-cfw-tooltip-show=true>Auto show tooltip</button>
+            <button type="button" class="btn btn-warning" data-cfw="tooltip" data-cfw-tooltip-title="Automatically shown" data-cfw-tooltip-placement="forward" data-cfw-tooltip-show=true>Auto show tooltip</button>
 
             <hr />
 
@@ -1059,7 +1060,7 @@ $(window).ready(function() {
                 <div class="tab-content">
                     <div class="tab-pane" id="tabpanel1">
                         <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
-                        <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="right">button</button> should trigger a popover on click.</p>
+                        <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
                     </div>
                     <div class="tab-pane" id="tabpanel2">
                         <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
@@ -1864,7 +1865,7 @@ $(window).ready(function() {
                 <h4>Text in a modal</h4>
                 <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
                 <h4>Popover in a modal</h4>
-                <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="right">button</button> should trigger a popover on click.</p>
+                <p>This <button type="button"  class="btn btn-default" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
                 <h4>Tooltips in a modal</h4>
                 <p><a href="#" data-cfw="tooltip" title="Tooltip">This link</a> and <a href="#" data-cfw="tooltip" title="Tooltip">that link</a> should have tooltips on hover.</p>
                 <h4>Collapse in a modal</h4>

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -363,7 +363,7 @@ $(function() {
         $trigger.CFW_Modal('show');
     });
 
-    QUnit.test('should store original body padding in data-cfw.padding-right before showing', function(assert) {
+    QUnit.test('should store original body padding in data-cfw.padding-dim before showing', function(assert) {
         assert.expect(2);
         var done = assert.async();
         var originalPadding = '';
@@ -376,11 +376,11 @@ $(function() {
 
         $target
             .on('afterShow.cfw.modal', function() {
-                assert.strictEqual($body.data('cfw.padding-right'), originalPadding, 'stored original body padding in data attribute');
+                assert.strictEqual($body.data('cfw.padding-dim'), originalPadding, 'stored original body padding in data attribute');
                 $trigger.CFW_Modal('hide');
             })
             .on('afterHide.cfw.modal', function() {
-                assert.strictEqual($body.data('cfw.padding-right'), undefined, 'stored original body padding in data attribute');
+                assert.strictEqual($body.data('cfw.padding-dim'), undefined, 'stored original body padding in data attribute');
                 $body.removeAttr('style');
                 done();
             });

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -290,8 +290,8 @@ $(function() {
     QUnit.test('should add position class before positioning so that position-specific styles are taken into account', function(assert) {
         assert.expect(1);
         var styles = '<style>'
-            + '.tooltip.right { white-space: nowrap; }'
-            + '.tooltip.right .tooltip-body { max-width: none; }'
+            + '.tooltip.forward { white-space: nowrap; }'
+            + '.tooltip.forward .tooltip-body { max-width: none; }'
             + '</style>';
         var $styles = $(styles).appendTo('head');
 
@@ -299,7 +299,7 @@ $(function() {
         var $target = $('<a href="#" title="very very very very very very very very long tooltip in one line"/>')
             .appendTo($container)
             .CFW_Tooltip({
-                placement: 'right',
+                placement: 'forward',
                 viewport: null
             })
             .CFW_Tooltip('show');
@@ -383,25 +383,25 @@ $(function() {
         $topTooltip.CFW_Tooltip('hide');
         assert.strictEqual($('.tooltip').length, 0, 'top positioned tooltip removed from dom');
 
-        var $rightTooltip = $('<div class="trigger" style="right: 0;" title="Right tooltip">Right Dynamic Tooltip</div>')
+        var $forwardTooltip = $('<div class="trigger" style="right: 0;" title="forward tooltip">forward Dynamic Tooltip</div>')
             .appendTo($container)
-            .CFW_Tooltip({ placement: 'right auto', viewport: '#qunit-fixture' });
+            .CFW_Tooltip({ placement: 'forward auto', viewport: '#qunit-fixture' });
 
-        $rightTooltip.CFW_Tooltip('show');
-        assert.ok($('.tooltip').is('.left'), 'right positioned tooltip is dynamically positioned left');
+        $forwardTooltip.CFW_Tooltip('show');
+        assert.ok($('.tooltip').is('.reverse'), 'forward positioned tooltip is dynamically positioned reverse');
 
-        $rightTooltip.CFW_Tooltip('hide');
-        assert.strictEqual($('.tooltip').length, 0, 'right positioned tooltip removed from dom');
+        $forwardTooltip.CFW_Tooltip('hide');
+        assert.strictEqual($('.tooltip').length, 0, 'forward positioned tooltip removed from dom');
 
-        var $leftTooltip = $('<div class="trigger" style="left: 0;" title="Left tooltip">Left Dynamic Tooltip</div>')
+        var $reverseTooltip = $('<div class="trigger" style="left: 0;" title="Reverse tooltip">Reverse Dynamic Tooltip</div>')
             .appendTo($container)
-            .CFW_Tooltip({ placement: 'auto left', viewport: '#qunit-fixture' });
+            .CFW_Tooltip({ placement: 'auto reverse', viewport: '#qunit-fixture' });
 
-        $leftTooltip.CFW_Tooltip('show');
-        assert.ok($('.tooltip').is('.right'), 'left positioned tooltip is dynamically positioned right');
+        $reverseTooltip.CFW_Tooltip('show');
+        assert.ok($('.tooltip').is('.forward'), 'reverse positioned tooltip is dynamically positioned forward');
 
-        $leftTooltip.CFW_Tooltip('hide');
-        assert.strictEqual($('.tooltip').length, 0, 'left positioned tooltip removed from dom');
+        $reverseTooltip.CFW_Tooltip('hide');
+        assert.strictEqual($('.tooltip').length, 0, 'reverse positioned tooltip removed from dom');
 
         $container.remove();
         $styles.remove();
@@ -608,7 +608,7 @@ $(function() {
         var $target = $('<a href="#" class="trigger" title="tip" style="top: 0px; left: 0px;"/>')
             .appendTo($container)
             .CFW_Tooltip({
-                placement: 'right',
+                placement: 'forward',
                 viewport: 'body',
                 padding: 12
             });
@@ -634,7 +634,7 @@ $(function() {
         var $target = $('<a href="#" class="trigger" title="tip" style="bottom: 0px; left: 0px;"/>')
             .appendTo($container)
             .CFW_Tooltip({
-                placement: 'right',
+                placement: 'forward',
                 viewport: 'body',
                 padding: 12
             });
@@ -1092,7 +1092,7 @@ $(function() {
                 var $tip = $('.tooltip-body');
                 var tipXrightEdge = $tip.offset().left + $tip.width();
                 var triggerXleftEdge = $trigger.offset().left;
-                assert.ok(tipXrightEdge < triggerXleftEdge, 'tooltip with auto left placement, when near the right edge of the viewport, gets left placement');
+                assert.ok(tipXrightEdge < triggerXleftEdge, 'tooltip with auto reverse placement, when near the right edge of the viewport, gets left placement');
                 $trigger.CFW_Tooltip('hide');
             })
             .on('afterHide.cfw.tooltip', function() {
@@ -1103,7 +1103,7 @@ $(function() {
             })
             .CFW_Tooltip({
                 container: 'body',
-                placement: 'auto left',
+                placement: 'auto reverse',
                 trigger: 'manual'
             });
 

--- a/test/visual/flexbox-list-group.html
+++ b/test/visual/flexbox-list-group.html
@@ -43,15 +43,15 @@ Holder.addTheme("gray", {
 
 <ul class="list-group">
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">14</span>
+    <span class="badge badge-pill float-end">14</span>
     Cras justo odio
   </li>
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">2</span>
+    <span class="badge badge-pill float-end">2</span>
     Dapibus ac facilisis in
   </li>
   <li class="list-group-item">
-    <span class="badge badge-pill float-right">1</span>
+    <span class="badge badge-pill float-end">1</span>
     Morbi leo risus
   </li>
 </ul>

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -41,7 +41,7 @@ Holder.addTheme("gray", {
 <h3>Select Sizing Comparison:</h3>
 <div class="select-sizing">
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-xs">Test</button>
       </div>
       <div class="col-md-1">
@@ -73,7 +73,7 @@ Holder.addTheme("gray", {
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-sm">Test</button>
       </div>
       <div class="col-md-1">
@@ -105,7 +105,7 @@ Holder.addTheme("gray", {
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary">Test</button>
       </div>
       <div class="col-md-1">
@@ -137,7 +137,7 @@ Holder.addTheme("gray", {
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-lg">Test</button>
       </div>
       <div class="col-md-1">
@@ -169,7 +169,7 @@ Holder.addTheme("gray", {
       </fieldset>
     </form>
     <form class="row">
-      <div class="col-md-2 text-right">
+      <div class="col-md-2 text-end">
         <button type="button" class="btn btn-primary btn-xl">Test</button>
       </div>
       <div class="col-md-1">

--- a/test/visual/tooltip.html
+++ b/test/visual/tooltip.html
@@ -1,0 +1,50 @@
+﻿<!DOCTYPE html>
+<html lang="en-us" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<title>Figuration - Flexbox Inline Forms</title>
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration-rtl.css" />
+
+<!--
+<script type="text/javascript" src="../../docs/assets/js/vendor/jquery.min.js"></script>
+<script type="text/javascript" src="../../dist/js/figuration.js"></script>
+-->
+
+<script type="text/javascript" src="../../docs/assets/js/vendor/jquery.min.js"></script>
+<script type="text/javascript" src="../../js/util.js"></script>
+<script type="text/javascript" src="../../js/drag.js"></script>
+<script type="text/javascript" src="../../js/collapse.js"></script>
+<script type="text/javascript" src="../../js/dropdown.js"></script>
+<script type="text/javascript" src="../../js/tab.js"></script>
+<script type="text/javascript" src="../../js/affix.js"></script>
+<script type="text/javascript" src="../../js/tooltip.js"></script>
+<script type="text/javascript" src="../../js/popover.js"></script>
+<script type="text/javascript" src="../../js/modal.js"></script>
+<script type="text/javascript" src="../../js/tab-responsive.js"></script>
+<script type="text/javascript" src="../../js/accordion.js"></script>
+<script type="text/javascript" src="../../js/slideshow.js"></script>
+<script type="text/javascript" src="../../js/scrollspy.js"></script>
+<script type="text/javascript" src="../../js/alert.js"></script>
+<script type="text/javascript" src="../../js/button.js"></script>
+<script type="text/javascript" src="../../js/lazy.js"></script>
+<script type="text/javascript" src="../../js/slider.js"></script>
+<script type="text/javascript" src="../../js/equalize.js"></script>
+<script type="text/javascript" src="../../js/common.js"></script>
+
+</head>
+<body>
+
+<button class="btn btn-default float-start" title="Tooltip at start" data-cfw="tooltip" data-cfw-tooltip-placement="reverse auto">Tooltip at start</button>
+
+<button class="btn btn-default" title="Tooltip at top" data-cfw="tooltip" data-cfw-tooltip-placement="top auto">Tooltip at top</button>
+
+<button class="btn btn-default float-end" title="Tooltip at end" data-cfw="tooltip" data-cfw-tooltip-placement="forward auto">Tooltip at end</button>
+
+<button class="btn btn-default" style="position: absolute; bottom: 0;" title="Tooltip at bottom" data-cfw="tooltip" data-cfw-tooltip-placement="bottom auto">Tooltip at bottom</button>
+
+
+</body>
+</html>


### PR DESCRIPTION
Working through adding `rtl` support to Figuration.

Some utility classes will be renamed to use `start/end` designation instead of `left/right` so they are no longer directional to the viewport, but the text direction.  Likewise other components will need updates too.

So far the list is:
- [x] Add RTLCSS to grunt process
- [x] Update float utils
  - `.float-*-start` replaces `.float-*-left`
  - `.float-*-end` replaces `.float-*-right`
- [x] Update text alignment utils
  - `.text-*-start` replaces `.text-*-left`
  - `.text-*-end` replaces `.text-*-right`
- [x] Update tooltip/popover position options
  - `reverse/forward` replaces the `left/right` options
- [x] Update dropdown alignment classes
  - dropdown now uses `.dropdown-menu-forward` and `.dropdown-menu-reverse` classes for alignment.  
  -  following examples apply to `ltr` mode, horizontal directions are opposite in `rtl` mode
     - `*-forward` aligns root menu on left edge of parent, sub-menus open to right 
     - `*-reverse` aligns root menu on right edge of parent, sub-menus open to left
- [x] Update modal padding handling

This is turning out the quite the undertaking, and while some parts are easy, others are a pain. 

 The biggest pain so far is having scrollbars swapping sides in **most** cases.  However, there does not seem to be a reliable way to tell where the scrollbar appears.