### PR TITLE
v4 - Color and palette overhaul

### DIFF
--- a/docs/content/color.md
+++ b/docs/content/color.md
@@ -7,7 +7,7 @@ group: content
 Figuration offers some simple color palettes extended from our base colors, similar to the concept by [Google's Material color palettes](https://www.google.com/design/spec/style/color.html#color-color-palette).
 
 Since our base colors tend to be dark, to mostly comply with [accessible text contrast ratios](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html) of 4.5:1 on a white background, the lighter side (<500 levels) of the palette has a larger interval than the darker side (>500 levels) to compensate.
-Please note that the `warning/mustard` color is not compliant with a 4.5:1 contrast ratio, and is not particularly suited for use as a text color.
+Please note that the `warning/yellow` color is not compliant with a 4.5:1 contrast ratio, and is not particularly suited for use as a text color.
 
 These can used for text or background colors. If applied to links, the colors will darken on hover.  Foregound items use the class format `.text-blue-500` and background items use `.bg-blue-500`.
 
@@ -106,19 +106,19 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
     </div>
 
     <div class="palette col-sm-4">
-        <div class="palette-base bg-mustard-500 text-light">
-            <p>mustard</p>
+        <div class="palette-base bg-yellow-500 text-light">
+            <p>yellow</p>
             500
         </div>
-        <div class="palette-item bg-mustard-50">50</div>
-        <div class="palette-item bg-mustard-100">100</div>
-        <div class="palette-item bg-mustard-200">200</div>
-        <div class="palette-item bg-mustard-300">300</div>
-        <div class="palette-item bg-mustard-400">400</div>
-        <div class="palette-item bg-mustard-500 text-light">500</div>
-        <div class="palette-item bg-mustard-600 text-light">600</div>
-        <div class="palette-item bg-mustard-700 text-light">700</div>
-        <div class="palette-item bg-mustard-800 text-light">800</div>
-        <div class="palette-item bg-mustard-900 text-light">900</div>
+        <div class="palette-item bg-yellow-50">50</div>
+        <div class="palette-item bg-yellow-100">100</div>
+        <div class="palette-item bg-yellow-200">200</div>
+        <div class="palette-item bg-yellow-300">300</div>
+        <div class="palette-item bg-yellow-400">400</div>
+        <div class="palette-item bg-yellow-500 text-light">500</div>
+        <div class="palette-item bg-yellow-600 text-light">600</div>
+        <div class="palette-item bg-yellow-700 text-light">700</div>
+        <div class="palette-item bg-yellow-800 text-light">800</div>
+        <div class="palette-item bg-yellow-900 text-light">900</div>
     </div>
 </div>

--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -211,7 +211,7 @@ $red:       #c81d0e;
 $green:     #108918;
 $blue:      #1242ba;
 $cyan:      #117dba;
-$mustard:   #c98800;
+$yellow:    #c98800;
 $gray:      #666;
 
 // Palette Map
@@ -220,7 +220,7 @@ $palette-themes: (
     "green":    $green,
     "blue":     $blue,
     "cyan":     $cyan,
-    "mustard":  $mustard,
+    "yellow":   $yellow,
     "gray":     $gray
 );
 {% endhighlight %}

--- a/docs/utilities/color.md
+++ b/docs/utilities/color.md
@@ -73,16 +73,18 @@ There are also two special text color cases for use with either light and dark b
 
 Similar to the contextual text color classes, easily set the background color of an element to any contextual class. Anchor components will darken on hover, just like the text classes.
 
+Background utilities **do not set** `color`, so in some cases you will want to use `.text-*` utilities.
+
 There is also a `.bg-transparent` for removing the background color for an element.
 
 {% example html %}
-<div class="bg-primary">Nullam id dolor id nibh ultricies vehicula ut id elit.</div>
-<div class="bg-success">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</div>
-<div class="bg-info">Maecenas sed diam eget risus varius blandit sit amet non magna.</div>
-<div class="bg-warning">Etiam porta sem malesuada magna mollis euismod.</div>
-<div class="bg-danger">Donec ullamcorper nulla non metus auctor fringilla.</div>
-<div class="bg-inverse">Cras mattis consectetur purus sit amet fermentum.</div>
-<div class="bg-faded"> Vestibulum ante ipsum primis in faucibus orci luctus.</div>
+<div class="bg-primary text-light">Nullam id dolor id nibh ultricies vehicula ut id elit.</div>
+<div class="bg-success text-dark">Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</div>
+<div class="bg-info text-light">Maecenas sed diam eget risus varius blandit sit amet non magna.</div>
+<div class="bg-warning text-dark">Etiam porta sem malesuada magna mollis euismod.</div>
+<div class="bg-danger text-light">Donec ullamcorper nulla non metus auctor fringilla.</div>
+<div class="bg-inverse text-light">Cras mattis consectetur purus sit amet fermentum.</div>
+<div class="bg-faded text-dark"> Vestibulum ante ipsum primis in faucibus orci luctus.</div>
 {% endexample %}
 
 ## Borders

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -486,7 +486,6 @@ $btn-default-hover-border:      $uibase-400 !default;
 $btn-default-active-hover-bg:   $uibase-100 !default;
 
 
-
 // Forms
 // =====
 // Padding and line-height should add up to buttons for inputs and selects

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -470,6 +470,13 @@ $btn-box-shadow:            inset 0 .125rem .25rem rgba(255, 255, 255, .25);
 $btn-focus-box-shadow:      0 0 2px 3px rgba(palette-context("info", 300), .75) !default; // px because simulating outline
 $btn-active-box-shadow:     inset 0 .125rem .25rem rgba(0, 0, 0, .25) !default;
 
+$btn-outline-bg:            transparent !default;
+$btn-outline-hover-color:   $white !default;
+
+$btn-disabled-opacity:      .6 !default;
+
+$btn-block-spacing-y:       .25rem !default;
+
 $btn-default-bg:                $white !default;
 $btn-default-color:             $uibase-500 !default;
 $btn-default-border:            $uibase-300 !default;
@@ -478,9 +485,6 @@ $btn-default-hover-color:       $uibase-600 !default;
 $btn-default-hover-border:      $uibase-400 !default;
 $btn-default-active-hover-bg:   $uibase-100 !default;
 
-$btn-disabled-opacity:      .6 !default;
-
-$btn-block-spacing-y:       .3rem !default;
 
 
 // Forms
@@ -826,7 +830,6 @@ $jumbotron-breakpoint:      sm !default;
 $badge-font-size:           75% !default;
 $badge-font-weight:         $font-weight-bold !default;
 $badge-padding-x:           .375em !default;
-//$badge-padding-y:           .25em !default;
 $badge-padding-y:           0 !default;
 $badge-line-height:         $line-height-base !default;
 $badge-border-radius:       .25em !default;
@@ -837,14 +840,13 @@ $badge-pill-padding-x:      .5em !default;
 // customizing padding or font-size on badges.
 $badge-pill-border-radius:  10rem !default;
 
-
 $badge-outline-bg:          transparent !default;
 
 $badge-default-bg:          palette($uibase, $level-context-bg) !default;
 $badge-default-color:       $uibase-500 !default;
 $badge-default-hover-bg:    palette($uibase, $level-control-border-color) !default;
 $badge-default-hover-color: color-if-contrast($uibase-600, $badge-default-hover-bg) !default;
-$badge-default-outline-color: $uibase;
+$badge-default-outline-color: $uibase-500;
 
 
 // Alerts

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -29,7 +29,6 @@ $palette-interval-dark:     .15% !default;
 // Minimum contrast ratio - WCAG 2.1 level AA spec
 $color-contrast-min-ratio:  4.5 !default;
 
-
 // Base Colors
 // =====
 $uibase:    #5a6570 !default;
@@ -841,11 +840,12 @@ $badge-pill-border-radius:  10rem !default;
 
 $badge-outline-bg:          transparent !default;
 
-$badge-default-bg:          palette($uibase, $level-context-bg) !default;
-$badge-default-color:       $uibase-500 !default;
-$badge-default-hover-bg:    palette($uibase, $level-control-border-color) !default;
-$badge-default-hover-color: color-if-contrast($uibase-600, $badge-default-hover-bg) !default;
-$badge-default-outline-color: $uibase-500;
+$badge-default-bg:              $white !default;
+$badge-default-color:           color-if-contrast($uibase-500, $badge-default-bg) !default;
+$badge-default-border:          $uibase-300 !default;
+$badge-default-hover-bg:        $uibase-50 !default;
+$badge-default-hover-color:     color-if-contrast($uibase-600, $badge-default-hover-bg) !default;
+$badge-default-hover-border:    $uibase-400 !default;
 
 
 // Alerts

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -40,6 +40,8 @@ $green:     #10ac21 !default;
 $blue:      #0d4ddc !default;
 $cyan:      #0080a7 !default;
 $yellow:    #fcc725 !default;
+$light:     palette($uibase, 50);
+$dark:      palette($uibase, 700);
 
 // Base UI Scale
 // =====
@@ -54,35 +56,39 @@ $uibase-700:  palette($uibase, 700);
 $uibase-800:  palette($uibase, 800);
 $uibase-900:  palette($uibase, 900);
 
+// Contextual Colors
+// =====
 $palette-themes: (
-    "uibase":   $uibase,
-    "red":      $red,
-    "green":    $green,
-    "blue":     $blue,
-    "cyan":     $cyan,
-    "yellow":   $yellow,
-    "gray":     $gray
+    "uibase":    $uibase,
+    "primary":   $blue,
+    "secondary": $uibase,
+    "info":      $cyan,
+    "success":   $green,
+    "warning":   $yellow,
+    "danger":    $red,
+    "gray":      $gray
 ) !default;
-
 
 // Contextual Colors
 // =====
 $context-themes: () !default;
 $context-colors: (
     "primary":   $blue,
-    "secondary": $gray,
+    "secondary": $uibase,
     "info":      $cyan,
     "success":   $green,
     "warning":   $yellow,
-    "danger":    $red
+    "danger":    $red,
+    "light":     $light,
+    "dark":      $dark
 ) !default;
 
 // Palette levels for use in _mix-context-colors() to determine
 // standardized contextual color mapping.
 $level-control-bg:                  500 !default;
-$level-control-border-color:        600 !default;
+$level-control-border-color:        500 !default;
 $level-control-hover-bg:            600 !default;
-$level-control-hover-border-color:  700 !default;
+$level-control-hover-border-color:  600 !default;
 $level-control-active-hover-bg:     700 !default;
 
 $level-context-bg:                  50 !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -13,6 +13,7 @@ $enable-rfs-fluid:      false !default;     // false
 $enable-rfs-scale:      false !default;     // false
 $enable-color-warnings: false !default;     //false
 
+
 // Palette
 // =====
 // List of levels to build CSS out for each of the palette themes
@@ -24,24 +25,40 @@ $palette-levels: 50 100 200 300 400 500 600 700 800 900 !default;
 $palette-interval-light:    .2% !default;
 $palette-interval-dark:     .15% !default;
 
-// Color
-// =====
-// Minimum contrast ratio - WCAG 2.1 level AA spec
-$color-contrast-min-ratio:  4.5 !default;
+// Palette levels for use in _mix-context-colors() to determine
+// standardized contextual color mapping.
+$level-control-bg:                  500 !default;
+$level-control-border-color:        500 !default;
+$level-control-hover-bg:            600 !default;
+$level-control-hover-border-color:  600 !default;
+$level-control-active-hover-bg:     700 !default;
+
+$level-context-bg:                  100 !default;
+$level-context-color:               800 !default;
+$level-context-border-color:        100 !default;
+$level-context-hover-bg:            200 !default;
+$level-context-hover-color:         900 !default;
+$level-context-hover-border-color:  200 !default; //deprecate
+
+// Increase (or decrease with negative number) to alter color for the hover state of
+//`.text-{color}-(palette-level} and `.bg-{color}-(palette-level} utilities
+$level-delta-hover-color:           200 !default;
+$level-delta-hover-bg:              200 !default;
+
 
 // Base Colors
 // =====
-$uibase:    #5a6570 !default;
+$uibase:    #546778 !default;
 $white:     #fff !default;
 $gray:      #666 !default;
 $black:     #000 !default;
 $red:       #df2314 !default;
 $green:     #10ac21 !default;
-$blue:      #0d4ddc !default;
-$cyan:      #0080a7 !default;
+$blue:      #005ff1 !default;
+$cyan:      #137db4 !default;
 $yellow:    #fcc725 !default;
-$light:     palette($uibase, 50);
-$dark:      palette($uibase, 700);
+$light:     palette($uibase, 50) !default;
+$dark:      palette($uibase, 700) !default;
 
 // Base UI Scale
 // =====
@@ -56,7 +73,7 @@ $uibase-700:  palette($uibase, 700);
 $uibase-800:  palette($uibase, 800);
 $uibase-900:  palette($uibase, 900);
 
-// Contextual Colors
+// Palette Colors
 // =====
 $palette-themes: (
     "uibase":    $uibase,
@@ -83,54 +100,17 @@ $context-colors: (
     "dark":      $dark
 ) !default;
 
-// Palette levels for use in _mix-context-colors() to determine
-// standardized contextual color mapping.
-$level-control-bg:                  500 !default;
-$level-control-border-color:        500 !default;
-$level-control-hover-bg:            600 !default;
-$level-control-hover-border-color:  600 !default;
-$level-control-active-hover-bg:     700 !default;
-
-$level-context-bg:                  50 !default;
-$level-context-color:               800 !default;
-$level-context-border-color:        100 !default;
-$level-context-hover-bg:            200 !default;
-$level-context-hover-color:         900 !default;
-$level-context-hover-border-color:  200 !default; //deprecate
-
-// Increase (or decrease with negative number) to alter color for the hover state of
-//`.text-{color}-(palette-level} and `.bg-{color}-(palette-level} utilities
-$level-color-hover-delta:    250 !default;
-$level-bg-hover-delta:       200 !default;
-
 // Process brand colors
 $brand-themes: _mix-context-colors($context-colors);
 // Merge into master themes map
 $context-themes: map-merge($context-themes, $brand-themes);
 
-// Sample of adding more colors using a mixing function
-// $custom-context: (
-//     "purple": #990099,
-//     "aqua":   #00ffff
-// );
-// Process custom colors into context color variants
-// $custom-themes: _mix-context-colors($custom-context);
-// Merge into master context themes map
-// $context-themes: map-merge($context-themes, $custom-themes);
-
-// Adding a single color map
-// $single-color: (
-//     "purple": (
-//         "control-bg":           #990099,
-//         "control-border":       #800080,
-//         "control-hover-bg":     #770077,
-//         "control-hover-border": #660066,
-//         "context-color":        #990099,
-//         "context-bg":           #ffb3ff,
-//         "context-border":       #ff29ff
-//     )
-// );
-// $context-themes: map-merge($context-themes, $single-color);
+// Color Contrast Settings
+// =====
+// Minimum contrast ratio - WCAG 2.1 level AA spec
+$color-contrast-min-ratio:  4.5 !default;
+$color-contrast-base-light: $white !default;
+$color-contrast-base-dark:  $uibase-900 !default;
 
 
 // Inverse Color
@@ -214,9 +194,6 @@ $grid-gutter-widths: (
 $body-bg:       $white !default;
 $body-color:    $uibase-900 !default;
 
-$faded-bg:       $uibase-50 !default;
-$faded-hover-bg: $uibase-100 !default;
-
 // Border dimension in pixels to get proper visual layout
 $border-width: 1px !default;
 $border-color: $uibase-300 !default;
@@ -226,7 +203,7 @@ $border-color: $uibase-300 !default;
 // Style anchor elements
 $link-color:            palette-context("primary", 500) !default;
 $link-decoration:       underline !default;
-$link-hover-color:      palette-context("primary", 850) !default;
+$link-hover-color:      palette-context("primary", 700) !default;
 $link-hover-decoration: underline !default;
 
 // Paragraph
@@ -273,12 +250,6 @@ $lead-font-weight:  600 !default;
 $lead-line-height:  $line-height-base !default;
 
 $small-font-size:   80% !default;
-
-$text-muted:        $uibase-500 !default;
-$text-light-color:  rgba(255, 255, 255, .875) !default;
-$text-light-hover:  rgba(255, 255, 255, 1) !default;
-$text-dark-color:   rgba(0, 0, 0, .875) !default;
-$text-dark-hover:   rgba(0, 0, 0, 1) !default;
 
 $mark-padding-x:    .25rem !default;
 $mark-bg:           #ff0 !default;
@@ -444,6 +415,7 @@ $figure-caption-color:      $uibase-500 !default;
 $table-margin-bottom:           $spacer !default;
 $table-cell-padding:            .75rem !default;
 $table-condensed-cell-padding:  .3125rem .5rem !default;
+$table-caption-color:           $uibase-500 !default;
 
 $table-bg:                  transparent !default;
 $table-bg-accent:           $uibase-50 !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -46,8 +46,9 @@ $level-delta-hover-color:           200 !default;
 $level-delta-hover-bg:              200 !default;
 
 
-// Base Colors
+// Colors
 // =====
+// Base Colors
 $uibase:    #546778 !default;
 $white:     #fff !default;
 $gray:      #666 !default;
@@ -61,7 +62,6 @@ $light:     palette($uibase, 50) !default;
 $dark:      palette($uibase, 700) !default;
 
 // Base UI Scale
-// =====
 $uibase-50:  palette($uibase, 50);
 $uibase-100:  palette($uibase, 100);
 $uibase-200:  palette($uibase, 200);
@@ -73,8 +73,7 @@ $uibase-700:  palette($uibase, 700);
 $uibase-800:  palette($uibase, 800);
 $uibase-900:  palette($uibase, 900);
 
-// Palette Colors
-// =====
+// Palette color
 $palette-themes: (
     "uibase":    $uibase,
     "primary":   $blue,
@@ -86,8 +85,7 @@ $palette-themes: (
     "gray":      $gray
 ) !default;
 
-// Contextual Colors
-// =====
+// Contextual colors
 $context-themes: () !default;
 $context-colors: (
     "primary":   $blue,
@@ -104,6 +102,7 @@ $context-colors: (
 $brand-themes: _mix-context-colors($context-colors);
 // Merge into master themes map
 $context-themes: map-merge($context-themes, $brand-themes);
+
 
 // Color Contrast Settings
 // =====

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -11,52 +11,57 @@ $enable-sizing:         true !default;      // true
 $enable-bp-smallest:    false !default;     // false
 $enable-rfs-fluid:      false !default;     // false
 $enable-rfs-scale:      false !default;     // false
+$enable-color-warnings: false !default;     //false
 
+// Palette
+// =====
+// List of levels to build CSS out for each of the palette themes
+// Valid levels 0-1000
+$palette-levels: 50 100 200 300 400 500 600 700 800 900 !default;
+
+// Percentage value per level to mix against white or black
+// Darker levels (>500) get narrower step interval than lighter
+$palette-interval-light:    .2% !default;
+$palette-interval-dark:     .15% !default;
 
 // Color
 // =====
 // Minimum contrast ratio - WCAG 2.1 level AA spec
-$color-min-contrast-ratio:  4.5 !default;
+$color-contrast-min-ratio:  4.5 !default;
 
-// Grayscale
+
+// Base Colors
 // =====
+$uibase:    #5a6570 !default;
 $white:     #fff !default;
+$gray:      #666 !default;
 $black:     #000 !default;
-$uibase:    #666 !default;
+$red:       #df2314 !default;
+$green:     #10ac21 !default;
+$blue:      #0d4ddc !default;
+$cyan:      #0080a7 !default;
+$yellow:    #fcc725 !default;
 
-$uibase-25:  palette($uibase, 25);
+// Base UI Scale
+// =====
 $uibase-50:  palette($uibase, 50);
-$uibase-75:  palette($uibase, 75);
 $uibase-100:  palette($uibase, 100);
 $uibase-200:  palette($uibase, 200);
 $uibase-300:  palette($uibase, 300);
 $uibase-400:  palette($uibase, 400);
-$uibase-450:  palette($uibase, 450);
 $uibase-500:  palette($uibase, 500);
 $uibase-600:  palette($uibase, 600);
 $uibase-700:  palette($uibase, 700);
 $uibase-800:  palette($uibase, 800);
 $uibase-900:  palette($uibase, 900);
 
-
-// Base Palette Colors
-// =====
-$red:       #c81d0e !default;
-$green:     #108918 !default;
-$blue:      #1242ba !default;
-$cyan:      #117cba !default;
-$mustard:   #c98800 !default;
-$gray:      #666 !default;
-
-// List of levels to build CSS out for each of the palette themes
-$palette-levels: 50 100 200 300 400 500 600 700 800 900 !default;
-
 $palette-themes: (
+    "uibase":   $uibase,
     "red":      $red,
     "green":    $green,
     "blue":     $blue,
     "cyan":     $cyan,
-    "mustard":  $mustard,
+    "yellow":   $yellow,
     "gray":     $gray
 ) !default;
 
@@ -66,24 +71,27 @@ $palette-themes: (
 $context-themes: () !default;
 $context-colors: (
     "primary":   $blue,
-    "secondary": palette($gray, 450), // bring down a bit
+    "secondary": $gray,
     "info":      $cyan,
     "success":   $green,
-    "warning":   $mustard,
+    "warning":   $yellow,
     "danger":    $red
 ) !default;
 
-// Palette levels for use in _mix-context-colors() to determine standardized
-// contextual color mapping
-$level-control-border:       600 !default;
-$level-control-hover-bg:     650 !default;
-$level-control-hover-border: 700 !default;
-$level-context-color:        600 !default;
-$level-context-bg:           75 !default;
-$level-context-border:       300 !default;
-$level-context-hover-color:  700 !default;
-$level-context-hover-bg:     125 !default;
-$level-context-hover-border: 550 !default;
+// Palette levels for use in _mix-context-colors() to determine
+// standardized contextual color mapping.
+$level-control-bg:                  500 !default;
+$level-control-border-color:        600 !default;
+$level-control-hover-bg:            600 !default;
+$level-control-hover-border-color:  700 !default;
+$level-control-active-hover-bg:     700 !default;
+
+$level-context-bg:                  50 !default;
+$level-context-color:               800 !default;
+$level-context-border-color:        100 !default;
+$level-context-hover-bg:            200 !default;
+$level-context-hover-color:         900 !default;
+$level-context-hover-border-color:  200 !default; //deprecate
 
 // Increase (or decrease with negative number) to alter color for the hover state of
 //`.text-{color}-(palette-level} and `.bg-{color}-(palette-level} utilities
@@ -108,10 +116,8 @@ $context-themes: map-merge($context-themes, $brand-themes);
 // Adding a single color map
 // $single-color: (
 //     "purple": (
-//         "control-color":        #fff,
 //         "control-bg":           #990099,
 //         "control-border":       #800080,
-//         "control-hover-color":  #fff,
 //         "control-hover-bg":     #770077,
 //         "control-hover-border": #660066,
 //         "context-color":        #990099,
@@ -320,7 +326,7 @@ $active-bg:         map-deep-get($context-themes, "primary", "control-bg") !defa
 $active-border:     map-deep-get($context-themes, "primary", "control-border") !default;
 $active-hover-bg:   map-deep-get($context-themes, "primary", "control-hover-bg") !default;
 
-$disabled-color:    $uibase-450 !default;
+$disabled-color:    $uibase-400 !default;
 $disabled-bg:       transparent !default;
 
 $caret-width:           .3125rem !default;
@@ -409,8 +415,8 @@ $embed-ratio: percentage(9 / 16) !default;
 $code-font-size:            87.5% !default;
 $code-padding-x:            .4375rem !default;
 $code-padding-y:            .125rem !default;
-$code-color:                map-get($context-colors, "danger") !default;
-$code-bg:                   $uibase-75 !default;
+$code-color:                palette($red, 550) !default;
+$code-bg:                   $uibase-50 !default;
 
 $kbd-color:                 $uibase-50 !default;
 $kbd-bg:                    $uibase-900 !default;
@@ -436,9 +442,9 @@ $table-condensed-cell-padding:  .3125rem .5rem !default;
 
 $table-bg:                  transparent !default;
 $table-bg-accent:           $uibase-50 !default;
-$table-bg-hover:            $uibase-75 !default;
+$table-bg-hover:            $uibase-100 !default;
 $table-bg-active:           $table-bg-hover !default;
-$table-bg-active-hover:     $uibase-100 !default;
+$table-bg-active-hover:     $uibase-200 !default;
 
 $table-head-color:          $uibase-900 !default;
 $table-head-bg:             $uibase-300 !default;
@@ -457,29 +463,24 @@ $table-border-color:        $uibase-300 !default;
 // =====
 $btn-padding-y:             .375rem !default;
 $btn-padding-x:             .75rem !default;
-$btn-line-height:           1.25 !default;
 $btn-font-weight:           $font-weight-normal !default;
+$btn-line-height:           1.25 !default;
+$btn-border-radius:         $border-radius !default;
 $btn-box-shadow:            inset 0 .125rem .25rem rgba(255, 255, 255, .25);
 $btn-focus-box-shadow:      0 0 2px 3px rgba(palette-context("info", 300), .75) !default; // px because simulating outline
 $btn-active-box-shadow:     inset 0 .125rem .25rem rgba(0, 0, 0, .25) !default;
 
-$btn-default-color:         $uibase-500 !default;
-$btn-default-bg:            $white !default;
-$btn-default-border:        rgba(0, 0, 0, .25) !default;
-$btn-default-hover-color:   $uibase-600 !default;
-$btn-default-hover-bg:      $uibase-75 !default;
-$btn-default-hover-border:  rgba(0, 0, 0, .5) !default;
-
-// Background color darken/lighten for ':active:hover' button state
-// Negative value will lighten, positive value will darken
-$btn-active-hover-adjust:   6% !default;
+$btn-default-bg:                $white !default;
+$btn-default-color:             $uibase-500 !default;
+$btn-default-border:            $uibase-300 !default;
+$btn-default-hover-bg:          $uibase-50 !default;
+$btn-default-hover-color:       $uibase-600 !default;
+$btn-default-hover-border:      $uibase-400 !default;
+$btn-default-active-hover-bg:   $uibase-100 !default;
 
 $btn-disabled-opacity:      .6 !default;
 
 $btn-block-spacing-y:       .3rem !default;
-
-// Allows for customizing button radius independently from global border radius
-$btn-border-radius:         $border-radius !default;
 
 
 // Forms
@@ -607,8 +608,8 @@ $switch-width-multiplier:               4 !default;
 $switch-control-bg:                     $input-bg !default;
 $switch-indicator-bg:                   $uibase-200 !default;
 
-$switch-active-control-bg:              $uibase-25 !default;
-$switch-active-indicator-bg:            $uibase-300 !default;
+$switch-active-control-bg:              $uibase-50 !default;
+$switch-active-indicator-bg:            $uibase-400 !default;
 
 $switch-focus-control-border-color:     $input-focus-border-color !default;
 $switch-focus-control-box-shadow-outer: $input-focus-box-shadow-outer !default;
@@ -822,14 +823,12 @@ $jumbotron-breakpoint:      sm !default;
 
 // Badges
 // =====
-$badge-color:               $white !default;
-$badge-bg:                  $uibase-400 !default;
-$badge-hover-bg:            $uibase-500 !default;
-$badge-link-hover-color:    $white !default;
 $badge-font-size:           75% !default;
 $badge-font-weight:         $font-weight-bold !default;
 $badge-padding-x:           .375em !default;
-$badge-padding-y:           .25em !default;
+//$badge-padding-y:           .25em !default;
+$badge-padding-y:           0 !default;
+$badge-line-height:         $line-height-base !default;
 $badge-border-radius:       .25em !default;
 $badge-border-width:        $border-width !default;
 
@@ -838,8 +837,14 @@ $badge-pill-padding-x:      .5em !default;
 // customizing padding or font-size on badges.
 $badge-pill-border-radius:  10rem !default;
 
+
 $badge-outline-bg:          transparent !default;
-$badge-outline-link-hover-color: $white !default;
+
+$badge-default-bg:          palette($uibase, $level-context-bg) !default;
+$badge-default-color:       $uibase-500 !default;
+$badge-default-hover-bg:    palette($uibase, $level-control-border-color) !default;
+$badge-default-hover-color: color-if-contrast($uibase-600, $badge-default-hover-bg) !default;
+$badge-default-outline-color: $uibase;
 
 
 // Alerts

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -478,10 +478,10 @@ $btn-disabled-opacity:      .6 !default;
 $btn-block-spacing-y:       .25rem !default;
 
 $btn-default-bg:                $white !default;
-$btn-default-color:             $uibase-500 !default;
+$btn-default-color:             color-if-contrast($uibase-500, $btn-default-bg) !default;
 $btn-default-border:            $uibase-300 !default;
 $btn-default-hover-bg:          $uibase-50 !default;
-$btn-default-hover-color:       $uibase-600 !default;
+$btn-default-hover-color:       color-if-contrast($uibase-600, $btn-default-hover-bg) !default;
 $btn-default-hover-border:      $uibase-400 !default;
 $btn-default-active-hover-bg:   $uibase-100 !default;
 

--- a/scss/component/_alert.scss
+++ b/scss/component/_alert.scss
@@ -32,10 +32,10 @@
 @each $theme, $colors in $context-themes {
     $color:       map-get($colors, "context-color");
     $bg:          map-get($colors, "context-bg");
-    $border:      map-get($colors, "context-border");
+    $border:      map-get($colors, "context-border-color");
     $hover-color: map-get($colors, "context-hover-color");
 
     .alert-#{$theme} {
-        @include alert-variant($color, $bg, $border, $hover-color);
+        @include alert-color($color, $bg, $border, $hover-color);
     }
 }

--- a/scss/component/_alert.scss
+++ b/scss/component/_alert.scss
@@ -35,6 +35,9 @@
     $border:      map-get($colors, "context-border-color");
     $hover-color: map-get($colors, "context-hover-color");
 
+    $color:       color-if-contrast($color, $bg);
+    $hover-color: color-if-contrast($hover-color, $bg);
+
     .alert-#{$theme} {
         @include alert-variant($color, $bg, $border, $hover-color);
     }

--- a/scss/component/_alert.scss
+++ b/scss/component/_alert.scss
@@ -36,6 +36,6 @@
     $hover-color: map-get($colors, "context-hover-color");
 
     .alert-#{$theme} {
-        @include alert-color($color, $bg, $border, $hover-color);
+        @include alert-variant($color, $bg, $border, $hover-color);
     }
 }

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -4,8 +4,7 @@
     padding: $badge-padding-y $badge-padding-x;
     @include font-size($badge-font-size);
     font-weight: $badge-font-weight;
-    line-height: 1;
-    color: $badge-color;
+    line-height: $badge-line-height;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
@@ -18,7 +17,8 @@
     }
 
     // Default color (linked badges get darker on :hover)
-    @include badge-variant($badge-color, $badge-bg, $badge-link-hover-color, $badge-hover-bg);
+    $color: color-if-contrast($badge-default-color, $badge-default-bg);
+    @include badge-color($badge-default-color, $badge-default-bg, $badge-default-bg, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-bg);
 }
 
 // Quick fix for badges in buttons
@@ -33,7 +33,6 @@ a.badge {
     text-decoration: none;
 
     @include hover-focus {
-        color: $badge-link-hover-color;
         text-decoration: none;
     }
 }
@@ -48,24 +47,35 @@ a.badge {
 
 // Colors (linked badges get darker on :hover)
 @each $theme, $colors in $context-themes {
-    $color:       map-get($colors, "control-color");
     $bg:          map-get($colors, "control-bg");
-    $hover-color: map-get($colors, "control-hover-color");
     $hover-bg:    map-get($colors, "control-hover-bg");
 
+    $color: color-if-contrast($badge-default-color, $bg);
+    $hover-color: color-if-contrast($color, $hover-bg);
+
     .badge-#{$theme} {
-        @include badge-variant($color, $bg, $hover-color, $hover-bg);
+        @include badge-color($color, $bg, $bg, $hover-color, $hover-bg, $hover-bg);
     }
 }
 
 // Outline (linked badges get color fill on :hover)
 .badge-outline {
-    @include badge-outline-variant($badge-bg);
+    $bg:          $badge-outline-bg;
+    $hover-bg:    $badge-default-bg;
+
+    $color: $badge-default-outline-color;
+    $hover-color: color-if-contrast($color, $hover-bg);
+
+    @include badge-color($color, $badge-outline-bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
 }
 @each $theme, $colors in $context-themes {
-    $color: map-get($colors, "control-bg");
+    $bg:          $badge-outline-bg;
+    $hover-bg:    map-get($colors, "control-bg");
+
+    $color:       map-get($colors, "control-bg");
+    $hover-color: color-if-contrast($white, $hover-bg);
 
     .badge-outline-#{$theme} {
-        @include badge-outline-variant($color);
+        @include badge-color($color, $bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
     }
 }

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -18,7 +18,7 @@
 
     // Default color (linked badges get darker on :hover)
     $color: color-if-contrast($badge-default-color, $badge-default-bg);
-    @include badge-color($badge-default-color, $badge-default-bg, $badge-default-bg, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-bg);
+    @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-bg, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-bg);
 }
 
 // Quick fix for badges in buttons
@@ -54,7 +54,7 @@ a.badge {
     $hover-color: color-if-contrast($color, $hover-bg);
 
     .badge-#{$theme} {
-        @include badge-color($color, $bg, $bg, $hover-color, $hover-bg, $hover-bg);
+        @include badge-variant($color, $bg, $bg, $hover-color, $hover-bg, $hover-bg);
     }
 }
 
@@ -66,7 +66,7 @@ a.badge {
     $color: $badge-default-outline-color;
     $hover-color: color-if-contrast($color, $hover-bg);
 
-    @include badge-color($color, $badge-outline-bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
+    @include badge-variant($color, $badge-outline-bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
 }
 @each $theme, $colors in $context-themes {
     $bg:          $badge-outline-bg;
@@ -76,6 +76,6 @@ a.badge {
     $hover-color: color-if-contrast($white, $hover-bg);
 
     .badge-outline-#{$theme} {
-        @include badge-color($color, $bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
+        @include badge-variant($color, $bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
     }
 }

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -17,8 +17,7 @@
     }
 
     // Default color (linked badges get darker on :hover)
-    $color: color-if-contrast($badge-default-color, $badge-default-bg);
-    @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-bg, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-bg);
+    @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
 }
 
 // Quick fix for badges in buttons
@@ -60,13 +59,7 @@ a.badge {
 
 // Outline (linked badges get color fill on :hover)
 .badge-outline {
-    $bg:          $badge-outline-bg;
-    $hover-bg:    $badge-default-bg;
-
-    $color: $badge-default-outline-color;
-    $hover-color: color-if-contrast($color, $hover-bg);
-
-    @include badge-variant($color, $badge-outline-bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
+    @include badge-variant($badge-default-color, $badge-outline-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
 }
 @each $theme, $colors in $context-themes {
     $bg:          $badge-outline-bg;

--- a/scss/component/_list-group.scss
+++ b/scss/component/_list-group.scss
@@ -75,7 +75,10 @@
     $color:       map-get($colors, "context-color");
     $bg:          map-get($colors, "context-bg");
     $hover-bg:    map-get($colors, "context-hover-bg");
-    $hover-color: $white;
+    $hover-color: map-get($colors, "context-hover-color");
+
+    $color:       color-if-contrast($color, $bg);
+    $hover-color: color-if-contrast($hover-color, $hover-bg);
 
     @include list-group-item-variant(#{$theme}, $bg, $color, $hover-bg, $hover-color);
 }

--- a/scss/component/_list-group.scss
+++ b/scss/component/_list-group.scss
@@ -77,5 +77,5 @@
     $hover-bg:    map-get($colors, "context-hover-bg");
     $hover-color: $white;
 
-    @include list-group-item-variant(#{$theme}, $bg, $color, $hover-bg, $hover-color);
+    @include list-group-item-color(#{$theme}, $bg, $color, $hover-bg, $hover-color);
 }

--- a/scss/component/_list-group.scss
+++ b/scss/component/_list-group.scss
@@ -77,5 +77,5 @@
     $hover-bg:    map-get($colors, "context-hover-bg");
     $hover-color: $white;
 
-    @include list-group-item-color(#{$theme}, $bg, $color, $hover-bg, $hover-color);
+    @include list-group-item-variant(#{$theme}, $bg, $color, $hover-bg, $hover-color);
 }

--- a/scss/component/_switch.scss
+++ b/scss/component/_switch.scss
@@ -122,7 +122,7 @@
 // Color variants
 @each $theme, $colors in $context-themes {
     // Lighter variation for consideration
-    //$var-indicator-bg:        map-get($colors, "context-border");
+    //$var-indicator-bg:        map-get($colors, "context-border-color");
     //$var-active-control-bg:   map-get($colors, "context-bg");
     //$var-active-indicator-bg: map-get($colors, "control-bg");
 

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -67,9 +67,9 @@ fieldset:disabled a.btn {
 // Contextual color variants
 @each $theme, $colors in $context-themes {
     $bg:                map-get($colors, "control-bg");
-    $border:            map-get($colors, "control-border");
+    $border:            map-get($colors, "control-border-color");
     $hover-bg:          map-get($colors, "control-hover-bg");
-    $hover-border:      map-get($colors, "control-hover-border");
+    $hover-border:      map-get($colors, "control-hover-border-color");
     $active-hover-bg:   map-get($colors, "control-active-hover-bg");
 
     $color:        color-if-contrast($btn-default-color, $bg);
@@ -82,16 +82,14 @@ fieldset:disabled a.btn {
 
 // Outline variant - remove all backgrounds
 @each $theme, $colors in $context-themes {
-    $color:        map-get($colors, "control-bg");
-    $bg:           transparent;
-    $border:       map-get($colors, "control-border");
-    $hover-color:  color-if-contrast($white, $bg);
-    $hover-bg:     $color;
-    $hover-border: map-get($colors, "control-hover-border");
-    $active-hover-bg:   map-get($colors, "control-active-hover-bg");
+    $bg:              $btn-outline-bg;
+    $border:          map-get($colors, "control-border-color");
+    $hover-bg:        map-get($colors, "control-bg");
+    $hover-border:    map-get($colors, "control-hover-border-color");
+    $active-hover-bg: map-get($colors, "control-active-hover-bg");
 
-    //$color:        color-if-contrast($color, $white);
-    $hover-color:  color-if-contrast($hover-color, $hover-bg);
+    $color:       map-get($colors, "control-bg");
+    $hover-color: color-if-contrast($btn-outline-hover-color, $hover-bg);
 
     .btn-outline-#{$theme} {
         @include button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -81,6 +81,9 @@ fieldset:disabled a.btn {
 }
 
 // Outline variant - remove all backgrounds
+.btn-outline {
+    @include button-variant($btn-default-color, $btn-outline-bg, $btn-default-border, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border, $btn-default-active-hover-bg);
+}
 @each $theme, $colors in $context-themes {
     $bg:              $btn-outline-bg;
     $border:          map-get($colors, "control-border-color");

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -55,7 +55,7 @@
     }
 
     // Default color
-    @include button-color($btn-default-color, $btn-default-bg, $btn-default-border, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border, $btn-default-active-hover-bg);
+    @include button-variant($btn-default-color, $btn-default-bg, $btn-default-border, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border, $btn-default-active-hover-bg);
 }
 
 // Future-proof disabling of clicks on `<a>` elements
@@ -76,7 +76,7 @@ fieldset:disabled a.btn {
     $hover-color:  color-if-contrast($color, $hover-bg);
 
     .btn-#{$theme} {
-        @include button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
+        @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
     }
 }
 
@@ -92,7 +92,7 @@ fieldset:disabled a.btn {
     $hover-color: color-if-contrast($btn-outline-hover-color, $hover-bg);
 
     .btn-outline-#{$theme} {
-        @include button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
+        @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
     }
 }
 
@@ -100,7 +100,7 @@ fieldset:disabled a.btn {
 // Make a button look and behave like a link
 .btn-link {
     text-decoration: $link-decoration;
-    @include button-color($link-color, transparent, transparent, $link-hover-color, transparent, transparent, transparent);
+    @include button-variant($link-color, transparent, transparent, $link-hover-color, transparent, transparent, transparent);
     @include box-shadow(none);
 
     @include hover-focus {

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -55,7 +55,7 @@
     }
 
     // Default color
-    @include button-variant($btn-default-color, $btn-default-bg, $btn-default-border, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border);
+    @include button-color($btn-default-color, $btn-default-bg, $btn-default-border, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border, $btn-default-active-hover-bg);
 }
 
 // Future-proof disabling of clicks on `<a>` elements
@@ -66,25 +66,35 @@ fieldset:disabled a.btn {
 
 // Contextual color variants
 @each $theme, $colors in $context-themes {
-    $color:        map-get($colors, "control-color");
-    $bg:           map-get($colors, "control-bg");
-    $border:       map-get($colors, "control-border");
-    $hover-color:  map-get($colors, "control-hover-color");
-    $hover-bg:     map-get($colors, "control-hover-bg");
-    $hover-border: map-get($colors, "control-hover-border");
+    $bg:                map-get($colors, "control-bg");
+    $border:            map-get($colors, "control-border");
+    $hover-bg:          map-get($colors, "control-hover-bg");
+    $hover-border:      map-get($colors, "control-hover-border");
+    $active-hover-bg:   map-get($colors, "control-active-hover-bg");
+
+    $color:        color-if-contrast($btn-default-color, $bg);
+    $hover-color:  color-if-contrast($color, $hover-bg);
 
     .btn-#{$theme} {
-        @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border);
+        @include button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
     }
 }
 
 // Outline variant - remove all backgrounds
 @each $theme, $colors in $context-themes {
     $color:        map-get($colors, "control-bg");
+    $bg:           transparent;
     $border:       map-get($colors, "control-border");
+    $hover-color:  color-if-contrast($white, $bg);
+    $hover-bg:     $color;
+    $hover-border: map-get($colors, "control-hover-border");
+    $active-hover-bg:   map-get($colors, "control-active-hover-bg");
+
+    //$color:        color-if-contrast($color, $white);
+    $hover-color:  color-if-contrast($hover-color, $hover-bg);
 
     .btn-outline-#{$theme} {
-        @include button-outline-variant($color, $border);
+        @include button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
     }
 }
 
@@ -92,7 +102,7 @@ fieldset:disabled a.btn {
 // Make a button look and behave like a link
 .btn-link {
     text-decoration: $link-decoration;
-    @include button-variant($link-color, transparent, transparent, $link-hover-color, transparent, transparent);
+    @include button-color($link-color, transparent, transparent, $link-hover-color, transparent, transparent, transparent);
     @include box-shadow(none);
 
     @include hover-focus {

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -293,7 +293,7 @@ table {
 caption {
     padding-top: $table-cell-padding;
     padding-bottom: $table-cell-padding;
-    color: $text-muted;
+    color: $table-caption-color;
     text-align: left;
     caption-side: bottom;
 }

--- a/scss/functions/_color-util.scss
+++ b/scss/functions/_color-util.scss
@@ -75,10 +75,13 @@
 // Get color with hopefully minimum contrast ratio against a given one
 // based on the minimum contrast ratio setting.
 @function color-contrast($color) {
-    @if (color-get-contrast-ratio(#fff, $color) <= $color-contrast-min-ratio) {
-        @return #000;
+    $color-light: $color-contrast-base-light;
+    $color-dark: $color-contrast-base-dark;
+
+    @if (color-get-contrast-ratio($color-light, $color) <= $color-contrast-min-ratio) {
+        @return $color-dark;
     }
-    @return #fff;
+    @return $color-light;
 }
 
 // Get color with maximum contrast against the given one.
@@ -102,7 +105,7 @@
     @if $enable-color-warnings {
         @warn "Auto-selected color (#{$colorauto}) does not meet the defined minimum contrast ratio (#{$color-contrast-min-ratio}:1) against the color (#{$color})! Now using a color with maximum contrast.";
     }
-    @return color-max-contrast($colorback);
+    @return color-max-contrast($color);
 }
 
 // Check to see if a color meets minimum contrast ratio and use it,

--- a/scss/functions/_color-util.scss
+++ b/scss/functions/_color-util.scss
@@ -1,10 +1,9 @@
 // Generate palette colors
 // Valid levels 0-1000
-// Darker levels (>500) get narrower step interval than light
-@function palette($color: $uibase, $level: 500) {
+@function palette($color, $level) {
     $base: 500;
-    $light-interval: .2%;
-    $dark-interval: .15%;
+    $light-interval: $palette-interval-light;
+    $dark-interval: $palette-interval-dark;
 
     $level-delta: $level - $base;
 
@@ -20,11 +19,13 @@
     }
 }
 
+//deprecate
 @function palette-context($key: "primary", $level: 500) {
     $color: map-get($context-colors, $key);
     @return palette($color, $level);
 }
 
+//deprecate
 @function palette-context-nohash($key: "primary", $level: 500) {
     $color: map-get($context-colors, $key);
     $hash: unquote(palette($color, $level) + "");
@@ -38,30 +39,27 @@
 
     @each $theme, $color in $map {
         // Color adjustments
-        $control-color:         $white;
-        $control-bg:            $color;
-        $control-border:        palette($color, $level-control-border);
-        $control-hover-color:   $white;
-        $control-hover-bg:      palette($color, $level-control-hover-bg);
-        $control-hover-border:  palette($color, $level-control-hover-border);
-        $context-color:         palette($color, $level-context-color);
-        $context-bg:            palette($color, $level-context-bg);
-        $context-border:        palette($color, $level-context-border);
-        $context-hover-color:   palette($color, $level-context-hover-color);
-        $context-hover-bg:      palette($color, $level-context-hover-bg);
-
+        $control-bg:                 palette($color, $level-control-bg);
+        $control-border-color:       palette($color, $level-control-border-color);
+        $control-hover-bg:           palette($color, $level-control-hover-bg);
+        $control-hover-border-color: palette($color, $level-control-hover-border-color);
+        $control-active-hover-bg:    palette($color, $level-control-active-hover-bg);
+        $context-bg:                 palette($color, $level-context-bg);
+        $context-color:              palette($color, $level-context-color);
+        $context-border-color:       palette($color, $level-context-border-color);
+        $context-hover-color:        palette($color, $level-context-hover-color);
+        $context-hover-bg:           palette($color, $level-context-hover-bg);
 
         // Build new map
         $new-map: (
-            "control-color": $control-color,
             "control-bg": $control-bg,
-            "control-border": $control-border,
-            "control-hover-color": $control-hover-color,
+            "control-border-color": $control-border-color,
             "control-hover-bg": $control-hover-bg,
-            "control-hover-border": $control-hover-border,
+            "control-hover-border-color": $control-hover-border-color,
+            "control-active-hover-bg": $control-active-hover-bg,
             "context-color": $context-color,
             "context-bg": $context-bg,
-            "context-border": $context-border,
+            "context-border-color": $context-border-color,
             "context-hover-color": $context-hover-color,
             "context-hover-bg": $context-hover-bg
         );
@@ -77,7 +75,7 @@
 // Get color with hopefully minimum contrast ratio against a given one
 // based on the minimum contrast ratio setting.
 @function color-contrast($color) {
-    @if (color-get-contrast-ratio(#fff, $color) <= $color-min-contrast-ratio) {
+    @if (color-get-contrast-ratio(#fff, $color) <= $color-contrast-min-ratio) {
         @return #000;
     }
     @return #fff;
@@ -97,21 +95,25 @@
 // ratio, otherwise get the max contrast.
 @function color-auto-contrast($color) {
     $colorauto: color-contrast($color);
-    @if (color-get-contrast-ratio($colorauto, $color) >= $color-min-contrast-ratio) {
+    @if (color-get-contrast-ratio($colorauto, $color) >= $color-contrast-min-ratio) {
         @return $colorauto;
     }
 
-    @warn "Auto-selected color (#{$colorauto}) does not meet the defined minimum contrast ratio (#{$color-min-contrast-ratio}:1) against the color (#{$color})! Now using a color with maximum contrast.";
+    @if $enable-color-warnings {
+        @warn "Auto-selected color (#{$colorauto}) does not meet the defined minimum contrast ratio (#{$color-contrast-min-ratio}:1) against the color (#{$color})! Now using a color with maximum contrast.";
+    }
     @return color-max-contrast($colorback);
 }
 
 // Check to see if a color meets minimum contrast ratio and use it,
 // otherwise get the best color contrast possible.
 @function color-if-contrast($colorfore, $colorback) {
-    @if (color-get-contrast-ratio($colorfore, $colorback) >= $color-min-contrast-ratio) {
+    @if (color-get-contrast-ratio($colorfore, $colorback) >= $color-contrast-min-ratio) {
         @return $colorfore;
     }
-    @warn "Foreground color (#{$colorfore}) does not meet the defined minimum contrast ratio (#{$color-min-contrast-ratio}:1) against the background color (#{$colorback})! Now auto-selecting a color with minimum contrast.";
+    @if $enable-color-warnings {
+        @warn "Foreground color (#{$colorfore}) does not meet the defined minimum contrast ratio (#{$color-contrast-min-ratio}:1) against the background color (#{$colorback})! Now auto-selecting a color with minimum contrast.";
+    }
     @return color-auto-contrast($colorback);
 }
 

--- a/scss/functions/_map-util.scss
+++ b/scss/functions/_map-util.scss
@@ -5,7 +5,7 @@
 // @param {Map} $map - Map
 // @param {Arglist} $keys - Key chain
 // @return {*} - Desired value
-// Example: $color: map-deep-get($context-themes, "primary", "control-color");
+// Example: $color: map-deep-get($context-themes, "primary", "control-bg");
 @function map-deep-get($map, $keys...) {
     @each $key in $keys {
         $map: map-get($map, $key);

--- a/scss/mixins/_alert.scss
+++ b/scss/mixins/_alert.scss
@@ -1,5 +1,5 @@
 // Alerts
-@mixin alert-color($color, $bg, $border, $hover-color) {
+@mixin alert-variant($color, $bg, $border, $hover-color) {
     color: $color;
     background-color: $bg;
     border-color: $border;

--- a/scss/mixins/_alert.scss
+++ b/scss/mixins/_alert.scss
@@ -1,5 +1,5 @@
 // Alerts
-@mixin alert-variant($color, $bg, $border, $hover-color) {
+@mixin alert-color($color, $bg, $border, $hover-color) {
     color: $color;
     background-color: $bg;
     border-color: $border;
@@ -7,6 +7,7 @@
     hr {
         border-top-color: $border;
     }
+
     .alert-link {
         color: $color;
 

--- a/scss/mixins/_background.scss
+++ b/scss/mixins/_background.scss
@@ -1,9 +1,8 @@
 // stylelint-disable declaration-no-important
 
 // Contextual backgrounds
-@mixin bg-variant($parent, $color, $bg, $hover-bg) {
+@mixin bg-variant($parent, $bg, $hover-bg) {
     #{$parent} {
-        color: $color !important;
         background-color: $bg !important;
     }
     a#{$parent} {

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -1,32 +1,14 @@
 // Badges
-@mixin badge-variant($color, $bg, $hover-color, $hover-bg) {
-    @if ($color != $badge-color) {
-        color: $color;
-    }
-    background-color: $bg;
-    border-color: $bg;
-
-    &[href] {
-        @include hover-focus {
-            @if ($hover-color != $badge-link-hover-color) {
-                color: $hover-color;
-            }
-            background-color: $hover-bg;
-            border-color: $hover-bg;
-        }
-    }
-}
-
-@mixin badge-outline-variant($color) {
+@mixin badge-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border) {
     color: $color;
-    background-color: $badge-outline-bg;
-    border-color: $color;
+    background-color: $bg;
+    border-color: $border;
 
     &[href] {
         @include hover-focus {
-            color: $badge-outline-link-hover-color;
-            background-color: $color;
-            border-color: $color;
+            color: $hover-color;
+            background-color: $hover-bg;
+            border-color: $hover-border;
         }
     }
 }

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -1,5 +1,5 @@
 // Badges
-@mixin badge-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border) {
+@mixin badge-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border) {
     color: $color;
     background-color: $bg;
     border-color: $border;

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -3,7 +3,7 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
-@mixin button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg) {
+@mixin button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg) {
     color: $color;
     background-color: $bg;
     border-color: $border;

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -3,7 +3,7 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
-@mixin button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-adjust: $btn-active-hover-adjust) {
+@mixin button-color($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg) {
     color: $color;
     background-color: $bg;
     border-color: $border;
@@ -30,42 +30,8 @@
 
         &:hover {
             color: $hover-color;
-            background-color: if(strip-unit($active-hover-adjust) <= 0, lighten($hover-bg, $active-hover-adjust * -1), darken($hover-bg, $active-hover-adjust));
+            background-color: $active-hover-bg;
             border-color: $hover-border;
-        }
-    }
-}
-
-@mixin button-outline-variant($color, $border, $hover-color: $white, $active-hover-adjust: $btn-active-hover-adjust) {
-    color: $color;
-    background-color: transparent;
-    background-image: none;
-    border-color: $border;
-
-    &:hover {
-        color: $hover-color;
-        background-color: $color;
-        border-color: $border;
-    }
-
-    &.disabled,
-    &:disabled {
-        color: $color;
-        background-color: transparent;
-        border-color: $border;
-    }
-
-    &:active,
-    &.active,
-    .open > & {
-        color: $hover-color;
-        background-color: $color;
-        border-color: $border;
-
-        &:hover {
-            color: $hover-color;
-            background-color: if(strip-unit($active-hover-adjust) <= 0, lighten($color, $active-hover-adjust * -1), darken($color, $active-hover-adjust));
-            border-color: $border;
         }
     }
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -6,8 +6,8 @@
 @mixin form-control-validation($color-name) {
     $color:        palette-context($color-name);
     $bg:           palette-context($color-name, $level-context-bg);
-    $border:       palette-context($color-name, $level-context-border);
-    $border-hover: palette-context($color-name, $level-context-hover-border);
+    $border:       palette-context($color-name, $level-context-border-color);
+    $border-hover: palette-context($color-name, $level-context-hover-border-color);
 
     // Color the label and help text
     .form-control-feedback,

--- a/scss/mixins/_gradients.scss
+++ b/scss/mixins/_gradients.scss
@@ -20,7 +20,7 @@
 }
 
 // Striped diagonal gradient
-@mixin gradient-striped($color: rgba(255,255,255,.15), $angle: 135deg) {
+@mixin gradient-striped($color: rgba(255,255,255,.25), $angle: 135deg) {
     background-image: linear-gradient($angle, $color 25%, transparent 25%, transparent 50%, $color 50%, $color 75%, transparent 75%, transparent);
 }
 

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -7,7 +7,7 @@
 }
 
 // List Groups
-@mixin list-group-item-variant($state, $bg, $color, $hover-bg, $hover-color) {
+@mixin list-group-item-color($state, $bg, $color, $hover-bg, $hover-color) {
     .list-group-item-#{$state} {
         color: $color;
         background-color: $bg;

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -7,7 +7,7 @@
 }
 
 // List Groups
-@mixin list-group-item-color($state, $bg, $color, $hover-bg, $hover-color) {
+@mixin list-group-item-variant($state, $bg, $color, $hover-bg, $hover-color) {
     .list-group-item-#{$state} {
         color: $color;
         background-color: $bg;

--- a/scss/utilities/_background.scss
+++ b/scss/utilities/_background.scss
@@ -1,16 +1,15 @@
 // stylelint-disable declaration-no-important
 
 // Special backgrounds
-@include bg-variant(".bg-inverse", map-get($inverse-color, "color"), map-get($inverse-color, "bg"), map-get($inverse-color, "hover-bg"));
-@include bg-variant(".bg-faded", inherit, $faded-bg, $faded-hover-bg);
+@include bg-variant(".bg-inverse", map-get($inverse-color, "bg"), map-get($inverse-color, "hover-bg"));
+@include bg-variant(".bg-faded", $faded-bg, $faded-hover-bg);
 
 // Contextual backgrounds
 @each $theme, $colors in $context-themes {
-    $color:    map-get($colors, "control-color");
     $bg:       map-get($colors, "control-bg");
     $hover-bg: map-get($colors, "control-hover-bg");
 
-    @include bg-variant(".bg-#{$theme}", $color, $bg, $hover-bg);
+    @include bg-variant(".bg-#{$theme}", $bg, $hover-bg);
 }
 
 // Palette colors

--- a/scss/utilities/_background.scss
+++ b/scss/utilities/_background.scss
@@ -1,9 +1,5 @@
 // stylelint-disable declaration-no-important
 
-// Special backgrounds
-@include bg-variant(".bg-inverse", map-get($inverse-color, "bg"), map-get($inverse-color, "hover-bg"));
-@include bg-variant(".bg-faded", $faded-bg, $faded-hover-bg);
-
 // Contextual backgrounds
 @each $theme, $colors in $context-themes {
     $bg:       map-get($colors, "control-bg");
@@ -16,7 +12,7 @@
 @if $enable-palette {
     @each $theme, $color in $palette-themes {
         @each $level in $palette-levels {
-            @include bg-palette-variant(".bg-#{$theme}-#{$level}", $color, $level, $level-bg-hover-delta);
+            @include bg-palette-variant(".bg-#{$theme}-#{$level}", $color, $level, $level-delta-hover-bg);
         }
     }
 }

--- a/scss/utilities/_text.scss
+++ b/scss/utilities/_text.scss
@@ -37,51 +37,28 @@
 .font-weight-bold   { font-weight: $font-weight-bold !important; }
 .font-italic        { font-style: italic !important; }
 
+// Truncated text
+.text-truncate {
+    @include text-truncate();
+}
+
 // Contextual colors
 @each $theme, $colors in $context-themes {
-    $color: map-get($colors, "control-bg");
+    $color: map-get($context-colors, $theme);
 
-    @include text-emphasis-variant(".text-#{$theme}", $color, $level-color-hover-delta);
+    @include text-emphasis-variant(".text-#{$theme}", $color, $level-delta-hover-color);
 }
 
 // Palette colors
 @if $enable-palette {
     @each $theme, $color in $palette-themes {
         @each $level in $palette-levels {
-            @include text-emphasis-palette-variant(".text-#{$theme}-#{$level}", $color, $level, $level-color-hover-delta);
+            @include text-emphasis-palette-variant(".text-#{$theme}-#{$level}", $color, $level, $level-delta-hover-color);
         }
     }
 }
 
-// Muted text
-@include text-emphasis-variant(".text-muted", $text-muted, $level-color-hover-delta);
-
-// Special case colors
-// stylelint-disable selector-no-qualifying-type
+// Special text colors
 .text-body {
     color: $body-color !important;
-}
-.text-light {
-    color: $text-light-color !important;
-}
-a.text-light {
-    @include hover-focus {
-        color: $text-light-hover !important;
-    }
-}
-.text-dark {
-    color: $text-dark-color !important;
-}
-a.text-dark {
-    @include hover-focus {
-        color: $text-dark-hover !important;
-    }
-}
-// stylelint-enable selector-no-qualifying-type
-
-// Truncated text
-.text-truncate {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1550,17 +1550,22 @@ Showing a <kbd>kdb sample</kbd>
 <button type="button" class="btn btn-info">Info</button>
 <button type="button" class="btn btn-warning">Warning</button>
 <button type="button" class="btn btn-danger">Danger</button>
+<button type="button" class="btn btn-light">Light</button>
+<button type="button" class="btn btn-dark">Dark</button>
 <button type="button" class="btn btn-link">Link</button>
 </p>
 
 <h3>Outline buttons</h3>
 <p>
+<button type="button" class="btn btn-outline">Default</button>
 <button type="button" class="btn btn-outline-primary">Primary</button>
 <button type="button" class="btn btn-outline-secondary">Secondary</button>
 <button type="button" class="btn btn-outline-success">Success</button>
 <button type="button" class="btn btn-outline-info">Info</button>
 <button type="button" class="btn btn-outline-warning">Warning</button>
 <button type="button" class="btn btn-outline-danger">Danger</button>
+<button type="button" class="btn btn-outline-light">Light</button>
+<button type="button" class="btn btn-outline-dark">Dark</button>
 </p>
 
 <h3>Active buttons</h3>
@@ -1572,15 +1577,20 @@ Showing a <kbd>kdb sample</kbd>
 <button type="button" class="btn btn-info active">Info</button>
 <button type="button" class="btn btn-warning active">Warning</button>
 <button type="button" class="btn btn-danger active">Danger</button>
+<button type="button" class="btn btn-light active">Light</button>
+<button type="button" class="btn btn-dark active">Dark</button>
 <button type="button" class="btn btn-link active">Link</button>
 </p>
 <p>
+<button type="button" class="btn btn-outline active">Default</button>
 <button type="button" class="btn btn-outline-primary active">Primary</button>
 <button type="button" class="btn btn-outline-secondary active">Secondary</button>
 <button type="button" class="btn btn-outline-success active">Success</button>
 <button type="button" class="btn btn-outline-info active">Info</button>
 <button type="button" class="btn btn-outline-warning active">Warning</button>
 <button type="button" class="btn btn-outline-danger active">Danger</button>
+<button type="button" class="btn btn-outline-light active">Light</button>
+<button type="button" class="btn btn-outline-dark active">Dark</button>
 </p>
 
 <h3>Disabled buttons</h3>
@@ -1593,14 +1603,19 @@ Showing a <kbd>kdb sample</kbd>
 <button type="button" class="btn btn-warning" disabled>Warning</button>
 <button type="button" class="btn btn-danger" disabled>Danger</button>
 <button type="button" class="btn btn-link" disabled>Link</button>
+<button type="button" class="btn btn-light" disabled>Light</button>
+<button type="button" class="btn btn-dark" disabled>Dark</button>
 </p>
 <p>
+<button type="button" class="btn btn-outline" disabled>Default</button>
 <button type="button" class="btn btn-outline-primary" disabled>Primary</button>
 <button type="button" class="btn btn-outline-secondary" disabled>Secondary</button>
 <button type="button" class="btn btn-outline-success" disabled>Success</button>
 <button type="button" class="btn btn-outline-info" disabled>Info</button>
 <button type="button" class="btn btn-outline-warning" disabled>Warning</button>
 <button type="button" class="btn btn-outline-danger" disabled>Danger</button>
+<button type="button" class="btn btn-outline-light" disabled>Light</button>
+<button type="button" class="btn btn-outline-dark" disabled>Dark</button>
 </p>
 Anchor variants:<br />
 <p>
@@ -1611,15 +1626,20 @@ Anchor variants:<br />
 <a href="#" role="button" class="btn btn-info disabled">Info</a>
 <a href="#" role="button" class="btn btn-warning disabled">Warning</a>
 <a href="#" role="button" class="btn btn-danger disabled">Danger</a>
+<a href="#" role="button" class="btn btn-light disabled">Light</a>
+<a href="#" role="button" class="btn btn-dark disabled">Dark</a>
 <a href="#" role="button" class="btn btn-link disabled">Link</a>
 </p>
 <p>
+<a href="#" role="button" class="btn btn-outline disabled">Default</a>
 <a href="#" role="button" class="btn btn-outline-primary disabled">Primary</a>
 <a href="#" role="button" class="btn btn-outline-secondary disabled">Secondary</a>
 <a href="#" role="button" class="btn btn-outline-success disabled">Success</a>
 <a href="#" role="button" class="btn btn-outline-info disabled">Info</a>
 <a href="#" role="button" class="btn btn-outline-warning disabled">Warning</a>
 <a href="#" role="button" class="btn btn-outline-danger disabled">Danger</a>
+<a href="#" role="button" class="btn btn-outline-light disabled">Light</a>
+<a href="#" role="button" class="btn btn-outline-dark disabled">Dark</a>
 </p>
 
 <h3>Button sizes</h3>
@@ -1766,16 +1786,26 @@ Anchor variants:<br />
 
 <h3>List group context</h3>
 <ul class="list-group">
-  <li class="list-group-item list-group-item-success">Dapibus ac facilisis in</li>
-  <li class="list-group-item list-group-item-info">Cras sit amet nibh libero</li>
-  <li class="list-group-item list-group-item-warning">Porta ac consectetur ac</li>
-  <li class="list-group-item list-group-item-danger">Vestibulum at eros</li>
+  <li class="list-group-item">Default list group item</li>
+  <li class="list-group-item list-group-item-primary">Primary list group item</li>
+  <li class="list-group-item list-group-item-secondary">Secondary list group item</li>
+  <li class="list-group-item list-group-item-success">Success list group item</li>
+  <li class="list-group-item list-group-item-info">Info list group item</li>
+  <li class="list-group-item list-group-item-warning">Warning list group item</li>
+  <li class="list-group-item list-group-item-danger">Danger list group item</li>
+  <li class="list-group-item list-group-item-light">Light list group item</li>
+  <li class="list-group-item list-group-item-dark">Dark list group item</li>
 </ul>
 <div class="list-group">
-  <a href="#" class="list-group-item list-group-item-action list-group-item-success">Dapibus ac facilisis in</a>
-  <a href="#" class="list-group-item list-group-item-action list-group-item-info">Cras sit amet nibh libero</a>
-  <a href="#" class="list-group-item list-group-item-action list-group-item-warning">Porta ac consectetur ac</a>
-  <a href="#" class="list-group-item list-group-item-action list-group-item-danger">Vestibulum at eros</a>
+  <a href="#" class="list-group-item list-group-item-action">Default list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-primary">Primary list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-secondary">Secondary list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-success">Success list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-info">Info list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-warning">Warning list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-danger">Danger list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-light">Light list group item</a>
+  <a href="#" class="list-group-item list-group-item-action list-group-item-dark">Dark list group item</a>
 </div>
 
 <h3>Custom list group</h3>
@@ -3178,6 +3208,8 @@ Anchor variants:<br />
 <span class="badge badge-info">Info</span>
 <span class="badge badge-warning">Warning</span>
 <span class="badge badge-danger">Danger</span>
+<span class="badge badge-light">Light</span>
+<span class="badge badge-dark">Dark</span>
 
 <h3>Badge anchors</h3>
 <a href="#" class="badge">Default</a>
@@ -3187,6 +3219,8 @@ Anchor variants:<br />
 <a href="#" class="badge badge-info">Info</a>
 <a href="#" class="badge badge-warning">Warning</a>
 <a href="#" class="badge badge-danger">Danger</a>
+<a href="#" class="badge badge-light">Light</a>
+<a href="#" class="badge badge-dark">Dark</a>
 
 <h3>Badge pills</h3>
 <span class="badge badge-pill">Default</span>
@@ -3196,6 +3230,8 @@ Anchor variants:<br />
 <span class="badge badge-pill badge-info">Info</span>
 <span class="badge badge-pill badge-warning">Warning</span>
 <span class="badge badge-pill badge-danger">Danger</span>
+<span class="badge badge-pill badge-light">Light</span>
+<span class="badge badge-pill badge-dark">Dark</span>
 
 <h3>Badge outline</h3>
 <span class="badge badge-outline">Default</span>
@@ -3205,6 +3241,8 @@ Anchor variants:<br />
 <span class="badge badge-outline-info">Info</span>
 <span class="badge badge-outline-warning">Warning</span>
 <span class="badge badge-outline-danger">Danger</span>
+<span class="badge badge-outline-light">Light</span>
+<span class="badge badge-outline-dark">Dark</span>
 
 <h3>Badge outline anchors</h3>
 <a href="#" class="badge badge-outline">Default</a>
@@ -3214,26 +3252,34 @@ Anchor variants:<br />
 <a href="#"  class="badge badge-outline-info">Info</a>
 <a href="#"  class="badge badge-outline-warning">Warning</a>
 <a href="#"  class="badge badge-outline-danger">Danger</a>
+<a href="#"  class="badge badge-outline-light">Light</a>
+<a href="#"  class="badge badge-outline-dark">Dark</a>
 
 
 <h3>Alerts</h3>
 <div class="alert alert-primary" role="alert">
-  <strong>Well done!</strong> You successfully read <a href="#" class="alert-link">this important alert message</a>.
+  Primary alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 <div class="alert alert-secondary" role="alert">
-  <strong>Well done!</strong> You successfully read <a href="#" class="alert-link">this important alert message</a>.
+  Secondary alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 <div class="alert alert-success" role="alert">
-  <strong>Well done!</strong> You successfully read <a href="#" class="alert-link">this important alert message</a>.
+  Success alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 <div class="alert alert-info" role="alert">
-  <strong>Heads up!</strong> This <a href="#" class="alert-link">alert needs your attention</a>, but it's not super important.
+  Info alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 <div class="alert alert-warning" role="alert">
-  <strong>Warning!</strong> Better check yourself, you're <a href="#" class="alert-link">not looking too good</a>.
+  Warning alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 <div class="alert alert-danger" role="alert">
-  <strong>Oh snap!</strong> <a href="#" class="alert-link">Change a few things up</a> and try submitting again.
+  Danger alert message with <a href="#" class="alert-link">an example link</a> included.
+</div>
+<div class="alert alert-light" role="alert">
+  Light alert message with <a href="#" class="alert-link">an example link</a> included.
+</div>
+<div class="alert alert-dark" role="alert">
+  Dark alert message with <a href="#" class="alert-link">an example link</a> included.
 </div>
 
 <h3>Full alert</h3>
@@ -4434,73 +4480,73 @@ $('#slider2').CFW_Slider({
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
-        Red:<br />
-        <div class="palette-item bg-red-50">50</div>
-        <div class="palette-item bg-red-100">100</div>
-        <div class="palette-item bg-red-200">200</div>
-        <div class="palette-item bg-red-300">300</div>
-        <div class="palette-item bg-red-400">400</div>
-        <div class="palette-item bg-red-500 text-light">500</div>
-        <div class="palette-item bg-red-600 text-light">600</div>
-        <div class="palette-item bg-red-700 text-light">700</div>
-        <div class="palette-item bg-red-800 text-light">800</div>
-        <div class="palette-item bg-red-900 text-light">900</div>
+        Danger:<br />
+        <div class="palette-item bg-danger-50">50</div>
+        <div class="palette-item bg-danger-100">100</div>
+        <div class="palette-item bg-danger-200">200</div>
+        <div class="palette-item bg-danger-300">300</div>
+        <div class="palette-item bg-danger-400">400</div>
+        <div class="palette-item bg-danger-500 text-light">500</div>
+        <div class="palette-item bg-danger-600 text-light">600</div>
+        <div class="palette-item bg-danger-700 text-light">700</div>
+        <div class="palette-item bg-danger-800 text-light">800</div>
+        <div class="palette-item bg-danger-900 text-light">900</div>
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
-        Green:<br />
-        <div class="palette-item bg-green-50">50</div>
-        <div class="palette-item bg-green-100">100</div>
-        <div class="palette-item bg-green-200">200</div>
-        <div class="palette-item bg-green-300">300</div>
-        <div class="palette-item bg-green-400">400</div>
-        <div class="palette-item bg-green-500 text-light">500</div>
-        <div class="palette-item bg-green-600 text-light">600</div>
-        <div class="palette-item bg-green-700 text-light">700</div>
-        <div class="palette-item bg-green-800 text-light">800</div>
-        <div class="palette-item bg-green-900 text-light">900</div>
+        Success:<br />
+        <div class="palette-item bg-success-50">50</div>
+        <div class="palette-item bg-success-100">100</div>
+        <div class="palette-item bg-success-200">200</div>
+        <div class="palette-item bg-success-300">300</div>
+        <div class="palette-item bg-success-400">400</div>
+        <div class="palette-item bg-success-500 text-light">500</div>
+        <div class="palette-item bg-success-600 text-light">600</div>
+        <div class="palette-item bg-success-700 text-light">700</div>
+        <div class="palette-item bg-success-800 text-light">800</div>
+        <div class="palette-item bg-success-900 text-light">900</div>
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
-        Blue:<br />
-        <div class="palette-item bg-blue-50">50</div>
-        <div class="palette-item bg-blue-100">100</div>
-        <div class="palette-item bg-blue-200">200</div>
-        <div class="palette-item bg-blue-300">300</div>
-        <div class="palette-item bg-blue-400">400</div>
-        <div class="palette-item bg-blue-500 text-light">500</div>
-        <div class="palette-item bg-blue-600 text-light">600</div>
-        <div class="palette-item bg-blue-700 text-light">700</div>
-        <div class="palette-item bg-blue-800 text-light">800</div>
-        <div class="palette-item bg-blue-900 text-light">900</div>
+        Primary:<br />
+        <div class="palette-item bg-primary-50">50</div>
+        <div class="palette-item bg-primary-100">100</div>
+        <div class="palette-item bg-primary-200">200</div>
+        <div class="palette-item bg-primary-300">300</div>
+        <div class="palette-item bg-primary-400">400</div>
+        <div class="palette-item bg-primary-500 text-light">500</div>
+        <div class="palette-item bg-primary-600 text-light">600</div>
+        <div class="palette-item bg-primary-700 text-light">700</div>
+        <div class="palette-item bg-primary-800 text-light">800</div>
+        <div class="palette-item bg-primary-900 text-light">900</div>
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
-        Cyan:<br />
-        <div class="palette-item bg-cyan-50">50</div>
-        <div class="palette-item bg-cyan-100">100</div>
-        <div class="palette-item bg-cyan-200">200</div>
-        <div class="palette-item bg-cyan-300">300</div>
-        <div class="palette-item bg-cyan-400">400</div>
-        <div class="palette-item bg-cyan-500 text-light">500</div>
-        <div class="palette-item bg-cyan-600 text-light">600</div>
-        <div class="palette-item bg-cyan-700 text-light">700</div>
-        <div class="palette-item bg-cyan-800 text-light">800</div>
-        <div class="palette-item bg-cyan-900 text-light">900</div>
+        Secondary:<br />
+        <div class="palette-item bg-secondary-50">50</div>
+        <div class="palette-item bg-secondary-100">100</div>
+        <div class="palette-item bg-secondary-200">200</div>
+        <div class="palette-item bg-secondary-300">300</div>
+        <div class="palette-item bg-secondary-400">400</div>
+        <div class="palette-item bg-secondary-500 text-light">500</div>
+        <div class="palette-item bg-secondary-600 text-light">600</div>
+        <div class="palette-item bg-secondary-700 text-light">700</div>
+        <div class="palette-item bg-secondary-800 text-light">800</div>
+        <div class="palette-item bg-secondary-900 text-light">900</div>
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
-        Yellow:<br />
-        <div class="palette-item bg-yellow-50">50</div>
-        <div class="palette-item bg-yellow-100">100</div>
-        <div class="palette-item bg-yellow-200">200</div>
-        <div class="palette-item bg-yellow-300">300</div>
-        <div class="palette-item bg-yellow-400">400</div>
-        <div class="palette-item bg-yellow-500 text-light">500</div>
-        <div class="palette-item bg-yellow-600 text-light">600</div>
-        <div class="palette-item bg-yellow-700 text-light">700</div>
-        <div class="palette-item bg-yellow-800 text-light">800</div>
-        <div class="palette-item bg-yellow-900 text-light">900</div>
+        Warning:<br />
+        <div class="palette-item bg-warning-50">50</div>
+        <div class="palette-item bg-warning-100">100</div>
+        <div class="palette-item bg-warning-200">200</div>
+        <div class="palette-item bg-warning-300">300</div>
+        <div class="palette-item bg-warning-400">400</div>
+        <div class="palette-item bg-warning-500 text-light">500</div>
+        <div class="palette-item bg-warning-600 text-light">600</div>
+        <div class="palette-item bg-warning-700 text-light">700</div>
+        <div class="palette-item bg-warning-800 text-light">800</div>
+        <div class="palette-item bg-warning-900 text-light">900</div>
     </div>
 </div>
 

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -4419,21 +4419,21 @@ $('#slider2').CFW_Slider({
 <h3>Palette Colors:</h3>
 
 <div class="row">
-    <div class="palette col-sm-4">
-        Grayscale:<br />
-        <div class="palette-item bg-gray-50">50</div>
-        <div class="palette-item bg-gray-100">100</div>
-        <div class="palette-item bg-gray-200">200</div>
-        <div class="palette-item bg-gray-300">300</div>
-        <div class="palette-item bg-gray-400">400</div>
-        <div class="palette-item bg-gray-500 text-light">500</div>
-        <div class="palette-item bg-gray-600 text-light">600</div>
-        <div class="palette-item bg-gray-700 text-light">700</div>
-        <div class="palette-item bg-gray-800 text-light">800</div>
-        <div class="palette-item bg-gray-900 text-light">900</div>
+    <div class="palette col-sm-4 col-lg-2">
+        UI Base:<br />
+        <div class="palette-item bg-uibase-50">50</div>
+        <div class="palette-item bg-uibase-100">100</div>
+        <div class="palette-item bg-uibase-200">200</div>
+        <div class="palette-item bg-uibase-300">300</div>
+        <div class="palette-item bg-uibase-400">400</div>
+        <div class="palette-item bg-uibase-500 text-light">500</div>
+        <div class="palette-item bg-uibase-600 text-light">600</div>
+        <div class="palette-item bg-uibase-700 text-light">700</div>
+        <div class="palette-item bg-uibase-800 text-light">800</div>
+        <div class="palette-item bg-uibase-900 text-light">900</div>
     </div>
 
-    <div class="palette col-sm-4">
+    <div class="palette col-sm-4 col-lg-2">
         Red:<br />
         <div class="palette-item bg-red-50">50</div>
         <div class="palette-item bg-red-100">100</div>
@@ -4447,7 +4447,7 @@ $('#slider2').CFW_Slider({
         <div class="palette-item bg-red-900 text-light">900</div>
     </div>
 
-    <div class="palette col-sm-4">
+    <div class="palette col-sm-4 col-lg-2">
         Green:<br />
         <div class="palette-item bg-green-50">50</div>
         <div class="palette-item bg-green-100">100</div>
@@ -4461,7 +4461,7 @@ $('#slider2').CFW_Slider({
         <div class="palette-item bg-green-900 text-light">900</div>
     </div>
 
-    <div class="palette col-sm-4">
+    <div class="palette col-sm-4 col-lg-2">
         Blue:<br />
         <div class="palette-item bg-blue-50">50</div>
         <div class="palette-item bg-blue-100">100</div>
@@ -4475,7 +4475,7 @@ $('#slider2').CFW_Slider({
         <div class="palette-item bg-blue-900 text-light">900</div>
     </div>
 
-    <div class="palette col-sm-4">
+    <div class="palette col-sm-4 col-lg-2">
         Cyan:<br />
         <div class="palette-item bg-cyan-50">50</div>
         <div class="palette-item bg-cyan-100">100</div>
@@ -4489,18 +4489,34 @@ $('#slider2').CFW_Slider({
         <div class="palette-item bg-cyan-900 text-light">900</div>
     </div>
 
-    <div class="palette col-sm-4">
-        Mustard:<br />
-        <div class="palette-item bg-mustard-50">50</div>
-        <div class="palette-item bg-mustard-100">100</div>
-        <div class="palette-item bg-mustard-200">200</div>
-        <div class="palette-item bg-mustard-300">300</div>
-        <div class="palette-item bg-mustard-400">400</div>
-        <div class="palette-item bg-mustard-500 text-light">500</div>
-        <div class="palette-item bg-mustard-600 text-light">600</div>
-        <div class="palette-item bg-mustard-700 text-light">700</div>
-        <div class="palette-item bg-mustard-800 text-light">800</div>
-        <div class="palette-item bg-mustard-900 text-light">900</div>
+    <div class="palette col-sm-4 col-lg-2">
+        Yellow:<br />
+        <div class="palette-item bg-yellow-50">50</div>
+        <div class="palette-item bg-yellow-100">100</div>
+        <div class="palette-item bg-yellow-200">200</div>
+        <div class="palette-item bg-yellow-300">300</div>
+        <div class="palette-item bg-yellow-400">400</div>
+        <div class="palette-item bg-yellow-500 text-light">500</div>
+        <div class="palette-item bg-yellow-600 text-light">600</div>
+        <div class="palette-item bg-yellow-700 text-light">700</div>
+        <div class="palette-item bg-yellow-800 text-light">800</div>
+        <div class="palette-item bg-yellow-900 text-light">900</div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="palette col-sm-4 col-lg-2">
+        Grayscale:<br />
+        <div class="palette-item bg-gray-50">50</div>
+        <div class="palette-item bg-gray-100">100</div>
+        <div class="palette-item bg-gray-200">200</div>
+        <div class="palette-item bg-gray-300">300</div>
+        <div class="palette-item bg-gray-400">400</div>
+        <div class="palette-item bg-gray-500 text-light">500</div>
+        <div class="palette-item bg-gray-600 text-light">600</div>
+        <div class="palette-item bg-gray-700 text-light">700</div>
+        <div class="palette-item bg-gray-800 text-light">800</div>
+        <div class="palette-item bg-gray-900 text-light">900</div>
     </div>
 </div>
 

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -4465,49 +4465,7 @@ $('#slider2').CFW_Slider({
 <h3>Palette Colors:</h3>
 
 <div class="row">
-    <div class="palette col-sm-4 col-lg-2">
-        UI Base:<br />
-        <div class="palette-item bg-uibase-50">50</div>
-        <div class="palette-item bg-uibase-100">100</div>
-        <div class="palette-item bg-uibase-200">200</div>
-        <div class="palette-item bg-uibase-300">300</div>
-        <div class="palette-item bg-uibase-400">400</div>
-        <div class="palette-item bg-uibase-500 text-light">500</div>
-        <div class="palette-item bg-uibase-600 text-light">600</div>
-        <div class="palette-item bg-uibase-700 text-light">700</div>
-        <div class="palette-item bg-uibase-800 text-light">800</div>
-        <div class="palette-item bg-uibase-900 text-light">900</div>
-    </div>
-
-    <div class="palette col-sm-4 col-lg-2">
-        Danger:<br />
-        <div class="palette-item bg-danger-50">50</div>
-        <div class="palette-item bg-danger-100">100</div>
-        <div class="palette-item bg-danger-200">200</div>
-        <div class="palette-item bg-danger-300">300</div>
-        <div class="palette-item bg-danger-400">400</div>
-        <div class="palette-item bg-danger-500 text-light">500</div>
-        <div class="palette-item bg-danger-600 text-light">600</div>
-        <div class="palette-item bg-danger-700 text-light">700</div>
-        <div class="palette-item bg-danger-800 text-light">800</div>
-        <div class="palette-item bg-danger-900 text-light">900</div>
-    </div>
-
-    <div class="palette col-sm-4 col-lg-2">
-        Success:<br />
-        <div class="palette-item bg-success-50">50</div>
-        <div class="palette-item bg-success-100">100</div>
-        <div class="palette-item bg-success-200">200</div>
-        <div class="palette-item bg-success-300">300</div>
-        <div class="palette-item bg-success-400">400</div>
-        <div class="palette-item bg-success-500 text-light">500</div>
-        <div class="palette-item bg-success-600 text-light">600</div>
-        <div class="palette-item bg-success-700 text-light">700</div>
-        <div class="palette-item bg-success-800 text-light">800</div>
-        <div class="palette-item bg-success-900 text-light">900</div>
-    </div>
-
-    <div class="palette col-sm-4 col-lg-2">
+     <div class="palette col-sm-4 col-lg-2">
         Primary:<br />
         <div class="palette-item bg-primary-50">50</div>
         <div class="palette-item bg-primary-100">100</div>
@@ -4536,6 +4494,34 @@ $('#slider2').CFW_Slider({
     </div>
 
     <div class="palette col-sm-4 col-lg-2">
+        Success:<br />
+        <div class="palette-item bg-success-50">50</div>
+        <div class="palette-item bg-success-100">100</div>
+        <div class="palette-item bg-success-200">200</div>
+        <div class="palette-item bg-success-300">300</div>
+        <div class="palette-item bg-success-400">400</div>
+        <div class="palette-item bg-success-500 text-light">500</div>
+        <div class="palette-item bg-success-600 text-light">600</div>
+        <div class="palette-item bg-success-700 text-light">700</div>
+        <div class="palette-item bg-success-800 text-light">800</div>
+        <div class="palette-item bg-success-900 text-light">900</div>
+    </div>
+
+    <div class="palette col-sm-4 col-lg-2">
+        Info:<br />
+        <div class="palette-item bg-info-50">50</div>
+        <div class="palette-item bg-info-100">100</div>
+        <div class="palette-item bg-info-200">200</div>
+        <div class="palette-item bg-info-300">300</div>
+        <div class="palette-item bg-info-400">400</div>
+        <div class="palette-item bg-info-500 text-light">500</div>
+        <div class="palette-item bg-info-600 text-light">600</div>
+        <div class="palette-item bg-info-700 text-light">700</div>
+        <div class="palette-item bg-info-800 text-light">800</div>
+        <div class="palette-item bg-info-900 text-light">900</div>
+    </div>
+
+    <div class="palette col-sm-4 col-lg-2">
         Warning:<br />
         <div class="palette-item bg-warning-50">50</div>
         <div class="palette-item bg-warning-100">100</div>
@@ -4548,9 +4534,37 @@ $('#slider2').CFW_Slider({
         <div class="palette-item bg-warning-800 text-light">800</div>
         <div class="palette-item bg-warning-900 text-light">900</div>
     </div>
+
+    <div class="palette col-sm-4 col-lg-2">
+        Danger:<br />
+        <div class="palette-item bg-danger-50">50</div>
+        <div class="palette-item bg-danger-100">100</div>
+        <div class="palette-item bg-danger-200">200</div>
+        <div class="palette-item bg-danger-300">300</div>
+        <div class="palette-item bg-danger-400">400</div>
+        <div class="palette-item bg-danger-500 text-light">500</div>
+        <div class="palette-item bg-danger-600 text-light">600</div>
+        <div class="palette-item bg-danger-700 text-light">700</div>
+        <div class="palette-item bg-danger-800 text-light">800</div>
+        <div class="palette-item bg-danger-900 text-light">900</div>
+    </div>
 </div>
 
 <div class="row">
+    <div class="palette col-sm-4 col-lg-2">
+        UI Base:<br />
+        <div class="palette-item bg-uibase-50">50</div>
+        <div class="palette-item bg-uibase-100">100</div>
+        <div class="palette-item bg-uibase-200">200</div>
+        <div class="palette-item bg-uibase-300">300</div>
+        <div class="palette-item bg-uibase-400">400</div>
+        <div class="palette-item bg-uibase-500 text-light">500</div>
+        <div class="palette-item bg-uibase-600 text-light">600</div>
+        <div class="palette-item bg-uibase-700 text-light">700</div>
+        <div class="palette-item bg-uibase-800 text-light">800</div>
+        <div class="palette-item bg-uibase-900 text-light">900</div>
+    </div>
+
     <div class="palette col-sm-4 col-lg-2">
         Grayscale:<br />
         <div class="palette-item bg-gray-50">50</div>

--- a/test/visual/forms.html
+++ b/test/visual/forms.html
@@ -291,7 +291,7 @@ Holder.addTheme("gray", {
         <div class="p-0_5 bg-red-400"><input type="text" class="form-control" placeholder="something"></div>
         <div class="p-0_5 bg-green-400"><input type="text" class="form-control" placeholder="something"></div>
         <div class="p-0_5 bg-cyan-400"><input type="text" class="form-control" placeholder="something"></div>
-        <div class="p-0_5 bg-mustard-400"><input type="text" class="form-control" placeholder="something"></div>
+        <div class="p-0_5 bg-yellow-400"><input type="text" class="form-control" placeholder="something"></div>
     </div>
     <div class="col">
         <div class="p-0_5"><select type="text" class="custom-select"><option>Select</option></select></div>
@@ -301,7 +301,7 @@ Holder.addTheme("gray", {
         <div class="p-0_5 bg-red-400"><select type="text" class="custom-select"><option>Select</option></select></div>
         <div class="p-0_5 bg-green-400"><select type="text" class="custom-select"><option>Select</option></select></div>
         <div class="p-0_5 bg-cyan-400"><select type="text" class="custom-select"><option>Select</option></select></div>
-        <div class="p-0_5 bg-mustard-400"><select type="text" class="custom-select"><option>Select</option></select></div>
+        <div class="p-0_5 bg-yellow-400"><select type="text" class="custom-select"><option>Select</option></select></div>
     </div>
 </div>
 <div class="row mb-1">
@@ -313,7 +313,7 @@ Holder.addTheme("gray", {
         <div class="p-0_5 bg-red-400"><label class="custom-file"><input type="file" id="file" class="custom-file-input"><span class="custom-file-control"></span></label></div>
         <div class="p-0_5 bg-green-400"><label class="custom-file"><input type="file" id="file" class="custom-file-input"><span class="custom-file-control"></span></label></div>
         <div class="p-0_5 bg-cyan-400"><label class="custom-file"><input type="file" id="file" class="custom-file-input"><span class="custom-file-control"></span></label></div>
-        <div class="p-0_5 bg-mustard-400"><label class="custom-file"><input type="file" id="file" class="custom-file-input"><span class="custom-file-control"></span></label></div>
+        <div class="p-0_5 bg-yellow-400"><label class="custom-file"><input type="file" id="file" class="custom-file-input"><span class="custom-file-control"></span></label></div>
     </div>
     <div class="col">
         <div class="p-0_5"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
@@ -323,7 +323,7 @@ Holder.addTheme("gray", {
         <div class="p-0_5 bg-red-400"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
         <div class="p-0_5 bg-green-400"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
         <div class="p-0_5 bg-cyan-400"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
-        <div class="p-0_5 bg-mustard-400"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
+        <div class="p-0_5 bg-yellow-400"><div class="input-group"><span class="input-group-addon" id="color-addon0">@</span><input type="text" class="form-control" placeholder="Username" aria-label="Username" aria-describedby="color-addon0"><span class="input-group-btn"><button class="btn" type="button">Button</button></span></div></div>
     </div>
 </div>
 


### PR DESCRIPTION
Completely reworking our colors and how they are processed.

- Lighten up the base colors and use the color-contrast functions to determine best fit text colors automatically.
- Update palette use to be more consistent across all the components, and try use the default specified levels  more, getting rid of the one-offs.
-Stop specifying text color for background color utils.
- Rework the `*-variant` mixins for greater re-use, and drop redundant mixins, creating one color mixin per component where possible.
  -  For example. previously buttons had two mixins, one for the standard buttons, one for outline variant.  Now we can just re-use the same mixin, at the cost of passing more arguments.

Other possibilities, still thinking these over:
- Add more colors to the palette system
- Add contextual colors to more components
