### PR TITLE
V4 focus hover states

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -266,7 +266,7 @@ $mark-padding-x:    .25rem !default;
 $mark-bg:           #ff0 !default;
 
 $hr-spacer-y:       1rem !default;
-$hr-border-color:   rgba(0, 0, 0, .1) !default;
+$hr-border-color:   rgba($black, .1) !default;
 $hr-border-width:   $border-width !default;
 
 $blockquote-font-size:          ($font-size-base * 1.1875) !default;
@@ -404,7 +404,7 @@ $thumbnail-bg:                  $body-bg !default;
 $thumbnail-border-width:        $border-width !default;
 $thumbnail-border-color:        $uibase-300 !default;
 $thumbnail-border-radius:       $border-radius !default;
-$thumbnail-box-shadow:          0 .0625rem .125rem rgba(0, 0, 0, .075) !default;
+$thumbnail-box-shadow:          0 .0625rem .125rem rgba($black, .075) !default;
 
 
 // Responsive embed
@@ -422,7 +422,7 @@ $code-bg:                   $uibase-50 !default;
 
 $kbd-color:                 $uibase-50 !default;
 $kbd-bg:                    $uibase-900 !default;
-$kbd-box-shadow:            inset 0 -.1rem 0 rgba(0, 0, 0, .25) !default;
+$kbd-box-shadow:            inset 0 -.1rem 0 rgba($black, .25) !default;
 $kbd-nested-font-weight:    $font-weight-bold !default;
 $kbd-border-radius:         .2rem !default;
 
@@ -469,9 +469,8 @@ $btn-padding-x:             .75rem !default;
 $btn-font-weight:           $font-weight-normal !default;
 $btn-line-height:           1.25 !default;
 $btn-border-radius:         $border-radius !default;
-$btn-box-shadow:            inset 0 .125rem .25rem rgba(255, 255, 255, .25) !default;
-$btn-focus-box-shadow:      0 0 2px 3px rgba(palette-context("info", 300), .75) !default; // px because simulating outline
-$btn-active-box-shadow:     inset 0 .125rem .25rem rgba(0, 0, 0, .25) !default;
+$btn-box-shadow:            inset 0 .125em .25em rgba($white, .25), 0 1px 1px rgba($black, .075) !default;
+$btn-active-box-shadow:     inset 0 .125em .25em rgba($black, .25), $btn-box-shadow !default;
 
 $btn-outline-bg:            transparent !default;
 
@@ -486,6 +485,7 @@ $btn-default-hover-bg:              $uibase-100 !default;
 $btn-default-hover-color:           color-if-contrast($uibase-600, $btn-default-hover-bg) !default;
 $btn-default-hover-border-color:    $uibase-400 !default;
 $btn-default-active-hover-bg:       $uibase-200 !default;
+$btn-default-active-hover-color:    color-if-contrast($btn-default-hover-color, $btn-default-active-hover-bg) !default;
 
 
 // Forms
@@ -501,16 +501,15 @@ $input-padding-x:               $btn-padding-x !default;
 
 $input-color:                   $uibase-700 !default;
 $input-bg:                      $white !default;
-$input-border-color:            rgba(0, 0, 0, .25) !default;
+$input-border-color:            rgba($black, .25) !default;
 $input-border-width:            $border-width !default;
 $input-border-radius:           $border-radius !default;
-$input-box-shadow:              inset 0 .125rem .125rem rgba(0, 0, 0, .1) !default;
+$input-box-shadow:              inset 0 .125em .125em rgba($black, .1) !default;
 
 $input-focus-color:             $input-color !default;
 $input-focus-bg:                $input-bg !default;
-$input-focus-border-color:      palette-context("info", 300) !default;
-$input-focus-box-shadow-outer:  $btn-focus-box-shadow !default;
-$input-focus-box-shadow-inner:  inset 0 .125rem .125rem rgba(0, 0, 0, .15) !default;
+$input-focus-border-color:      palette-context("primary", 300) !default;
+$input-focus-box-shadow:        inset 0 .125em .125em rgba($black, .15) !default;
 
 $input-disabled-color:          $component-disabled-color !default;
 $input-disabled-bg:             $uibase-50 !default;
@@ -560,7 +559,7 @@ $custom-control-spacer-y:               .5rem !default;
 $custom-control-indicator-size:         1rem !default;
 $custom-control-indicator-bg:           $uibase-50 !default;
 $custom-control-indicator-bg-size:      50% 50% !default;
-$custom-control-indicator-box-shadow:   inset 0 .25rem .25rem rgba(0, 0, 0, .1) !default;
+$custom-control-indicator-box-shadow:   inset 0 .25rem .25rem rgba($black, .1) !default;
 $custom-control-indicator-border-width: $border-width !default;
 $custom-control-indicator-border-color: $input-border-color !default;
 
@@ -619,8 +618,7 @@ $switch-active-control-bg:              $uibase-50 !default;
 $switch-active-indicator-bg:            $uibase-400 !default;
 
 $switch-focus-control-border-color:     $input-focus-border-color !default;
-$switch-focus-control-box-shadow-outer: $input-focus-box-shadow-outer !default;
-$switch-focus-control-box-shadow-inner: $input-focus-box-shadow-inner !default;
+$switch-focus-control-box-shadow:       $input-focus-box-shadow !default;
 
 $switch-disabled-description-color:     $uibase-400 !default;
 $switch-disabled-cursor:                $cursor-disabled !default;
@@ -636,11 +634,11 @@ $progress-height:               1rem !default;
 $progress-font-size:            ($font-size-base * .75) !default;
 $progress-bg:                   $uibase-50 !default;
 $progress-border-radius:        $border-radius !default;
-$progress-box-shadow:           inset 0 .125rem .125rem rgba(0, 0, 0, .1) !default;
+$progress-box-shadow:           inset 0 .125rem .125rem rgba($black, .1) !default;
 $progress-bar-color:            $white !default;
 $progress-bar-bg:               $uibase-300 !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
-$progress-bar-box-shadow:       inset 0 -.125rem 0 rgba(0, 0, 0, .1) !default;
+$progress-bar-box-shadow:       inset 0 -.125rem 0 rgba($black, .1) !default;
 
 
 // List group
@@ -719,7 +717,7 @@ $dropdown-border-radius:        $border-radius !default;
 $dropdown-divider-width:        $border-width !default;
 $dropdown-divider-color:        $component-section-border-color !default;
 $dropdown-divider-spacer:       ($spacer / 2) !default;
-$dropdown-box-shadow:           0 .2rem .3rem rgba(0, 0, 0, .175) !default;
+$dropdown-box-shadow:           0 .2rem .3rem rgba($black, .175) !default;
 
 // Border radius where menu/submenu aligns or 'attaches' to control item.
 $dropdown-attach-border-radius: 0 !default;
@@ -791,7 +789,7 @@ $navbar-brand-font-size:            ($font-size-base * 1.25) !default;
 $navbar-brand-font-weight:          $font-weight-bold !default;
 
 $navbar-divider-width:              $border-width !default;
-$navbar-divider-color:              rgba(0, 0, 0, .65) !default;
+$navbar-divider-color:              rgba($black, .65) !default;
 $navbar-divider-margin-x:           $navbar-item-padding-x !default;
 $navbar-divider-margin-y:           $navbar-item-padding-y !default;
 
@@ -800,19 +798,19 @@ $navbar-toggle-padding-y:           $btn-padding-y !default;
 $navbar-toggle-padding-x:           $btn-padding-x !default;
 $navbar-toggle-border-radius:       $btn-border-radius !default;
 
-$navbar-dark-color:                 rgba(255, 255, 255, .65) !default;
-$navbar-dark-hover-color:           rgba(255, 255, 255, .9) !default;
-$navbar-dark-active-color:          rgba(255, 255, 255, .95) !default;
-$navbar-dark-disabled-color:        rgba(255, 255, 255, .5) !default;
-$navbar-dark-divider-color:         rgba(255, 255, 255, .7) !default;
-$navbar-dark-toggle-border:         rgba(255, 255, 255, .35) !default;
+$navbar-dark-color:                 rgba($white, .65) !default;
+$navbar-dark-hover-color:           rgba($white, .9) !default;
+$navbar-dark-active-color:          rgba($white, .95) !default;
+$navbar-dark-disabled-color:        rgba($white, .5) !default;
+$navbar-dark-divider-color:         rgba($white, .7) !default;
+$navbar-dark-toggle-border:         rgba($white, .35) !default;
 
-$navbar-light-color:                rgba(0, 0, 0, .6) !default;
-$navbar-light-hover-color:          rgba(0, 0, 0, .85) !default;
-$navbar-light-active-color:         rgba(0, 0, 0, .95) !default;
-$navbar-light-disabled-color:       rgba(0, 0, 0, .5) !default;
-$navbar-light-divider-color:        rgba(0, 0, 0, .65) !default;
-$navbar-light-toggle-border:        rgba(0, 0, 0, .35) !default;
+$navbar-light-color:                rgba($black, .6) !default;
+$navbar-light-hover-color:          rgba($black, .85) !default;
+$navbar-light-active-color:         rgba($black, .95) !default;
+$navbar-light-disabled-color:       rgba($black, .5) !default;
+$navbar-light-divider-color:        rgba($black, .65) !default;
+$navbar-light-toggle-border:        rgba($black, .35) !default;
 
 
 // Jumbotron
@@ -930,7 +928,7 @@ $popover-border-width:          $border-width !default;
 $popover-border-color:          $component-overlay-border-color !default;
 $popover-border-radius:         .3125rem !default;
 $popover-inner-border-radius:   calc(#{$popover-border-radius} - #{$popover-border-width}) !default;
-$popover-box-shadow:            0 .2rem .3rem rgba(0, 0, 0, .175) !default;
+$popover-box-shadow:            0 .2rem .3rem rgba($black, .175) !default;
 
 $popover-header-padding-y:      .75rem !default;
 $popover-header-padding-x:      1rem !default;
@@ -970,15 +968,15 @@ $modal-inner-padding-x:         1rem !default;
 $modal-content-bg:               $component-bg !default;
 $modal-content-border-color:     $component-overlay-border-color !default;
 $modal-content-border-width:     $border-width !default;
-$modal-content-xs-box-shadow:    0 .2rem .6rem rgba(0, 0, 0, .5) !default;
-$modal-content-sm-up-box-shadow: 0 .3rem 1rem rgba(0, 0, 0, .5) !default;
+$modal-content-xs-box-shadow:    0 .2rem .6rem rgba($black, .5) !default;
+$modal-content-sm-up-box-shadow: 0 .3rem 1rem rgba($black, .5) !default;
 
 $modal-footer-padding-y:        .75rem !default;
 $modal-footer-padding-x:        1rem !default;
 
 $modal-backdrop-bg:             $dark !default;
 $modal-backdrop-opacity:        .5 !default;
-$modal-header-border-color:     rgba(0, 0, 0, .1) !default;
+$modal-header-border-color:     rgba($black, .1) !default;
 $modal-footer-border-color:     $modal-header-border-color !default;
 $modal-header-border-width:     $modal-content-border-width !default;
 $modal-footer-border-width:     $modal-header-border-width !default;
@@ -1020,8 +1018,8 @@ $slider-track-border-radius:        $border-radius !default;
 
 $slider-selection-bg:               $uibase-300 !default;
 
-$slider-thumb-shadow:               inset .125rem .125rem .125rem rgba(255, 255, 255, .4), inset -.125rem -.125rem .125rem rgba(0, 0, 0, .15) !default;
-$slider-track-shadow:               inset 0 .0625rem .125rem rgba(0, 0, 0, .1) !default;
+$slider-thumb-shadow:               inset .125rem .125rem .125rem rgba($white, .4), inset -.125rem -.125rem .125rem rgba($black, .15) !default;
+$slider-track-shadow:               inset 0 .0625rem .125rem rgba($black, .1) !default;
 
 $slider-disabled-track-opacity:     .75 !default;
 $slider-disabled-thumb-opacity:     .9 !default;

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -36,8 +36,9 @@
     color: $pagination-color;
     text-decoration: none;
 
-    &:hover {
-        z-index: 1;
+    &:hover,
+    &:focus {
+        z-index: 2;
         color: $pagination-hover-color;
         text-decoration: none;
         background-color: $pagination-hover-bg;
@@ -48,10 +49,6 @@
         z-index: 1;
         color: $pagination-active-color;
         background-color: $pagination-active-bg;
-    }
-
-    &:focus {
-        z-index: 2;
     }
 
     &.disabled {

--- a/scss/component/_switch.scss
+++ b/scss/component/_switch.scss
@@ -18,7 +18,7 @@
     background-clip: padding-box;
     border: $input-border-width solid $input-border-color;
     @include border-radius($input-border-radius);
-    @include box-shadow($input-box-shadow, 0 0 transparent);
+    @include box-shadow($input-box-shadow);
     @include transition($input-transition, $switch-control-transition);
 
     &::before {
@@ -55,17 +55,13 @@
             // calc() use in transform
             //transform: translateX(calc(-100% + #{$input-border-width}));
             transform: translateX(-100%) translateX(#{$input-border-width});
-            @include box-shadow($switch-active-indicator-box-shadow, 0 0 transparent);
+            @include box-shadow($switch-active-indicator-box-shadow);
         }
     }
 
     &:focus ~ .switch-control {
         border-color: $switch-focus-control-border-color;
-        @if ($enable-shadows) {
-            box-shadow: $switch-focus-control-box-shadow-inner, $switch-focus-control-box-shadow-outer;
-        } @else {
-            box-shadow: $switch-focus-control-box-shadow-outer;
-        }
+        @include box-shadow($switch-focus-control-box-shadow);
     }
 
     &:disabled {

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -12,21 +12,14 @@
     user-select: none;
     border: $input-border-width solid transparent;
     @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
-    @include box-shadow($btn-box-shadow, 0 0 transparent);
+    @include box-shadow($btn-box-shadow);
     @include transition($btn-transition);
 
-    @include hover-focus {
-        text-decoration: none;
-    }
-
+    &:hover,
     &:focus,
     &.focus {
-        outline: 0;
-        @if $enable-shadows {
-            box-shadow: $btn-box-shadow, $btn-focus-box-shadow;
-        } @else {
-            box-shadow: $btn-focus-box-shadow;
-        }
+        text-decoration: none;
+        @include box-shadow($btn-box-shadow);
     }
 
     // Disabled comes first so active can restyle
@@ -44,18 +37,15 @@
         background-image: none;
         @include box-shadow($btn-active-box-shadow);
 
+        &:hover,
         &:focus,
         &.focus {
-            @if $enable-shadows {
-                box-shadow: $btn-active-box-shadow, $btn-focus-box-shadow;
-            } @else {
-                box-shadow: $btn-focus-box-shadow;
-            }
+            @include box-shadow($btn-active-box-shadow);
         }
     }
 
     // Default color
-    @include button-variant($btn-default-color, $btn-default-bg, $btn-default-border-color, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border-color, $btn-default-active-hover-bg);
+    @include button-variant($btn-default-color, $btn-default-bg, $btn-default-border-color, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border-color, $btn-default-active-hover-color, $btn-default-active-hover-bg);
 }
 
 // Future-proof disabling of clicks on `<a>` elements
@@ -66,34 +56,18 @@ fieldset:disabled a.btn {
 
 // Contextual color variants
 @each $theme, $colors in $context-themes {
-    $bg:                map-get($colors, "control-bg");
-    $color:             map-get($colors, "control-color");
-    $border:            map-get($colors, "control-border-color");
-    $hover-bg:          map-get($colors, "control-hover-bg");
-    $hover-color:       map-get($colors, "control-hover-color");
-    $hover-border:      map-get($colors, "control-hover-border-color");
-    $active-hover-bg:   map-get($colors, "control-active-hover-bg");
-
     .btn-#{$theme} {
-        @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
+        @include button-variant-control($theme, $colors);
     }
 }
 
 // Outline variant - remove all backgrounds
 .btn-outline {
-    @include button-variant($btn-default-color, $btn-outline-bg, $btn-default-border-color, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border-color, $btn-default-active-hover-bg);
+    @include button-variant($btn-default-color, $btn-outline-bg, $btn-default-border-color, $btn-default-hover-color, $btn-default-hover-bg, $btn-default-hover-border-color, $btn-default-active-hover-color, $btn-default-active-hover-bg);
 }
 @each $theme, $colors in $context-themes {
-    $bg:                $btn-outline-bg;
-    $color:             map-get($context-colors, $theme);
-    $border:            map-get($colors, "control-bg");
-    $hover-bg:          map-get($colors, "control-bg");
-    $hover-color:       map-get($colors, "control-hover-color");
-    $hover-border:      map-get($colors, "control-border-color");
-    $active-hover-bg:   map-get($colors, "control-hover-bg");
-
     .btn-outline-#{$theme} {
-        @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg);
+        @include button-variant-control-outline($theme, $colors, $btn-outline-bg);
     }
 }
 
@@ -101,17 +75,17 @@ fieldset:disabled a.btn {
 // Make a button look and behave like a link
 .btn-link {
     text-decoration: $link-decoration;
-    @include button-variant($link-color, transparent, transparent, $link-hover-color, transparent, transparent, transparent);
+    @include button-variant($link-color, transparent, transparent, $link-hover-color, transparent, transparent, $link-hover-color, transparent);
     @include box-shadow(none);
 
     @include hover-focus {
         color: $link-hover-color;
         text-decoration: $link-hover-decoration;
+        @include box-shadow(none);
     }
 
     &.disabled,
     &:disabled {
-        color: $link-color;
         text-decoration: none;
     }
 

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -26,12 +26,7 @@
     }
 
     &:focus ~ .custom-control-indicator {
-        // the mixin is not used here to make sure there is feedback
-        @if ($enable-shadows) {
-            box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-        } @else {
-            box-shadow: $input-focus-box-shadow-outer;
-        }
+        @include box-shadow($input-focus-box-shadow);
     }
 
     &:active ~ .custom-control-indicator {
@@ -139,7 +134,7 @@
     } @else {
         border-radius: 0;
     }
-    @include box-shadow($input-box-shadow, 0 0 transparent);
+    @include box-shadow($input-box-shadow);
     @include transition($input-transition);
     appearance: none;
 
@@ -149,11 +144,7 @@
         border-color: $input-focus-border-color;
         outline: 0;
 
-        @if ($enable-shadows) {
-            box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-        } @else {
-            box-shadow: $input-focus-box-shadow-outer;
-        }
+        @include box-shadow($input-focus-box-shadow);
 
         &::-ms-value {
             // For visual consistency with other platforms/browsers,
@@ -224,11 +215,11 @@
 
     &:focus ~ .custom-file-control {
         border-color: $input-focus-border-color;
-        @if ($enable-shadows) {
-            box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-        } @else {
-            box-shadow: $input-focus-box-shadow-outer;
-        }
+        @include box-shadow($input-focus-box-shadow);
+    }
+
+    &:focus ~ .custom-file-control::before {
+        @include box-shadow($btn-box-shadow);
     }
 }
 
@@ -249,7 +240,7 @@
     background-clip: padding-box;
     border: $input-border-width solid $input-border-color;
     @include border-radius($input-border-radius);
-    @include box-shadow($input-box-shadow, 0 0 transparent);
+    @include box-shadow($input-box-shadow);
     @include transition($input-transition);
 
     &:empty::after {
@@ -275,6 +266,7 @@
         content: map-get(map-get($custom-file-text, button-label), en);
         background-color: $custom-file-button-bg;
         border-left: $input-border-width solid $input-border-color;
+        @include box-shadow($btn-box-shadow);
     }
 
     @each $lang, $text in map-get($custom-file-text, button-label) {
@@ -300,7 +292,7 @@
     border: $input-border-width solid $input-border-color;
 
     @include border-radius($input-border-radius);
-    @include box-shadow($input-box-shadow, 0 0 transparent);
+    @include box-shadow($input-box-shadow);
     @include transition($input-transition);
 
     @include form-control-focus();

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -15,7 +15,7 @@
     border: $input-border-width solid $input-border-color;
     // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
     @include border-radius($input-border-radius);
-    @include box-shadow($input-box-shadow, 0 0 transparent);
+    @include box-shadow($input-box-shadow);
     @include transition($input-transition);
 
     // Unstyle the caret on `<select>`s in IE10+.
@@ -36,11 +36,7 @@
 
     &:focus,
     &.focus {
-        @if ($enable-shadows) {
-            box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-        } @else {
-            box-shadow: $input-focus-box-shadow-outer;
-        }
+        @include box-shadow($input-focus-box-shadow);
     }
 
     // Disabled and read-only inputs

--- a/scss/functions/_color-util.scss
+++ b/scss/functions/_color-util.scss
@@ -48,6 +48,7 @@
         $control-hover-color:        color-if-contrast($control-color, $control-hover-bg);
         $control-hover-border-color: palette($color, $level-control-hover-border-color);
         $control-active-hover-bg:    palette($color, $level-control-active-hover-bg);
+        $control-active-hover-color: color-if-contrast($control-hover-color, $control-active-hover-bg);
         $context-bg:                 palette($color, $level-context-bg);
         $context-color:              palette($color, $level-context-color);
         $context-border-color:       palette($color, $level-context-border-color);
@@ -63,6 +64,7 @@
             "control-hover-color": $control-hover-color,
             "control-hover-border-color": $control-hover-border-color,
             "control-active-hover-bg": $control-active-hover-bg,
+            "control-active-hover-color": $control-active-hover-color,
             "context-bg": $context-bg,
             "context-color": $context-color,
             "context-border-color": $context-border-color,

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -3,12 +3,12 @@
 // Easily pump out default styles, as well as :hover, :focus, :active,
 // and disabled options for all buttons
 
-@mixin button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-bg) {
+@mixin button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-color, $active-hover-bg) {
     color: $color;
     background-color: $bg;
     border-color: $border;
 
-    &:hover {
+    @include hover-focus() {
         color: $hover-color;
         background-color: $hover-bg;
         border-color: $hover-border;
@@ -28,12 +28,36 @@
         background-color: $hover-bg;
         border-color: $hover-border;
 
-        &:hover {
-            color: $hover-color;
+        @include hover-focus() {
+            color: $active-hover-color;
             background-color: $active-hover-bg;
-            border-color: $hover-border;
         }
     }
+}
+
+@mixin button-variant-control($theme, $colors) {
+    $bg:                 map-get($colors, "control-bg");
+    $color:              map-get($colors, "control-color");
+    $border:             map-get($colors, "control-border-color");
+    $hover-bg:           map-get($colors, "control-hover-bg");
+    $hover-color:        map-get($colors, "control-hover-color");
+    $hover-border:       map-get($colors, "control-hover-border-color");
+    $active-hover-bg:    map-get($colors, "control-active-hover-bg");
+    $active-hover-color: map-get($colors, "control-active-hover-color");
+
+    @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-color, $active-hover-bg);
+}
+
+@mixin button-variant-control-outline($theme, $colors, $bg: $btn-outline-bg) {
+    $color:              map-get($context-colors, $theme);
+    $border:             map-get($colors, "control-bg");
+    $hover-bg:           map-get($colors, "control-bg");
+    $hover-color:        map-get($colors, "control-hover-color");
+    $hover-border:       map-get($colors, "control-border-color");
+    $active-hover-bg:    map-get($colors, "control-hover-bg");
+    $active-hover-color: map-get($colors, "control-hover-color");
+
+    @include button-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border, $active-hover-color, $active-hover-bg);
 }
 
 // Button sizes

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -24,11 +24,7 @@
 
         &:focus {
             border-color: $border-hover;
-            @if ($enable-shadows) {
-                box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-            } @else {
-                box-shadow: $input-focus-box-shadow-outer;
-            }
+            @include box-shadow($input-focus-box-shadow);
         }
     }
 
@@ -58,10 +54,6 @@
         background-color: $input-focus-bg;
         border-color: $input-focus-border-color;
         outline: 0;
-        @if ($enable-shadows) {
-            box-shadow: $input-focus-box-shadow-inner, $input-focus-box-shadow-outer;
-        } @else {
-            box-shadow: $input-focus-box-shadow-outer;
-        }
+        @include box-shadow($input-focus-box-shadow);
     }
 }


### PR DESCRIPTION
It seems, at least personally, that I am almost always turning off the focus `box=shadow` on inputs and buttons, and adding a focus/hover color.

Visually it is great when put on a light color background, such as the default body background color, but when used on a dark background, they just dont seem to work well.

So we are going back to having a consolidated hover/focus coloring.