### PR TITLE
CSS-only checkbox/radio buttons

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -468,6 +468,7 @@ $btn-padding-y:             .375rem !default;
 $btn-padding-x:             .75rem !default;
 $btn-font-weight:           $font-weight-normal !default;
 $btn-line-height:           1.25 !default;
+$btn-border-width:          $border-width !default;
 $btn-border-radius:         $border-radius !default;
 $btn-box-shadow:            inset 0 .125em .25em rgba($white, .25), 0 1px 1px rgba($black, .075) !default;
 $btn-active-box-shadow:     inset 0 .125em .25em rgba($black, .25), $btn-box-shadow !default;

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -12,10 +12,10 @@
 
         // Bring the "active" button to the front
         &:active,
-        &.active,
-        &:hover {
+        &.active {
             z-index: 1;
         }
+        &:hover,
         &:focus,
         &.focus {
             z-index: 2;
@@ -36,26 +36,22 @@
 
 .btn-group {
     // Prevent double borders when buttons are next to each other
-    .btn + .btn,
-    .btn + .btn-group,
-    .btn-group + .btn,
-    .btn-group + .btn-group {
-        margin-left: -$border-width;
+    > .btn:not(:first-child),
+    > .btn-group:not(:first-child),
+    > .btn-check:not(:first-child) {
+        margin-left: -$btn-border-width;
     }
 
-    > .btn:first-child {
-        margin-left: 0;
-    }
-
-    // Reset rounded corners individual because sometimes a single button can be
-    // in a .btn-group and we need :first-child and :last-child to both match.
+    // Reset rounded corners
     > .btn:not(:last-child):not(.dropdown-toggle),
-    > .btn-group:not(:last-child) > .btn {
+    > .btn-group:not(:last-child) > .btn,
+    > .btn-check:not(:last-child) > .btn {
         @include border-end-radius(0);
     }
 
     > .btn:not(:first-child),
-    > .btn-group:not(:first-child) > .btn {
+    > .btn-group:not(:first-child) > .btn,
+    > .btn-check:not(:first-child) > .btn {
         @include border-start-radius(0);
     }
 }
@@ -92,72 +88,29 @@
 
     > .btn,
     > .btn-group,
-    > .btn-group > .btn {
+    > .btn-group > .btn,
+    > .btn-check,
+    > .btn-check > .btn {
         width: 100%;
         max-width: 100%;
     }
 
-    > .btn + .btn,
-    > .btn + .btn-group,
-    > .btn-group + .btn,
-    > .btn-group + .btn-group {
-        margin-top: -$border-width;
+    > .btn:not(:first-child),
+    > .btn-group:not(:first-child),
+    > .btn-check:not(:first-child) {
+        margin-top: -$btn-border-width;
     }
 
-    > .btn:first-child {
-        margin-top: 0;
+    // Reset rounded corners
+    > .btn:not(:last-child):not(.dropdown-toggle),
+    > .btn-group:not(:last-child) > .btn,
+    > .btn-check:not(:last-child) > .btn {
+        @include border-bottom-radius(0);
     }
 
-    > .btn {
-        &:not(:first-child):not(:last-child) {
-            border-radius: 0;
-        }
-        &:first-child:not(:last-child) {
-            @include border-bottom-radius(0);
-        }
-        &:last-child:not(:first-child) {
-            @include border-top-radius(0);
-        }
-    }
-
-    > .btn-group:not(:first-child):not(:last-child) > .btn {
-        border-radius: 0;
-    }
-
-    > .btn-group:first-child:not(:last-child) {
-        > .btn:last-child,
-        > .dropdown-toggle {
-            @include border-bottom-radius(0);
-        }
-    }
-
-    > .btn-group:last-child:not(:first-child) > .btn:first-child {
+    > .btn:not(:first-child),
+    > .btn-group:not(:first-child) > .btn,
+    > .btn-check:not(:first-child) > .btn {
         @include border-top-radius(0);
-    }
-}
-
-
-// Checkbox and radio options
-// In order to support the browser's form validation feedback, powered by the
-// `required` attribute, we have to "hide" the inputs via `clip`. We cannot use
-// `display: none;` or `visibility: hidden;` as that also hides the popover.
-// Simply visually hiding the inputs via `opacity` would leave them clickable in
-// certain cases which is prevented by using `clip` and `pointer-events`.
-// This way, we ensure a DOM element is visible to position the popover from.
-//
-// See https://github.com/twbs/bootstrap/pull/12794 and
-// https://github.com/twbs/bootstrap/pull/14559 for more information.
-
-[data-cfw="buttons"] {
-    > .btn,
-    > .btn-group > .btn {
-        // stylelint-disable selector-no-qualifying-type
-        input[type="radio"],
-        input[type="checkbox"] {
-            position: absolute;
-            clip: rect(0, 0, 0, 0);
-            pointer-events: none;
-        }
-        // stylelint-enable selector-no-qualifying-type
     }
 }

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -5,7 +5,8 @@
     display: inline-flex;
     vertical-align: middle; // match .btn alignment given font-size hack above
 
-    > .btn {
+    > .btn,
+    > .btn-check > .btn {
         position: relative;
         flex: 0 1 auto;
         margin-bottom: 0; // Override default `<label>` value
@@ -20,6 +21,10 @@
         &.focus {
             z-index: 2;
         }
+    }
+
+    > .btn-check > .btn-check-input:focus ~ .btn {
+        z-index: 2;
     }
 }
 

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -139,34 +139,29 @@ input[type="button"] {
     }
 }
 
-// Checkbox and radio options
-// In order to support the browser's form validation feedback, powered by the
-// `required` attribute, we have to "hide" the inputs via `clip`. We cannot use
-// `display: none;` or `visibility: hidden;` as that also hides the popover.
-// Simply visually hiding the inputs via `opacity` would leave them clickable in
-// certain cases which is prevented by using `clip` and `pointer-events`.
-// This way, we ensure a DOM element is visible to position the popover from.
+// Checkbox and radio button
 .btn-check {
     position: relative;
     display: inline-block;
-    vertical-align: middle; // match .btn alignment given font-size hack above
+    vertical-align: middle;
+}
 
-    & > input[type="radio"],
-    & > input[type="checkbox"] {
-        position: absolute;
-        clip: rect(0, 0, 0, 0);
-        pointer-events: none;
-    }
+// Place input behind the label
+.btn-check-input {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+    pointer-events: none;
 
-    > label {
+    // Override label margin
+    ~ .btn {
         margin-bottom: 0;
     }
-}
 
-// Force outline on for inputs
-// stylelint-disable declaration-block-no-duplicate-properties
-.btn-check-input:focus ~ .btn {
-    outline: 1px dotted;
-    outline: 5px auto -webkit-focus-ring-color;
+    // Force outline on for inputs
+    // stylelint-disable declaration-block-no-duplicate-properties
+    &:focus ~ .btn {
+        outline: 1px dotted;
+        outline: 5px auto -webkit-focus-ring-color;
+    }
+    // stylelint-enable declaration-block-no-duplicate-properties
 }
-// stylelint-enable declaration-block-no-duplicate-properties

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -22,17 +22,10 @@
         @include box-shadow($btn-box-shadow);
     }
 
-    // Force outline on for inputs
-    // stylelint-disable declaration-block-no-duplicate-properties
-    .btn-check-input:focus ~ & {
-        outline: 1px dotted;
-        outline: 5px auto -webkit-focus-ring-color;
-    }
-    // stylelint-enable declaration-block-no-duplicate-properties
-
     // Disabled comes first so active can restyle
     &.disabled,
-    &:disabled {
+    &:disabled,
+    .btn-check-input:disabled ~ & {
         cursor: $cursor-disabled;
         opacity: $btn-disabled-opacity;
         @include box-shadow(none);
@@ -40,21 +33,21 @@
 
     &:not(:disabled):not(.disabled):active,
     &:not(:disabled):not(.disabled).active,
-    .btn-check-input:checked ~ &,
+    .btn-check-input:not(:disabled):checked ~ &,
     .open > & {
         // Remove the gradient for the pressed/active state
         background-image: none;
         @include box-shadow($btn-active-box-shadow);
     }
 
-    &:active:hover,
-    &.active:hover,
-    &:active:focus,
-    &.active:focus,
-    .btn-check-input:checked:hover ~ &,
-    .btn-check-input:checked:focus ~ &,
-    .open:hover > &,
-    .open:focus > & {
+    &:not(:disabled):not(.disabled):active:hover,
+    &:not(:disabled):not(.disabled).active:hover,
+    &:not(:disabled):not(.disabled):active:focus,
+    &:not(:disabled):not(.disabled).active:focus,
+    .btn-check-input:not(:disabled):checked:focus ~ &,
+    .btn-check-input:not(:disabled):checked ~ &:hover,
+    .open > &:hover,
+    .open > &:focus {
         @include box-shadow($btn-active-box-shadow);
     }
 
@@ -64,7 +57,8 @@
 
 // Future-proof disabling of clicks on `<a>` elements
 a.btn.disabled,
-fieldset:disabled a.btn {
+fieldset:disabled a.btn,
+.btn-check-input:disabled ~ .btn {
     pointer-events: none;
 }
 
@@ -157,12 +151,22 @@ input[type="button"] {
     display: inline-block;
     vertical-align: middle; // match .btn alignment given font-size hack above
 
-    // stylelint-disable selector-no-qualifying-type
     & > input[type="radio"],
     & > input[type="checkbox"] {
         position: absolute;
         clip: rect(0, 0, 0, 0);
         pointer-events: none;
     }
-    // stylelint-enable selector-no-qualifying-type
+
+    > label {
+        margin-bottom: 0;
+    }
 }
+
+// Force outline on for inputs
+// stylelint-disable declaration-block-no-duplicate-properties
+.btn-check-input:focus ~ .btn {
+    outline: 1px dotted;
+    outline: 5px auto -webkit-focus-ring-color;
+}
+// stylelint-enable declaration-block-no-duplicate-properties

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -10,17 +10,25 @@
     white-space: nowrap;
     vertical-align: middle;
     user-select: none;
-    border: $input-border-width solid transparent;
+    border: $btn-border-width solid transparent;
     @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-border-radius);
     @include box-shadow($btn-box-shadow);
     @include transition($btn-transition);
 
     &:hover,
     &:focus,
-    &.focus {
+    .btn-check-input:focus ~ & {
         text-decoration: none;
         @include box-shadow($btn-box-shadow);
     }
+
+    // Force outline on for inputs
+    // stylelint-disable declaration-block-no-duplicate-properties
+    .btn-check-input:focus ~ & {
+        outline: 1px dotted;
+        outline: 5px auto -webkit-focus-ring-color;
+    }
+    // stylelint-enable declaration-block-no-duplicate-properties
 
     // Disabled comes first so active can restyle
     &.disabled,
@@ -32,16 +40,22 @@
 
     &:not(:disabled):not(.disabled):active,
     &:not(:disabled):not(.disabled).active,
+    .btn-check-input:checked ~ &,
     .open > & {
         // Remove the gradient for the pressed/active state
         background-image: none;
         @include box-shadow($btn-active-box-shadow);
+    }
 
-        &:hover,
-        &:focus,
-        &.focus {
-            @include box-shadow($btn-active-box-shadow);
-        }
+    &:active:hover,
+    &.active:hover,
+    &:active:focus,
+    &.active:focus,
+    .btn-check-input:checked:hover ~ &,
+    .btn-check-input:checked:focus ~ &,
+    .open:hover > &,
+    .open:focus > & {
+        @include box-shadow($btn-active-box-shadow);
     }
 
     // Default color
@@ -129,4 +143,26 @@ input[type="button"] {
     &.btn-block {
         width: 100%;
     }
+}
+
+// Checkbox and radio options
+// In order to support the browser's form validation feedback, powered by the
+// `required` attribute, we have to "hide" the inputs via `clip`. We cannot use
+// `display: none;` or `visibility: hidden;` as that also hides the popover.
+// Simply visually hiding the inputs via `opacity` would leave them clickable in
+// certain cases which is prevented by using `clip` and `pointer-events`.
+// This way, we ensure a DOM element is visible to position the popover from.
+.btn-check {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle; // match .btn alignment given font-size hack above
+
+    // stylelint-disable selector-no-qualifying-type
+    & > input[type="radio"],
+    & > input[type="checkbox"] {
+        position: absolute;
+        clip: rect(0, 0, 0, 0);
+        pointer-events: none;
+    }
+    // stylelint-enable selector-no-qualifying-type
 }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -10,7 +10,6 @@
 
     &:hover,
     &:focus,
-    .btn-check-input:hover ~ &,
     .btn-check-input:focus ~ & {
         color: $hover-color;
         background-color: $hover-bg;
@@ -18,29 +17,30 @@
     }
 
     &.disabled,
-    &:disabled {
+    &:disabled,
+    .btn-check-input:disabled ~ & {
         color: $color;
         background-color: $bg;
         border-color: $border;
     }
 
-    &:active,
-    &.active,
-    .btn-check-input:checked ~ &,
+    &:not(:disabled):not(.disabled):active,
+    &:not(:disabled):not(.disabled).active,
+    .btn-check-input:not(:disabled):checked ~ &,
     .open > & {
         color: $hover-color;
         background-color: $hover-bg;
         border-color: $hover-border;
     }
 
-    &:active:hover,
-    &.active:hover,
-    &:active:focus,
-    &.active:focus,
-    .btn-check-input:checked:hover ~ &,
-    .btn-check-input:checked:focus ~ &,
-    .open:hover > &,
-    .open:focus > & {
+    &:not(:disabled):not(.disabled):active:hover,
+    &:not(:disabled):not(.disabled).active:hover,
+    &:not(:disabled):not(.disabled):active:focus,
+    &:not(:disabled):not(.disabled).active:focus,
+    .btn-check-input:not(:disabled):checked:focus ~ &,
+    .btn-check-input:not(:disabled):checked ~ &:hover,
+    .open > &:hover,
+    .open > &:focus {
         color: $active-hover-color;
         background-color: $active-hover-bg;
     }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -8,7 +8,10 @@
     background-color: $bg;
     border-color: $border;
 
-    @include hover-focus() {
+    &:hover,
+    &:focus,
+    .btn-check-input:hover ~ &,
+    .btn-check-input:focus ~ & {
         color: $hover-color;
         background-color: $hover-bg;
         border-color: $hover-border;
@@ -23,15 +26,23 @@
 
     &:active,
     &.active,
+    .btn-check-input:checked ~ &,
     .open > & {
         color: $hover-color;
         background-color: $hover-bg;
         border-color: $hover-border;
+    }
 
-        @include hover-focus() {
-            color: $active-hover-color;
-            background-color: $active-hover-bg;
-        }
+    &:active:hover,
+    &.active:hover,
+    &:active:focus,
+    &.active:focus,
+    .btn-check-input:checked:hover ~ &,
+    .btn-check-input:checked:focus ~ &,
+    .open:hover > &,
+    .open:focus > & {
+        color: $active-hover-color;
+        background-color: $active-hover-bg;
     }
 }
 

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -333,21 +333,15 @@ $(window).ready(function() {
 
             <strong>Toggle State:</strong>
             <p>
-            <button type="button" data-cfw="button" class="btn btn-info">Single toggle</button>
-            &nbsp;
-            <button type="button" data-cfw="button" class="btn btn-info active">Single toggle</button>
-            </p>
-            <p>
                 <div class="btn-check">
-                    <input id="newTog0" type="checkbox" class="btn-check-input">
-                    <label for="newTog0" class="btn btn-info">Single toggle</label>
+                    <input id="checkbox0" type="checkbox" class="btn-check-input">
+                    <label for="checkbox0" class="btn btn-info">Single toggle</label>
                 </div>
                 &nbsp;
                 <div class="btn-check">
-                    <input id="newTog1" type="checkbox" class="btn-check-input" checked>
-                    <label for="newTog1" class="btn btn-info">Single toggle</label>
+                    <input id="checkbox1" type="checkbox" class="btn-check-input" checked>
+                    <label for="checkbox1" class="btn btn-info">Single toggle</label>
                 </div>
-
             </p>
 
             <div class="row mb-1">
@@ -355,33 +349,35 @@ $(window).ready(function() {
                     <strong>Checkbox:</strong>
                 </div>
                 <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-info" id="btnTog1">
-                            <input type="checkbox" checked /> Check 1
-                        </label>
-                        <label class="btn btn-info" id="btnTog2">
-                            <input type="checkbox" /> Check 2
-                        </label>
-                        <label class="btn btn-info" id="btnTog3">
-                            <input type="checkbox" /> Check 3
-                        </label>
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="checkbox2" type="checkbox" class="btn-check-input" checked>
+                            <label for="checkbox2" class="btn btn-info">Check 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox3" type="checkbox" class="btn-check-input">
+                            <label for="checkbox3" class="btn btn-info">Check 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox4" type="checkbox" class="btn-check-input">
+                            <label for="checkbox4" class="btn btn-info">Check 3</label>
+                        </div>
                     </div>
-                    <br />
-                    <a href="#" onclick="$('#btnTog1').CFW_Button('toggle'); return false;">Toggle 1</a>
-                    <a href="#" onclick="$('#btnTog2').CFW_Button('toggle'); return false;">Toggle 2</a>
-                    <a href="#" onclick="$('#btnTog3').CFW_Button('toggle'); return false;">Toggle 3</a>
                 </div>
                 <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-outline-info" id="btnTogO1">
-                            <input type="checkbox" checked /> Check 1
-                        </label>
-                        <label class="btn btn-outline-info" id="btnTogO2">
-                            <input type="checkbox" /> Check 2
-                        </label>
-                        <label class="btn btn-outline-info" id="btnTogO3">
-                            <input type="checkbox" /> Check 3
-                        </label>
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="checkbox5" type="checkbox" class="btn-check-input" checked>
+                            <label for="checkbox5" class="btn btn-outline-info">Check 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox6" type="checkbox" class="btn-check-input">
+                            <label for="checkbox6" class="btn btn-outline-info">Check 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox7" type="checkbox" class="btn-check-input">
+                            <label for="checkbox7" class="btn btn-outline-info">Check 3</label>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -390,92 +386,77 @@ $(window).ready(function() {
                     <strong>Radio:</strong>
                 </div>
                 <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-info">
-                            <input type="radio" name="options0" checked /> Radio 1
-                        </label>
-                        <label class="btn btn-info">
-                            <input type="radio" name="options0" /> Radio 2
-                        </label>
-                        <label class="btn btn-info">
-                            <input type="radio" name="options0" /> Radio 3
-                        </label>
-                    </div>
-                </div>
-                <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-outline-info">
-                            <input type="radio" name="options1" checked /> Radio 1
-                        </label>
-                        <label class="btn btn-outline-info">
-                            <input type="radio" name="options1" /> Radio 2
-                        </label>
-                        <label class="btn btn-outline-info">
-                            <input type="radio" name="options1" /> Radio 3
-                        </label>
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="radio0-0" type="radio" name="radio0" class="btn-check-input" checked>
+                            <label for="radio0-0" class="btn btn-info">Radio 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="radio0-1" type="radio" name="radio0" class="btn-check-input">
+                            <label for="radio0-1" class="btn btn-info">Radio 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="radio0-2" type="radio" name="radio0" class="btn-check-input">
+                            <label for="radio0-2" class="btn btn-info">Radio 3</label>
+                        </div>
                     </div>
                 </div>
                 <div class="col-sm-6">
                     <div class="btn-group">
                         <div class="btn-check">
-                            <input id="options2-1" type="radio" name="options2" class="btn-check-input" checked>
-                            <label for="options2-1" class="btn btn-info">Radio 1</label>
+                            <input id="radio1-0" type="radio" name="radio1" class="btn-check-input" checked>
+                            <label for="radio1-0" class="btn btn-outline-info">Radio 1</label>
                         </div>
                         <div class="btn-check">
-                            <input id="options2-2" type="radio" name="options2" class="btn-check-input" checked>
-                            <label for="options2-2" class="btn btn-info">Radio 2</label>
+                            <input id="radio1-1" type="radio" name="radio1" class="btn-check-input">
+                            <label for="radio1-1" class="btn btn-outline-info">Radio 2</label>
                         </div>
                         <div class="btn-check">
-                            <input id="options2-3" type="radio" name="options2" class="btn-check-input" checked>
-                            <label for="options2-3" class="btn btn-info">Radio 3</label>
+                            <input id="radio1-2" type="radio" name="radio1" class="btn-check-input">
+                            <label for="radio1-2" class="btn btn-outline-info">Radio 3</label>
                         </div>
-                    </div>
-                </div>
-            </div>
-            <div class="row mb-1">
-                <div class="col-12">
-                    <strong>Buttons:</strong>
-                    <br />
-                    <div class="btn-group" data-cfw="buttons">
-                        <button class="btn" type="button">One</button>
-                        <button class="btn active" type="button">Two</button>
-                        <button class="btn" type="button">Three</button>
                     </div>
                 </div>
             </div>
 
             <strong>Toggle State (Disabled):</strong>
             <p>
-            <button type="button" data-cfw="button" class="btn btn-info disabled">Single toggle</button>
-            &nbsp;
-            <button type="button" data-cfw="button" class="btn btn-info" disabled>Single toggle</button>
-            <p>
+                <div class="btn-check">
+                    <input id="checkbox8" type="checkbox" class="btn-check-input" disabled>
+                    <label for="checkbox8" class="btn btn-info">Single toggle</label>
+                </div>
+            </p>
             <div class="row mb-1">
                 <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-outline-info" id="btnTogO1">
-                            <input type="checkbox" checked /> Check 1
-                        </label>
-                        <label class="btn btn-outline-info" id="btnTogO2">
-                            <input type="checkbox" disabled /> Check 2
-                        </label>
-                        <label class="btn btn-outline-info disabled" id="btnTogO3">
-                            <input type="checkbox" /> Check 3
-                        </label>
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="checkbox9" type="checkbox" class="btn-check-input" checked>
+                            <label for="checkbox9" class="btn btn-outline-info">Check 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox10" type="checkbox" class="btn-check-input">
+                            <label for="checkbox10" class="btn btn-outline-info">Check 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="checkbox11" type="checkbox" class="btn-check-input" disabled>
+                            <label for="checkbox11" class="btn btn-outline-info">Check 3</label>
+                        </div>
                     </div>
-
                 </div>
                 <div class="col-sm-6">
-                    <div class="btn-group" data-cfw="buttons">
-                        <label class="btn btn-info">
-                            <input type="radio" name="optionsD" /> Radio 1
-                        </label>
-                        <label class="btn btn-info">
-                            <input type="radio" name="optionsD" disabled /> Radio 2
-                        </label>
-                        <label class="btn btn-info disabled">
-                            <input type="radio" name="optionsD" /> Radio 3
-                        </label>
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="radio2-0" type="radio" name="radio2" class="btn-check-input" checked>
+                            <label for="radio2-0" class="btn btn-info">Radio 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="radio2-1" type="radio" name="radio2" class="btn-check-input">
+                            <label for="radio2-1" class="btn btn-info">Radio 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="radio2-2" type="radio" name="radio2" class="btn-check-input" disabled>
+                            <label for="radio2-2" class="btn btn-info">Radio 3</label>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -337,6 +337,18 @@ $(window).ready(function() {
             &nbsp;
             <button type="button" data-cfw="button" class="btn btn-info active">Single toggle</button>
             </p>
+            <p>
+                <div class="btn-check">
+                    <input id="newTog0" type="checkbox" class="btn-check-input">
+                    <label for="newTog0" class="btn btn-info">Single toggle</label>
+                </div>
+                &nbsp;
+                <div class="btn-check">
+                    <input id="newTog1" type="checkbox" class="btn-check-input" checked>
+                    <label for="newTog1" class="btn btn-info">Single toggle</label>
+                </div>
+
+            </p>
 
             <div class="row mb-1">
                 <div class="col-12">
@@ -401,6 +413,22 @@ $(window).ready(function() {
                         <label class="btn btn-outline-info">
                             <input type="radio" name="options1" /> Radio 3
                         </label>
+                    </div>
+                </div>
+                <div class="col-sm-6">
+                    <div class="btn-group">
+                        <div class="btn-check">
+                            <input id="options2-1" type="radio" name="options2" class="btn-check-input" checked>
+                            <label for="options2-1" class="btn btn-info">Radio 1</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="options2-2" type="radio" name="options2" class="btn-check-input" checked>
+                            <label for="options2-2" class="btn btn-info">Radio 2</label>
+                        </div>
+                        <div class="btn-check">
+                            <input id="options2-3" type="radio" name="options2" class="btn-check-input" checked>
+                            <label for="options2-3" class="btn btn-info">Radio 3</label>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/test/visual/flexbox-button.html
+++ b/test/visual/flexbox-button.html
@@ -89,16 +89,19 @@
 
     <hr />
 
-    <div class="btn-group-vertical" data-cfw="buttons" role="group">
-        <label class="btn btn-info">
-            <input type="checkbox" /> One
-        </label>
-        <label class="btn btn-info">
-            <input type="checkbox" /> Two
-        </label>
-        <label class="btn btn-info">
-            <input type="checkbox" /> Three
-        </label>
+    <div class="btn-group-vertical">
+        <div class="btn-check">
+            <input id="checkbox2" type="checkbox" class="btn-check-input" checked>
+            <label for="checkbox2" class="btn btn-info">Check 1</label>
+        </div>
+        <div class="btn-check">
+            <input id="checkbox3" type="checkbox" class="btn-check-input">
+            <label for="checkbox3" class="btn btn-info">Check 2</label>
+        </div>
+        <div class="btn-check">
+            <input id="checkbox4" type="checkbox" class="btn-check-input">
+            <label for="checkbox4" class="btn btn-info">Check 3</label>
+        </div>
     </div>
 
     <hr />


### PR DESCRIPTION
Add a CSS-only checkbox/radio button to the `.btn` styled buttons.  This is along the lines of the custom forms items and the switches (which will need to be updated also).

This should allow us to drop the `buttons.js` from the Widgets.

Idea:
```
<div class="btn-check">
    <input id="checkbox0" type="checkbox" class="btn-check-input">
    <label for="checkbox0" class="btn btn-info">Single toggle</label>
</div>
```