### PR TITLE
v4 - Responsive Typography

### DIFF
--- a/docs/assets/scss/_player.scss
+++ b/docs/assets/scss/_player.scss
@@ -277,7 +277,7 @@
     display: block;
     max-width: 100%;
     padding: .25rem;
-    font-size: .9375rem;
+    @include font-size(.9375rem);
     color: #fff;
     text-align: center;
     background-color: rgba(0, 0, 0, .65);
@@ -287,5 +287,5 @@
 .player-fulldisplay .player-caption-display {
     bottom: 5rem;
     padding: .5rem 1rem;
-    font-size: 1.25rem;
+    @include font-size(1.25rem);
 }

--- a/docs/assets/scss/_responsive-tests.scss
+++ b/docs/assets/scss/_responsive-tests.scss
@@ -40,7 +40,7 @@
 .responsive-utilities-test span {
     display: block;
     padding: 1rem .5rem;
-    font-size: 1rem;
+    @include font-size(1rem);
     font-weight: $font-weight-bold;
     line-height: 1.1;
     text-align: center;

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -15,7 +15,7 @@ $docs-color: #246;
     display: block;
     width: 12em;
     max-width: 100%;
-    font-size: 1rem;
+    @include font-size(1rem);
     font-weight: $font-weight-bold;
     color: $black;
     text-align: center;
@@ -104,7 +104,7 @@ $docs-color: #246;
 .cf-header-menu {
     display: inline-block;
     margin-top: -.25rem;
-    font-size: 1.5rem;
+    @include font-size(1.5rem);
     font-weight: $font-weight-bold;
     line-height: .75;
 }
@@ -121,15 +121,15 @@ $docs-color: #246;
 .home-icons {
     .far,
     .fas {
-        font-size: 3.5rem;
+        @include font-size(3.5rem);
         vertical-align: middle;
     }
 
     .fa-mobile-alt {
-        font-size: 2.5rem;
+        @include font-size(2.5rem);
     }
     .fa-tablet-alt {
-        font-size: 3rem;
+        @include font-size(3rem);
     }
 
     .far + .far,
@@ -188,7 +188,7 @@ $docs-color: #246;
     .lead {
         margin-top: 1rem;
         margin-bottom: 1.5rem;
-        font-size: 1.5rem;
+        @include font-size(1.5rem);
     }
 
     .splash-home {
@@ -300,7 +300,7 @@ $docs-color: #246;
 
 // TOC
 #markdown-toc {
-    font-size: .9375rem;
+    @include font-size(.9375rem);
 
     ul {
         padding-left: 2rem;
@@ -320,7 +320,7 @@ $docs-color: #246;
     order: 2;
     padding-top: 1rem;
     padding-bottom: 1rem;
-    font-size: .875rem;
+    @include font-size(.875rem);
 
     .section-toc {
         @supports (position: sticky) {
@@ -355,7 +355,7 @@ $docs-color: #246;
             left: -1rem;
             display: block;
             width: .1875rem;
-            font-size: 5rem;
+            @include font-size(5rem);
             line-height: .5rem;
             content: " ";
             background-color: #246;
@@ -375,10 +375,10 @@ $docs-color: #246;
 
 // Title item
 .cf-title {
-    font-size: 3rem;
+    @include font-size(3rem);
 
     + p {
-        font-size: 1.15rem;
+        @include font-size(1.15rem);
         font-weight: 600;
     }
 }
@@ -454,7 +454,7 @@ h4 {
     }
 
     pre code {
-        font-size: inherit;
+        @include font-size(inherit);
         color: #3f3f3f;
     }
 }
@@ -511,7 +511,7 @@ h4 {
     .h6 {
         margin-top: 0;
         margin-bottom: .5rem;
-        font-size: 1.25rem;
+        @include font-size(1.25rem);
     }
 
     p:last-child,
@@ -564,7 +564,7 @@ h4 {
 .palette-base,
 .palette-item {
     padding: .5rem 1rem;
-    font-size: .875rem;
+    @include font-size(.875rem);
 }
 .palette-base {
     margin-bottom: .25rem;
@@ -574,7 +574,7 @@ h4 {
 .topLink a {
     display: inline-block;
     padding: .15rem .5rem;
-    font-size: .875rem;
+    @include font-size(.875rem);
     color: #c3c3c3;
     text-decoration: none;
     white-space: nowrap;
@@ -621,7 +621,7 @@ h4 {
 // Footer
 .cf-footer {
     padding: .75rem 0;
-    font-size: 85%;
+    @include font-size(85%);
     text-align: center;
     background-color: $uibase-50;
     border-top: 2px solid $uibase-700;

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -1,6 +1,7 @@
 // Toggles
 // Used in conjunction with global variables to enable certain theme features.
 @import "mixins/box-shadow";
+@import "mixins/font-size";
 @import "mixins/gradients";
 @import "mixins/transition";
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -239,7 +239,7 @@ $line-height-base:  1.5 !default;
 // Responsive Typography - ratio
 // Fluidly scales font size ratio by viewport dimension
 // Cannot be combined with another Responsive Typography method!
-$font-size-ratio:                   true !default;
+$font-size-ratio:                   false !default;
 $font-size-ratio-minimum-size:      1rem !default;
 $font-size-ratio-breakpoint:        bp-to-em(1200px) !default;
 $font-size-ratio-factor:            5 !default;
@@ -250,8 +250,16 @@ $font-size-ratio-generate-static:   true !default;
 // Steps font size by breakpoint
 // Cannot be combined with another Responsive Typography method!
 // [TODO]
-$font-size-scale:               false !default;
-
+$font-size-scale:                   true !default;
+$font-size-scale-minimum-size:      1rem !default;
+$font-size-scale-generate-static:   true !default;
+$font-size-scale-factor: (
+    xs: .65,
+    sm: .7375,
+    md: .825,
+    lg: .9125,
+    xl: 1
+) !default;
 
 $font-weight-light:     300 !default;
 $font-weight-normal:    normal !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -304,10 +304,10 @@ $responsive-font-size-fluid-two-dimensional:   false !default;
 // Scaled Responsive Typography
 // Steps font size by breakpoint.
 $responsive-font-size-scale-factor: (
-    xs: .65,
-    sm: .7375,
-    md: .825,
-    lg: .9125,
+    xs: .625,
+    sm: .71875,
+    md: .8125,
+    lg: .90625,
     xl: 1
 ) !default;
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -10,7 +10,7 @@ $enable-palette:        true !default;      // true
 $enable-sizing:         true !default;      // true
 $enable-bp-smallest:    false !default;     // false
 $enable-rfs-fluid:      false !default;     // false
-$enable-rfs-scale:      true !default;     // false
+$enable-rfs-scale:      false !default;     // false
 
 
 // Color
@@ -244,12 +244,12 @@ $font-weight-normal:    normal !default;
 $font-weight-bold:      bold !default;
 $font-weight-base:      $font-weight-normal !default;
 
-$font-size-h1:  2.5rem !default;
-$font-size-h2:  2rem !default;
-$font-size-h3:  1.75rem !default;
-$font-size-h4:  1.5rem !default;
-$font-size-h5:  1.25rem !default;
-$font-size-h6:  1rem !default;
+$font-size-h1:  ($font-size-base * 2.5) !default;
+$font-size-h2:  ($font-size-base * 2) !default;
+$font-size-h3:  ($font-size-base * 1.75) !default;
+$font-size-h4:  ($font-size-base * 1.5) !default;
+$font-size-h5:  ($font-size-base * 1.25) !default;
+$font-size-h6:  ($font-size-base * 1) !default;
 
 $headings-margin-bottom:    ($spacer / 2) !default;
 $headings-font-family:      inherit !default;
@@ -257,7 +257,7 @@ $headings-font-weight:      600 !default;
 $headings-line-height:      1.25 !default;
 $headings-color:            inherit !default;
 
-$lead-font-size:    1.25rem !default;
+$lead-font-size:    ($font-size-base * 1.25) !default;
 $lead-font-weight:  600 !default;
 $lead-line-height:  $line-height-base !default;
 
@@ -276,7 +276,7 @@ $hr-spacer-y:       1rem !default;
 $hr-border-color:   rgba(0, 0, 0, .1) !default;
 $hr-border-width:   $border-width !default;
 
-$blockquote-font-size:          1.1875rem !default;
+$blockquote-font-size:          ($font-size-base * 1.1875) !default;
 $blockquote-color:              $body-color !default;
 $blockquote-footer-font-size:   $font-size-base !default;
 $blockquote-footer-color:       $uibase-400 !default;
@@ -342,25 +342,25 @@ $drag-text-shadow:      0 .0625rem 0 #fff !default;
 // 'md' is considered to be the default size, so no classes for this size designator are generated, as in *no* `.btn-md`.
 $component-sizes: (
     xs: (
-        font-size:      .75rem,
+        font-size:      ($font-size-base * .75),
         padding-y:      .1875rem,
         padding-x:      .375rem,
         border-radius:  .1875rem
     ),
     sm: (
-        font-size:      .875rem,
+        font-size:      ($font-size-base * .875),
         padding-y:      .25rem,
         padding-x:      .5rem,
         border-radius:  .1875rem
     ),
     lg: (
-        font-size:      1.125rem,
+        font-size:      ($font-size-base * 1.125),
         padding-y:      .5rem,
         padding-x:      1.125rem,
         border-radius:  .3125rem
     ),
     xl: (
-        font-size:      1.25rem,
+        font-size:      ($font-size-base * 1.25),
         padding-y:      .625rem,
         padding-x:      1.25rem,
         border-radius:  .3125rem
@@ -625,7 +625,7 @@ $switch-active-indicator-box-shadow:    $btn-active-box-shadow !default;
 // Progress bars
 // =====
 $progress-height:               1rem !default;
-$progress-font-size:            .75rem !default;
+$progress-font-size:            ($font-size-base * .75) !default;
 $progress-bg:                   $uibase-50 !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .125rem .125rem rgba(0, 0, 0, .1) !default;
@@ -731,7 +731,7 @@ $dropdown-link-disabled-bg:     $disabled-bg !default;
 $dropdown-item-padding-x:       1.25rem !default;
 $dropdown-item-padding-y:       .1875rem !default;
 
-$dropdown-header-font-size:     .875rem !default;
+$dropdown-header-font-size:     ($font-size-base * .875) !default;
 $dropdown-header-font-weight:   $font-weight-normal !default;
 $dropdown-header-color:         $uibase-400 !default;
 
@@ -781,7 +781,7 @@ $navbar-item-padding-y:             .3125rem !default;
 
 $navbar-brand-padding-y:            .125rem !default;
 $navbar-brand-margin-x:             1rem !default;
-$navbar-brand-font-size:            1.25rem !default;
+$navbar-brand-font-size:            ($font-size-base * 1.25) !default;
 $navbar-brand-font-weight:          $font-weight-bold !default;
 
 $navbar-divider-width:              $border-width !default;
@@ -789,7 +789,7 @@ $navbar-divider-color:              rgba(0, 0, 0, .65) !default;
 $navbar-divider-margin-x:           $navbar-item-padding-x !default;
 $navbar-divider-margin-y:           $navbar-item-padding-y !default;
 
-$navbar-toggle-font-size:           1.25rem !default;
+$navbar-toggle-font-size:           ($font-size-base * 1.25) !default;
 $navbar-toggle-padding-y:           $btn-padding-y !default;
 $navbar-toggle-padding-x:           $btn-padding-x !default;
 $navbar-toggle-border-radius:       $btn-border-radius !default;
@@ -901,7 +901,7 @@ $tooltip-padding-y:     .25rem !default;
 $tooltip-padding-x:     .5rem !default;
 $tooltip-margin:        .2rem !default;
 
-$tooltip-font-size:     .875rem !default;
+$tooltip-font-size:     ($font-size-base * .875) !default;
 $tooltip-color:         $white !default;
 $tooltip-bg:            $black !default;
 $tooltip-opacity:       .9 !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -166,10 +166,10 @@ $grid-breakpoints: (
 // =====
 // Define the maximum width of `.container` for different screen sizes.
 $container-max-widths: (
-    sm: rem-calc(544px),
-    md: rem-calc(720px),
-    lg: rem-calc(960px),
-    xl: rem-calc(1152px)
+    sm: rem(544px),
+    md: rem(720px),
+    lg: rem(960px),
+    xl: rem(1152px)
 ) !default;
 @include _assert-ascending($container-max-widths, "container", "$container-max-widths");
 
@@ -235,6 +235,23 @@ $font-family-base:          $font-family-sans-serif !default;
 
 $font-size-base:    1rem !default;
 $line-height-base:  1.5 !default;
+
+// Responsive Typography - ratio
+// Fluidly scales font size ratio by viewport dimension
+// Cannot be combined with another Responsive Typography method!
+$font-size-ratio:                   true !default;
+$font-size-ratio-minimum-size:      1rem !default;
+$font-size-ratio-breakpoint:        bp-to-em(1200px) !default;
+$font-size-ratio-factor:            5 !default;
+$font-size-ratio-two-dimensional:   false !default;
+$font-size-ratio-generate-static:   true !default;
+
+// Responsive Typography - scale
+// Steps font size by breakpoint
+// Cannot be combined with another Responsive Typography method!
+// [TODO]
+$font-size-scale:               false !default;
+
 
 $font-weight-light:     300 !default;
 $font-weight-normal:    normal !default;
@@ -867,7 +884,7 @@ $card-columns-column-gap:   1.25rem !default;
 
 // Tooltips
 // =====
-$tooltip-max-width:     rem-calc(208px) !default;  // 208px=>13rem
+$tooltip-max-width:     rem(208px) !default;  // 208px=>13rem
 $tooltip-padding-y:     .25rem !default;
 $tooltip-padding-x:     .5rem !default;
 $tooltip-margin:        .2rem !default;
@@ -887,7 +904,7 @@ $tooltip-arrow-color:   $tooltip-bg !default;
 // =====
 $popover-font-size:             $font-size-base;
 $popover-bg:                    $white !default;
-$popover-max-width:             rem-calc(288px) !default;  // 288px=>18rem
+$popover-max-width:             rem(288px) !default;  // 288px=>18rem
 $popover-border-width:          $border-width !default;
 $popover-border-color:          $uibase-200 !default;
 $popover-border-radius:         .3125rem !default;
@@ -945,9 +962,9 @@ $modal-footer-border-width:     $modal-header-border-width !default;
 $modal-border-radius:           .3rem !default;
 $modal-inner-border-radius:     calc(#{$modal-border-radius} - #{$modal-content-border-width}) !default;
 
-$modal-sm:                      rem-calc(304px) !default; // 304px=>19rem
-$modal-md:                      rem-calc(528px) !default; // 528px=>33rem
-$modal-lg:                      rem-calc(896px) !default; // 896px=>56rem
+$modal-sm:                      rem(304px) !default; // 304px=>19rem
+$modal-md:                      rem(528px) !default; // 528px=>33rem
+$modal-lg:                      rem(896px) !default; // 896px=>56rem
 
 $modal-breakpoint:              sm !default; // When to start scaling up modal width
 $modal-lg-breakpoint:           lg !default; // The minimum breakpoint to allow `.modal-lg`

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -9,6 +9,9 @@ $enable-print-styles:   true !default;      // true
 $enable-palette:        true !default;      // true
 $enable-sizing:         true !default;      // true
 $enable-bp-smallest:    false !default;     // false
+$enable-rfs-fluid:      false !default;     // false
+$enable-rfs-scale:      true !default;     // false
+
 
 // Color
 // =====
@@ -236,31 +239,6 @@ $font-family-base:          $font-family-sans-serif !default;
 $font-size-base:    1rem !default;
 $line-height-base:  1.5 !default;
 
-// Responsive Typography - ratio
-// Fluidly scales font size ratio by viewport dimension
-// Cannot be combined with another Responsive Typography method!
-$font-size-ratio:                   false !default;
-$font-size-ratio-minimum-size:      1rem !default;
-$font-size-ratio-breakpoint:        bp-to-em(1200px) !default;
-$font-size-ratio-factor:            5 !default;
-$font-size-ratio-two-dimensional:   false !default;
-$font-size-ratio-generate-static:   true !default;
-
-// Responsive Typography - scale
-// Steps font size by breakpoint
-// Cannot be combined with another Responsive Typography method!
-// [TODO]
-$font-size-scale:                   true !default;
-$font-size-scale-minimum-size:      1rem !default;
-$font-size-scale-generate-static:   true !default;
-$font-size-scale-factor: (
-    xs: .65,
-    sm: .7375,
-    md: .825,
-    lg: .9125,
-    xl: 1
-) !default;
-
 $font-weight-light:     300 !default;
 $font-weight-normal:    normal !default;
 $font-weight-bold:      bold !default;
@@ -306,6 +284,32 @@ $blockquote-footer-color:       $uibase-400 !default;
 $list-inline-padding: .3em !default;
 
 $dt-font-weight:    $font-weight-bold !default;
+
+// Responsive Typography
+// =====
+// **Only one responsive typography method can be enabled.**
+// By default, these are off, resulting in a static font size across all viewport sizes.
+
+// Common settings
+// Only used when one of Responsive Typography methods is enabled.
+$responsive-font-size-minimum-size:     1rem !default;
+$responsive-font-size-generate-static:  true !default;
+
+// Ratioed Responsive Typography
+// Fluidly scales font size ratio by viewport dimension.
+$responsive-font-size-fluid-breakpoint:        bp-to-em(1200px) !default;
+$responsive-font-size-fluid-factor:            5 !default;
+$responsive-font-size-fluid-two-dimensional:   false !default;
+
+// Scaled Responsive Typography
+// Steps font size by breakpoint.
+$responsive-font-size-scale-factor: (
+    xs: .65,
+    sm: .7375,
+    md: .825,
+    lg: .9125,
+    xl: 1
+) !default;
 
 // Component pieces
 // =====

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -2,7 +2,7 @@
 .badge {
     display: inline-block;
     padding: $badge-padding-y $badge-padding-x;
-    font-size: $badge-font-size;
+    @include font-size($badge-font-size);
     font-weight: $badge-font-weight;
     line-height: 1;
     color: $badge-color;

--- a/scss/component/_close.scss
+++ b/scss/component/_close.scss
@@ -1,6 +1,6 @@
 .close {
     float: right;
-    font-size: $close-font-size;
+    @include font-size($close-font-size);
     font-weight: $close-font-weight;
     line-height: 1;
     color: $close-color;

--- a/scss/component/_drag.scss
+++ b/scss/component/_drag.scss
@@ -1,6 +1,6 @@
 .drag {
     float: right;
-    font-size: $drag-font-size;
+    @include font-size($drag-font-size);
     font-weight: $drag-font-weight;
     line-height: 1;
     color: $drag-color;

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -35,7 +35,7 @@
     min-width: $dropdown-min-width;
     padding: $dropdown-padding-y 0;
     margin: $dropdown-spacer 0 0; // override default ul
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     color: $body-color;
     text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
     list-style: none;
@@ -185,7 +185,7 @@
 .dropdown-header {
     display: block;
     padding: $dropdown-item-padding-y $dropdown-item-padding-x;
-    font-size: $dropdown-header-font-size;
+    @include font-size($dropdown-header-font-size);
     font-weight: $dropdown-header-font-weight;
     line-height: inherit;
     color: $dropdown-header-color;

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -57,7 +57,7 @@
 .input-group-addon {
     padding: $input-padding-y $input-padding-x;
     margin-bottom: 0; // Allow use of <label> elements by overriding our default margin-bottom
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     font-weight: $font-weight-normal;
     line-height: $input-line-height;
     color: $input-group-addon-color;

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -36,7 +36,7 @@
     padding-top: $navbar-brand-padding-y;
     padding-bottom: $navbar-brand-padding-y;
     margin-right: $navbar-brand-margin-x;
-    font-size: $navbar-brand-font-size;
+    @include font-size($navbar-brand-font-size);
     font-weight: $navbar-brand-font-weight;
     line-height: inherit;
     text-decoration: none;
@@ -105,7 +105,7 @@
 // Custom button for toggling the `.navbar-collapse`, powered by the collapse plugin.
 .navbar-toggle {
     padding: $navbar-toggle-padding-y $navbar-toggle-padding-x;
-    font-size: $navbar-toggle-font-size;
+    @include font-size($navbar-toggle-font-size);
     line-height: 1;
     background-color: transparent; // Remove default button style
     border: $border-width solid transparent; // Remove default button style

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -6,7 +6,7 @@
     // Our parent element can be arbitrary since popovers are by default inserted as a sibling of their target element.
     // So reset our font and text properties to avoid inheriting weird values.
     @include reset-text;
-    font-size: $popover-font-size;
+    @include font-size($popover-font-size);
     // Allow breaking very long words so they don't overflow the popover's bounds
     word-wrap: break-word;
     background-color: $popover-bg;
@@ -94,7 +94,7 @@
     padding: $popover-header-padding-y $popover-header-padding-x;
     padding-right: ($popover-header-padding-x * 2);
     margin: 0; // reset heading margin
-    font-size: $popover-header-font-size;
+    @include font-size($popover-header-font-size);
     color: $popover-header-color;
     background-color: $popover-header-bg;
     border-bottom: $popover-header-border-width solid $popover-header-border-color;

--- a/scss/component/_progress.scss
+++ b/scss/component/_progress.scss
@@ -7,7 +7,7 @@
     display: flex;
     height: $progress-height;
     overflow: hidden; // Force rounded corners by cropping
-    font-size: $progress-font-size;
+    @include font-size($progress-font-size);
     background-color: $progress-bg;
     @include border-radius($progress-border-radius);
     @include box-shadow($progress-box-shadow);

--- a/scss/component/_switch.scss
+++ b/scss/component/_switch.scss
@@ -10,7 +10,7 @@
     width: ($font-size-base * $switch-width-multiplier);
     height: $select-height;
     overflow: hidden;
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     line-height: $input-line-height;
     vertical-align: middle;
     background-color: $switch-control-bg;

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -5,7 +5,7 @@
     // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
     // So reset our font and text properties to avoid inheriting weird values.
     @include reset-text;
-    font-size: $tooltip-font-size;
+    @include font-size($tooltip-font-size);
     // Allow breaking very long words so they don't overflow the tooltip's bounds
     word-wrap: break-word;
     opacity: 0;
@@ -68,7 +68,7 @@
         position: static;
         padding: $tooltip-padding-y $tooltip-padding-x;
         margin-top: -$tooltip-padding-y;
-        font-size: 1.25rem;
+        @include font-size(1.25rem);
         color: $white;
         text-shadow: none;
         opacity: 1;

--- a/scss/core/_code.scss
+++ b/scss/core/_code.scss
@@ -9,7 +9,7 @@ samp {
 // Inline code
 code {
     padding: $code-padding-y $code-padding-x;
-    font-size: $code-font-size;
+    @include font-size($code-font-size);
     color: $code-color;
     background-color: $code-bg;
     @include border-radius($border-radius);
@@ -18,7 +18,7 @@ code {
 // User input typically entered via keyboard
 kbd {
     padding: $code-padding-y $code-padding-x;
-    font-size: $code-font-size;
+    @include font-size($code-font-size);
     color: $kbd-color;
     background-color: $kbd-bg;
     @include border-radius($kbd-border-radius);
@@ -35,7 +35,7 @@ kbd {
 // Blocks of code
 pre {
     display: block;
-    font-size: $code-font-size;
+    @include font-size($code-font-size);
     color: $pre-color;
 
     // Account for some code outputs that place code tags in pre tags

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -198,7 +198,7 @@
             height: $sz-select-height;
             padding: $sz-padding-y ($sz-padding-x / 2);
             padding-right: ($sz-padding-x + $custom-select-indicator-padding);
-            font-size: $sz-font-size;
+            @include font-size($sz-font-size);
             background-position: right ($sz-padding-x / 2) center;
         }
         // stylelint-enable declaration-block-no-duplicate-properties
@@ -291,7 +291,7 @@
     width: auto;
     min-width: $input-height;
     height: $input-height;
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     line-height: $input-line-height;
     color: $input-color;
     background-color: $input-bg;

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -7,7 +7,7 @@
     // Make inputs the height of their button counterpart (line-height + padding + border)
     height: $select-height;
     padding: $input-padding-y ($input-padding-x / 2);
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     line-height: $input-line-height;
     color: $input-color;
     background-color: $input-bg;
@@ -103,7 +103,7 @@ textarea.form-control {
 // When you need the legend text to be the same size as regular labels.
 .form-control-legend {
     margin-bottom: 0; // Override the `<legend>` default
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
 }
 
 // Static form control text
@@ -136,7 +136,7 @@ textarea.form-control {
         %form-control-#{$size} {
             height: $sz-select-height;
             padding: $sz-padding-y ($sz-padding-x / 2);
-            font-size: $sz-font-size;
+            @include font-size($sz-font-size);
             @include border-radius($sz-border-radius);
         }
 
@@ -148,12 +148,12 @@ textarea.form-control {
         .form-control-static-#{$size} {
             padding-top: calc(#{$sz-padding-y} + #{$input-border-width});
             padding-bottom: calc(#{$sz-padding-y} + #{$input-border-width});
-            font-size: $sz-font-size;
+            @include font-size($sz-font-size);
             //line-height: ($sz-font-size * $input-line-height);
         }
 
         .form-control-legend-#{$size} {
-            font-size: $sz-font-size;
+            @include font-size($sz-font-size);
         }
     }
 }

--- a/scss/core/_images.scss
+++ b/scss/core/_images.scss
@@ -26,6 +26,6 @@
     line-height: 1;
 }
 .figure-caption {
-    font-size: $figure-caption-font-size;
+    @include font-size($figure-caption-font-size);
     color: $figure-caption-color;
 }

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -66,7 +66,7 @@ section {
 body {
     margin: 0; // 1
     font-family: $font-family-base;
-    font-size: $font-size-base;
+    @include font-size($font-size-base);
     font-weight: $font-weight-base;
     line-height: $line-height-base;
     color: $body-color;

--- a/scss/core/_typography.scss
+++ b/scss/core/_typography.scss
@@ -14,16 +14,16 @@ h6, .h6 {
     color: $headings-color;
 }
 
-h1, .h1 { font-size: $font-size-h1; }
-h2, .h2 { font-size: $font-size-h2; }
-h3, .h3 { font-size: $font-size-h3; }
-h4, .h4 { font-size: $font-size-h4; }
-h5, .h5 { font-size: $font-size-h5; }
-h6, .h6 { font-size: $font-size-h6; }
+h1, .h1 { @include font-size($font-size-h1); }
+h2, .h2 { @include font-size($font-size-h2); }
+h3, .h3 { @include font-size($font-size-h3); }
+h4, .h4 { @include font-size($font-size-h4); }
+h5, .h5 { @include font-size($font-size-h5); }
+h6, .h6 { @include font-size($font-size-h6); }
 
 // Lead in
 .lead {
-    font-size: $lead-font-size;
+    @include font-size($lead-font-size);
     font-weight: $lead-font-weight;
     line-height: $lead-line-height;
 }
@@ -39,7 +39,7 @@ hr {
 // Emphasis
 small,
 .small {
-    font-size: $small-font-size;
+    @include font-size($small-font-size);
     font-weight: $font-weight-normal;
 }
 
@@ -77,12 +77,12 @@ mark,
 // Blockquotes
 .blockquote {
     margin-bottom: $spacer;
-    font-size: $blockquote-font-size;
+    @include font-size($blockquote-font-size);
     color: $blockquote-color;
 }
 .blockquote-footer {
     display: block;
-    font-size: $blockquote-footer-font-size;
+    @include font-size($blockquote-footer-font-size);
     color: $blockquote-footer-color;
 
     &::before {

--- a/scss/functions/_rem-calc.scss
+++ b/scss/functions/_rem-calc.scss
@@ -1,6 +1,6 @@
 // stylelint-disable length-zero-no-unit
 
-// Remove the unit of a length
+// Remove the unit from a value, returning number only.
 // From: https://css-tricks.com/snippets/sass/strip-unit-function/
 // @param {Number} $number - Number to remove unit from
 // @return {Number} - Unitless number
@@ -12,56 +12,26 @@
     @return $number;
 }
 
-
-// Converts one or more pixel values into matching rem values.
-// Borrowed from: https://github.com/zurb/foundation-sites/blob/develop/scss/util/_unit.scss
-// @param {Number|List} $values - One or more values to convert. Be sure to separate them with spaces and not commas. If you need to convert a comma-separated list, wrap the list in parentheses.
-// @param {Number} $base [null] - The base value to use when calculating the `rem`. If you're using Figuration out of the box, this is 16px. If this parameter is `null`, the function will reference the `$font-size-root` variable as the base.
-// @returns {List} A list of converted values.
-@function rem-calc($values, $base: null) {
-    $rem-values: ();
-    $count: length($values);
-
-    // If no base is defined, assume 100% default
-    @if $base == null {
-        $base: 100%;
-    }
-
-    // If the base font size is a %, then multiply it by 16px
-    // This is because 100% font size = 16px in most browsers
-    @if unit($base) == "%" {
-        $base: ($base / 100%) * 16px;
-    }
-
-    @if $count == 1 {
-        @return _px-to-rem($values, $base);
-    }
-
-    @for $i from 1 through $count {
-        $rem-values: append($rem-values, _px-to-rem(nth($values, $i), $base));
-    }
-
-    @return $rem-values;
-}
-
-
-// Converts a pixel value to matching rem value. *Any* value passed, regardless of unit, is assumed to be a pixel value.
-// By default, the base pixel value used to calculate the rem value is taken from the `$font-size-root` variable.
-// Borrowed from: https://github.com/zurb/foundation-sites/blob/develop/scss/util/_unit.scss
-// @access private
+// Converts any value to matching rem value.
+// *Any* value passed, regardless of unit, is assumed to be a pixel value.
 // @param {Number} $value - Pixel value to convert.
-// @param {Number} $base [null] - Base for pixel conversion.
 // @returns {Number} A number in rems, calculated based on the given value and the base pixel value. rem values are passed through as is.
-@function _px-to-rem($value, $base: null) {
+@function -any-to-rem($value) {
     // Check if the value is a number
     @if type-of($value) != "number" {
-        @warn inspect($value) + " was passed to rem-calc(), which is not a number.";
+        @warn inspect($value) + " was passed to rem(), which is not a number.";
         @return $value;
     }
 
-    // Calculate rem if units for $value is not rem
+    // Convert em into rem
+    @if unit($value) == "em" {
+        $value: strip-unit($value) * 1rem;
+    }
+
+    // Calculate rem if units for $value is not rem or em
+    // Using 16px = 100% font size common in most browsers
     @if unit($value) != "rem" {
-        $value: strip-unit($value) / strip-unit($base) * 1rem;
+        $value: strip-unit($value) / strip-unit(16px) * 1rem;
     }
 
     // Turn 0rem into 0
@@ -72,13 +42,29 @@
     @return $value;
 }
 
+// Converts one or more values into matching rem values.
+// @param {Number|List} $values - One or more values to convert. Be sure to separate them with spaces and not commas. If you need to convert a comma-separated list, wrap the list in parentheses.
+// @returns {List} A list of converted values.
+@function rem($values) {
+    $rem-values: ();
+    $count: length($values);
+
+    @if $count == 1 {
+        @return _any-to-rem($values);
+    }
+
+    @for $i from 1 through $count {
+        $rem-values: append($rem-values, _any-to-rem(nth($values, $i)));
+    }
+
+    @return $rem-values;
+}
 
 // Converts a unitless, pixel, or rem value to em, for use in breakpoints.
-// Borrowed from: https://github.com/zurb/foundation-sites/blob/develop/scss/util/_unit.scss
 @function bp-to-em($value) {
     // Pixel and unitless values are converted to rem
     @if unit($value) == "px" or unitless($value) {
-        $value: rem-calc($value, $base: 16px);
+        $value: rem($value);
     }
 
     // Convert to em

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -73,7 +73,7 @@
 // Button sizes
 @mixin button-size($padding-y, $padding-x, $font-size, $border-radius) {
     padding: $padding-y $padding-x;
-    font-size: $font-size;
+    @include font-size($font-size);
     // Manually declare to provide an override to the browser default
     @if $enable-rounded {
         border-radius: $border-radius;

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -131,7 +131,7 @@ $fs-minimum: strip-unit($fs-minimum);
         $fs-scaled: null;
         $fs-output: null;
         @if $fs > $fs-minimum and $factor != 1 {
-            $fs-scaled: $fs * $factor;
+            $fs-scaled: $fs-minimum + ($fs - $fs-minimum) * $factor;
             $fs-output: #{$fs-scaled}rem#{$fs-append};
         }
 

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -1,13 +1,3 @@
-// For later reference:
-
-// px vs em vs rem
-//https://stackoverflow.com/questions/11799236/should-i-use-px-or-rem-value-units-in-my-css
-//https://stackoverflow.com/a/43131958
-//https://stackoverflow.com/questions/11799236/should-i-use-px-or-rem-value-units-in-my-css/43131958#43131958
-
-// Media queries
-//https://engageinteractive.co.uk/blog/em-vs-rem-vs-px
-
 // Calculate minimum font size as unitless rem eqivalent.
 $fs-minimum: rem($font-size-ratio-minimum-size);
 $fs-minimum: strip-unit($fs-minimum);
@@ -82,8 +72,6 @@ $fs-breakpoint: null;
         $fs-min: $fs-minimum + ($fs - $fs-minimum) / $font-size-ratio-factor;
         // Calculate difference between given font-size and minimum font-size for given font-size.
         $fs-diff: $fs - $fs-min;
-
-
 
         // Minimum font-size formatting.
         // No need to check if the unit is valid, because we did that before.

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -103,7 +103,7 @@ $fs-breakpoint: null;
             // prevents the media query from overriding the font size.
             &,
             .font-size-static &,
-            &font-size-static {
+            &.font-size-static {
                 font-size: $fs-static;
             }
         } @else {

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -1,0 +1,141 @@
+// For later reference:
+
+// px vs em vs rem
+//https://stackoverflow.com/questions/11799236/should-i-use-px-or-rem-value-units-in-my-css
+//https://stackoverflow.com/a/43131958
+//https://stackoverflow.com/questions/11799236/should-i-use-px-or-rem-value-units-in-my-css/43131958#43131958
+
+// Media queries
+//https://engageinteractive.co.uk/blog/em-vs-rem-vs-px
+
+// Calculate minimum font size as unitless rem eqivalent.
+$fs-minimum: rem($font-size-ratio-minimum-size);
+$fs-minimum: strip-unit($fs-minimum);
+
+// Check for only one responsive typography method in use.
+@if $font-size-ratio and $font-size-scale {
+    @error "More than one Responsive Typography (font-size) method has been selected. Please update your settings to only use one of the available Repsonsive Typography methods.";
+}
+
+$fs-breakpoint: null;
+
+@if $font-size-ratio {
+    // Check breakpoint unit.
+    $fs-breakpoint-unit: unit($font-size-ratio-breakpoint);
+    @if $fs-breakpoint-unit != em {
+        @error "`#{$fs-breakpoint-unit}` is not a valid unit for $font-size-ratio-breakpoint. Please use `em`.";
+    }
+
+    // Calculate breakpoint as unitless rem eqivalent.
+    $fs-breakpoint: rem($font-size-ratio-breakpoint);
+    $fs-breakpoint: strip-unit($fs-breakpoint);
+
+    // Check scaling factor.
+    @if type-of($font-size-ratio-factor) != "number" or $font-size-ratio-factor < 1 {
+        @error "`#{$font-size-ratio-factor}` is not a valid  $font-size-ratio-factor, it must be greater or equal to 1.";
+    }
+}
+
+@mixin font-size($fs, $important: false) {
+    $fs-append: "";
+
+    // Add !important rule to the append if set
+    @if $important {
+        $fs-append: " !important";
+    }
+
+    // If $fs isn't a number (like inherit) or $fs has a unit (not px or rem, like 1.5em) or $fs is 0, just print the value.
+    @if type-of($fs) != "number" or (not unitless($fs) and unit($fs) != "px" and unit($fs) != "rem") or $fs == 0 {
+        font-size: #{$fs}#{$fs-append};
+    } @else if ($font-size-ratio) {
+        // Use ratio variant
+        @include font-size-ratio($fs, $fs-append);
+    } @else if ($font-size-scale) {
+        // Use scaled variant
+        @include font-size-scale($fs, $fs-append);
+    } @else {
+        // No variant selected, just print the font-size.
+        font-size: #{$fs}#{$fs-append};
+    }
+}
+
+// Responsive typography sizing using viewport ratio
+@mixin font-size-ratio($fs, $fs-append) {
+    // Variable holders
+    $fs-static: null;
+    $fs-fluid: null;
+
+    // Calculate font size as unitless rem eqivalent.
+    $fs: rem($fs);
+    $fs: strip-unit($fs);
+
+    // Set default font-size output.
+    $fs-static: #{$fs}rem#{$fs-append};
+
+    // Only add media query if font-size is bigger than the minimum font-size.
+    // If $font-size-ratio-factor == 1, no rescaling will take place.
+    @if $fs > $fs-minimum and $font-size-ratio-factor != 1 {
+        $min-width: $font-size-ratio-breakpoint;
+        $variable-unit: null;
+
+        // Calculate minimum font-size for given font-size.
+        $fs-min: $fs-minimum + ($fs - $fs-minimum) / $font-size-ratio-factor;
+        // Calculate difference between given font-size and minimum font-size for given font-size.
+        $fs-diff: $fs - $fs-min;
+
+
+
+        // Minimum font-size formatting.
+        // No need to check if the unit is valid, because we did that before.
+        $min-width: #{$fs-min}rem;
+
+        // If two-dimensional, use smallest of screen width and height.
+        @if $font-size-ratio-two-dimensional {
+            $variable-unit: vmin;
+        } @else {
+            $variable-unit: vw;
+        }
+
+        // Calculate the variable width between 0 and $fs-breakpoint.
+        $variable-width: #{$fs-diff * 100 / $fs-breakpoint}#{$variable-unit};
+
+        // Set the calculated font-size.
+        $fs-fluid: calc(#{$min-width} + #{$variable-width}) #{$fs-append};
+    }
+
+    // Rendering.
+    @if $fs-fluid == null {
+        // Only render static font-size if no fluid font-size is available.
+        font-size: $fs-static;
+    } @else {
+        $mq-value: $font-size-ratio-breakpoint;
+
+        @if $font-size-ratio-generate-static {
+            // Adding an extra class increases specificity, which
+            // prevents the media query from overriding the font size.
+            &,
+            .font-size-static &,
+            &font-size-static {
+                font-size: $fs-static;
+            }
+        } @else {
+            font-size: $fs-static;
+        }
+
+        @if $font-size-ratio-two-dimensional {
+            @media (max-width: #{$mq-value}), (max-height: #{$mq-value}) {
+                font-size: $fs-fluid;
+            }
+        } @else {
+            @media (max-width: #{$mq-value}) {
+                font-size: $fs-fluid;
+            }
+        }
+    }
+}
+
+// Responsive typography sizing using breakpoint scaling
+@mixin font-size-scale($fs, $fs-append) {
+    // [TODO] - return basic font-size for now
+    font-size: #{$fs}#{$fs-append};
+}

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -1,7 +1,11 @@
-// Check for only one responsive typography method in use.
-@if $font-size-ratio and $font-size-scale {
+// Make sure only one responsive typography method is enabled.
+@if $enable-rfs-fluid and $enable-rfs-scale {
     @error "More than one Responsive Typography (font-size) method has been selected. Please update your settings to only use one of the available Repsonsive Typography methods.";
 }
+
+// Calculate minimum font size as unitless rem equivalent.
+$fs-minimum: rem($responsive-font-size-minimum-size);
+$fs-minimum: strip-unit($fs-minimum);
 
 @mixin font-size($fs, $important: false) {
     $fs-append: "";
@@ -14,10 +18,10 @@
     // If $fs isn't a number (like inherit) or $fs has a unit (not px or rem, like 1.5em) or $fs is 0, just print the value.
     @if type-of($fs) != "number" or (not unitless($fs) and unit($fs) != "px" and unit($fs) != "rem") or $fs == 0 {
         font-size: #{$fs}#{$fs-append};
-    } @else if ($font-size-ratio) {
-        // Use ratio variant
-        @include font-size-ratio($fs, $fs-append);
-    } @else if ($font-size-scale) {
+    } @else if ($enable-rfs-fluid) {
+        // Use fluid variant
+        @include font-size-fluid($fs, $fs-append);
+    } @else if ($enable-rfs-scale) {
         // Use scaled variant
         @include font-size-scale($fs, $fs-append);
     } @else {
@@ -27,24 +31,20 @@
 }
 
 // Responsive typography sizing using viewport ratio
-@mixin font-size-ratio($fs, $fs-append) {
+@mixin font-size-fluid($fs, $fs-append) {
     // Check breakpoint unit.
-    $fs-breakpoint-unit: unit($font-size-ratio-breakpoint);
+    $fs-breakpoint-unit: unit($responsive-font-size-fluid-breakpoint);
     @if $fs-breakpoint-unit != em {
-        @error "`#{$fs-breakpoint-unit}` is not a valid unit for $font-size-ratio-breakpoint. Please use `em`.";
+        @error "`#{$fs-breakpoint-unit}` is not a valid unit for $responsive-font-size-fluid-breakpoint. Please use `em`.";
     }
 
     // Check scaling factor.
-    @if type-of($font-size-ratio-factor) != "number" or $font-size-ratio-factor < 1 {
-        @error "`#{$font-size-ratio-factor}` is not a valid  $font-size-ratio-factor, it must be greater or equal to 1.";
+    @if type-of($responsive-font-size-fluid-factor) != "number" or $responsive-font-size-fluid-factor < 1 {
+        @error "`#{$responsive-font-size-fluid-factor}` is not a valid  $responsive-font-size-fluid-factor, it must be greater or equal to 1.";
     }
 
-    // Calculate minimum font size as unitless rem equivalent.
-    $fs-minimum: rem($font-size-ratio-minimum-size);
-    $fs-minimum: strip-unit($fs-minimum);
-
     // Calculate breakpoint as unitless rem equivalent.
-    $fs-breakpoint: rem($font-size-ratio-breakpoint);
+    $fs-breakpoint: rem($responsive-font-size-fluid-breakpoint);
     $fs-breakpoint: strip-unit($fs-breakpoint);
 
     // Calculate font size as unitless rem equivalent.
@@ -55,14 +55,14 @@
     $fs-static: #{$fs}rem#{$fs-append};
 
     // Only add media query if font-size is bigger than the minimum font-size.
-    // If $font-size-ratio-factor == 1, no rescaling will take place.
+    // If $responsive-font-size-fluid-factor == 1, no rescaling will take place.
     $fs-fluid: null;
-    @if $fs > $fs-minimum and $font-size-ratio-factor != 1 {
-        $min-width: $font-size-ratio-breakpoint;
+    @if $fs > $fs-minimum and $responsive-font-size-fluid-factor != 1 {
+        $min-width: $responsive-font-size-fluid-breakpoint;
         $variable-unit: null;
 
         // Calculate minimum font-size for given font-size.
-        $fs-min: $fs-minimum + ($fs - $fs-minimum) / $font-size-ratio-factor;
+        $fs-min: $fs-minimum + ($fs - $fs-minimum) / $responsive-font-size-fluid-factor;
         // Calculate difference between given font-size and minimum font-size for given font-size.
         $fs-diff: $fs - $fs-min;
 
@@ -70,7 +70,7 @@
         $min-width: #{$fs-min}rem;
 
         // If two-dimensional, use smallest of screen width and height.
-        @if $font-size-ratio-two-dimensional {
+        @if $responsive-font-size-fluid-two-dimensional {
             $variable-unit: vmin;
         } @else {
             $variable-unit: vw;
@@ -83,14 +83,14 @@
         $fs-fluid: calc(#{$min-width} + #{$variable-width}) #{$fs-append};
     }
 
-    // Rendering.
+    // Render output.
     @if $fs-fluid == null {
         // Only render static font-size if no fluid font-size is available.
         font-size: $fs-static;
     } @else {
-        $mq-value: $font-size-ratio-breakpoint;
+        $mq-value: $responsive-font-size-fluid-breakpoint;
 
-        @if $font-size-ratio-generate-static {
+        @if $responsive-font-size-generate-static {
             // Adding an extra class increases specificity, which
             // prevents the media query from overriding the font size.
             &,
@@ -102,7 +102,7 @@
             font-size: $fs-static;
         }
 
-        @if $font-size-ratio-two-dimensional {
+        @if $responsive-font-size-fluid-two-dimensional {
             @media (max-width: #{$mq-value}), (max-height: #{$mq-value}) {
                 font-size: $fs-fluid;
             }
@@ -120,18 +120,14 @@
     $fs: rem($fs);
     $fs: strip-unit($fs);
 
-    // Calculate minimum font size as unitless rem equivalent.
-    $fs-minimum: rem($font-size-scale-minimum-size);
-    $fs-minimum: strip-unit($fs-minimum);
-
     // Set default font-size output.
     $fs-static: #{$fs}rem#{$fs-append};
     $fs-prev: null;
     @each $breakpoint in map-keys($grid-breakpoints) {
-        $factor: map-get($font-size-scale-factor, $breakpoint);
+        $factor: map-get($responsive-font-size-scale-factor, $breakpoint);
 
         // Only add media query if font-size is bigger than the minimum font-size.
-        // If $font-size-ratio-factor == 1, no rescaling will take place.
+        // If $factor == 1, no rescaling will take place.
         $fs-scaled: null;
         $fs-output: null;
         @if $fs > $fs-minimum and $factor != 1 {
@@ -143,7 +139,7 @@
         @if $fs-scaled == null {
             @if $fs-prev != $fs {
                 // Only render static font-size if no scaled font-size is available.
-                @if $font-size-scale-generate-static and $fs > $fs-minimum {
+                @if $responsive-font-size-generate-static and $fs > $fs-minimum {
                     @include media-breakpoint-up($breakpoint) {
                         font-size: $fs-static;
                     }

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -116,6 +116,57 @@
 
 // Responsive typography sizing using breakpoint scaling
 @mixin font-size-scale($fs, $fs-append) {
-    // [TODO] - return basic font-size for now
-    font-size: #{$fs}#{$fs-append};
+    // Calculate font size as unitless rem equivalent.
+    $fs: rem($fs);
+    $fs: strip-unit($fs);
+
+    // Calculate minimum font size as unitless rem equivalent.
+    $fs-minimum: rem($font-size-scale-minimum-size);
+    $fs-minimum: strip-unit($fs-minimum);
+
+    // Set default font-size output.
+    $fs-static: #{$fs}rem#{$fs-append};
+    $fs-prev: null;
+    @each $breakpoint in map-keys($grid-breakpoints) {
+        $factor: map-get($font-size-scale-factor, $breakpoint);
+
+        // Only add media query if font-size is bigger than the minimum font-size.
+        // If $font-size-ratio-factor == 1, no rescaling will take place.
+        $fs-scaled: null;
+        $fs-output: null;
+        @if $fs > $fs-minimum and $factor != 1 {
+            $fs-scaled: $fs * $factor;
+            $fs-output: #{$fs-scaled}rem#{$fs-append};
+        }
+
+        // Rendering.
+        @if $fs-scaled == null {
+            @if $fs-prev != $fs {
+                // Only render static font-size if no scaled font-size is available.
+                @if $font-size-scale-generate-static and $fs > $fs-minimum {
+                    @include media-breakpoint-up($breakpoint) {
+                        font-size: $fs-static;
+                    }
+                    // Adding an extra class increases specificity, which
+                    // prevents the media query from overriding the font size.
+                    .font-size-static &,
+                    &.font-size-static {
+                        font-size: $fs-static;
+                    }
+                } @else {
+                    @include media-breakpoint-up($breakpoint) {
+                        font-size: $fs-static;
+                    }
+                }
+            }
+            $fs-prev: $fs;
+        } @else {
+            @if $fs-prev != $fs-scaled {
+                @include media-breakpoint-up($breakpoint) {
+                    font-size: $fs-output;
+                }
+            }
+            $fs-prev: $fs-scaled;
+        }
+    }
 }

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -1,29 +1,6 @@
-// Calculate minimum font size as unitless rem eqivalent.
-$fs-minimum: rem($font-size-ratio-minimum-size);
-$fs-minimum: strip-unit($fs-minimum);
-
 // Check for only one responsive typography method in use.
 @if $font-size-ratio and $font-size-scale {
     @error "More than one Responsive Typography (font-size) method has been selected. Please update your settings to only use one of the available Repsonsive Typography methods.";
-}
-
-$fs-breakpoint: null;
-
-@if $font-size-ratio {
-    // Check breakpoint unit.
-    $fs-breakpoint-unit: unit($font-size-ratio-breakpoint);
-    @if $fs-breakpoint-unit != em {
-        @error "`#{$fs-breakpoint-unit}` is not a valid unit for $font-size-ratio-breakpoint. Please use `em`.";
-    }
-
-    // Calculate breakpoint as unitless rem eqivalent.
-    $fs-breakpoint: rem($font-size-ratio-breakpoint);
-    $fs-breakpoint: strip-unit($fs-breakpoint);
-
-    // Check scaling factor.
-    @if type-of($font-size-ratio-factor) != "number" or $font-size-ratio-factor < 1 {
-        @error "`#{$font-size-ratio-factor}` is not a valid  $font-size-ratio-factor, it must be greater or equal to 1.";
-    }
 }
 
 @mixin font-size($fs, $important: false) {
@@ -51,11 +28,26 @@ $fs-breakpoint: null;
 
 // Responsive typography sizing using viewport ratio
 @mixin font-size-ratio($fs, $fs-append) {
-    // Variable holders
-    $fs-static: null;
-    $fs-fluid: null;
+    // Check breakpoint unit.
+    $fs-breakpoint-unit: unit($font-size-ratio-breakpoint);
+    @if $fs-breakpoint-unit != em {
+        @error "`#{$fs-breakpoint-unit}` is not a valid unit for $font-size-ratio-breakpoint. Please use `em`.";
+    }
 
-    // Calculate font size as unitless rem eqivalent.
+    // Check scaling factor.
+    @if type-of($font-size-ratio-factor) != "number" or $font-size-ratio-factor < 1 {
+        @error "`#{$font-size-ratio-factor}` is not a valid  $font-size-ratio-factor, it must be greater or equal to 1.";
+    }
+
+    // Calculate minimum font size as unitless rem equivalent.
+    $fs-minimum: rem($font-size-ratio-minimum-size);
+    $fs-minimum: strip-unit($fs-minimum);
+
+    // Calculate breakpoint as unitless rem equivalent.
+    $fs-breakpoint: rem($font-size-ratio-breakpoint);
+    $fs-breakpoint: strip-unit($fs-breakpoint);
+
+    // Calculate font size as unitless rem equivalent.
     $fs: rem($fs);
     $fs: strip-unit($fs);
 
@@ -64,6 +56,7 @@ $fs-breakpoint: null;
 
     // Only add media query if font-size is bigger than the minimum font-size.
     // If $font-size-ratio-factor == 1, no rescaling will take place.
+    $fs-fluid: null;
     @if $fs > $fs-minimum and $font-size-ratio-factor != 1 {
         $min-width: $font-size-ratio-breakpoint;
         $variable-unit: null;
@@ -74,7 +67,6 @@ $fs-breakpoint: null;
         $fs-diff: $fs - $fs-min;
 
         // Minimum font-size formatting.
-        // No need to check if the unit is valid, because we did that before.
         $min-width: #{$fs-min}rem;
 
         // If two-dimensional, use smallest of screen width and height.

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -3,7 +3,7 @@
     .page-text,
     .page-link {
         padding: $padding-y $padding-x;
-        font-size: $font-size;
+        @include font-size($font-size);
     }
 
     .page-item {

--- a/scss/mixins/_switch.scss
+++ b/scss/mixins/_switch.scss
@@ -22,7 +22,7 @@
     .switch-control {
         width: ($font-size * $switch-width-multiplier);
         height: $outer-height;
-        font-size: $font-size;
+        @include font-size($font-size);
         @include border-radius($border-radius);
 
         &::before {
@@ -31,7 +31,7 @@
     }
 
     .switch-description {
-        font-size: $font-size;
+        @include font-size($font-size);
     }
 
     &.switch-rounded {


### PR DESCRIPTION
Start of the Responsive Typography work.

Types:
- [x] Standard sizing - this is the default mode - same as v3
- [x] Ratio scaling - variable sizing based on viewport dimension
- [x] Stepped scaling - one defined size per breakpoint

## Possible Features

- Minimum font-size check, where anything below the defined setting (default: `1rem`) will not be scaled. Preventing a *too small* text size from occurring becoming unreadable.
- Maximum breakpoint for ratio variant to keep size from blowing up too large.
- Option to generate a .`font-size-static` to override font scaling where desired.
- Maximum font-size check for stepped scaling variant?

## Opinionated Implementation 

So far I am thinking about using a **very opinionated** font size method where the `font-size()` mixin enforces the use of `rem` units on almost all of sizing.  The though being that we leave the `html/:root` font-size alone, and assume a `16px` default that most browsers seem to use.  The mixin will then convert any (`%`, `px`, `em`) sizes to a matching `rem` size.  No other option is currently available.

This goes along with the continued use of `em` units for our breakpoints.

The hope is that this will provide a greater level of accessibility, and provide a better experience for those who might alter the default font-size of their browser.

Currently, if no variant of typography is selected, the units will not be modified, but this might change, and recommendations to use `rem` units for `font-size`, and unitless `line-height`s should be mention in the docs.

A few related items regarding `rem` font-size and `em` breakpoints:
- https://stackoverflow.com/questions/11799236/should-i-use-px-or-rem-value-units-in-my-css/43131958#43131958
- https://engageinteractive.co.uk/blog/em-vs-rem-vs-px
- https://zellwk.com/blog/media-query-units/

## References

Responsive concepts borrowed from:
- https://github.com/MartijnCuppens/rfs
- https://zellwk.com/blog/responsive-typography/


