### PR TITLE
Rework cursor rules

### DIFF
--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -457,7 +457,7 @@ Grid-based form layouts also support [control sizing]({{ site.baseurl }}/content
 
 Default checkboxes and radios are improved upon with the help of `.form-check`, **a single class for both input types that improves the layout and behavior of their HTML elements**. Checkboxes are for selecting one or several options in a list, while radios are for selecting one option from many.
 
-Disabled checkboxes and radios are supported, but to provide a `not-allowed` cursor on hover of the parent `<label>`, you'll need to add the `.disabled` class to the parent `.form-check`. The disabled class will also lighten the text color to help indicate the input's state.
+Disabled checkboxes and radios are supported, but you will need to add the `.disabled` class to the parent `.form-check` to also lighten the text color to help indicate the input's state.
 
 ### Default (stacked)
 
@@ -593,7 +593,7 @@ When you want to have read-only fields in your form styled as plain text, use th
 
 ## Disabled States
 
-Add the `disabled` boolean attribute on an input to prevent user interactions. Disabled inputs appear lighter and add a `not-allowed` cursor.
+Add the `disabled` boolean attribute on an input to prevent user interactions. Disabled inputs appear lighter in color.
 
 {% example html %}
 <input class="form-control" id="disabledInput" type="text" placeholder="Disabled input" disabled>

--- a/docs/get-started/accessibility.md
+++ b/docs/get-started/accessibility.md
@@ -69,7 +69,7 @@ It should also be noted that:
 - `<a>`s don't support the `disabled` attribute.
 - The `.disabled` class uses a future-friendly `pointer-events: none` property to try to disable the `pointer-events` and link functionality of `<a>`s, but that CSS property is not yet standardized.
 - In browsers which support `pointer-events: none`, keyboard navigation remains unaffected, meaning that sighted keyboard users and users of assistive technologies will still be able to activate these links.
-- When using both the `pointer-events:none` and `cursor: not-allowed` styles, the disabled cursor is not shown when hovering over the item.
+- When using both the `pointer-events: none` and `cursor: not-allowed` styles, the disabled cursor is not shown when hovering over the item.
 
 Some solutions include:
 - In some cases, an acceptable solution would be to replace the `<a>` element with a `<span>` to allow for a similar layout.  This is due to `<span>`s also having a default `display: inline` and are not clickable or focusable through keyboard interaction.

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -218,11 +218,6 @@ $link-hover-decoration: underline !default;
 $paragraph-spacer-y:    1rem !default;
 
 
-// Cursors
-// =====
-$cursor-disabled:       not-allowed !default;
-
-
 // Typography
 // =====
 // Font, line-height, and color for body text, headings, and more.
@@ -564,7 +559,6 @@ $custom-control-indicator-box-shadow:   inset 0 .25rem .25rem rgba($black, .1) !
 $custom-control-indicator-border-width: $border-width !default;
 $custom-control-indicator-border-color: $input-border-color !default;
 
-$custom-control-disabled-cursor:             $cursor-disabled !default;
 $custom-control-disabled-indicator-bg:       $uibase-200 !default;
 $custom-control-disabled-description-color:  $uibase-400 !default;
 
@@ -622,7 +616,6 @@ $switch-focus-control-border-color:     $input-focus-border-color !default;
 $switch-focus-control-box-shadow:       $input-focus-box-shadow !default;
 
 $switch-disabled-description-color:     $uibase-400 !default;
-$switch-disabled-cursor:                $cursor-disabled !default;
 $switch-disabled-opacity:               .6 !default;
 
 $switch-indicator-box-shadow:           $btn-box-shadow !default;

--- a/scss/component/_close.scss
+++ b/scss/component/_close.scss
@@ -13,6 +13,10 @@
         text-decoration: none;
         opacity: .75;
     }
+
+    .close:not(:disabled):not(.disabled) {
+        cursor: pointer;
+    }
 }
 
 // Additional properties for button version

--- a/scss/component/_drag.scss
+++ b/scss/component/_drag.scss
@@ -12,8 +12,11 @@
     @include hover-focus {
         color: $drag-color;
         text-decoration: none;
-        cursor: move;
         opacity: .75;
+    }
+
+    .close:not(:disabled):not(.disabled) {
+        cursor: move;
     }
 }
 

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -167,7 +167,6 @@
     &:disabled {
         color: $dropdown-link-disabled-color;
         text-decoration: none;
-        cursor: $cursor-disabled;
         background-color: $dropdown-link-disabled-bg;
         background-image: none; // Remove CSS gradient
     }

--- a/scss/component/_list-group.scss
+++ b/scss/component/_list-group.scss
@@ -50,7 +50,6 @@
     &:disabled {
         color: $list-group-disabled-color;
         text-decoration: none;
-        cursor: $cursor-disabled;
         background-color: $list-group-disabled-bg;
     }
 

--- a/scss/component/_nav.scss
+++ b/scss/component/_nav.scss
@@ -18,7 +18,6 @@
     // By default it also influences `.nav-tab` and `.nav-pills`
     &.disabled {
         color: $nav-link-disabled-color;
-        cursor: $cursor-disabled;
         opacity: $nav-link-disabled-opacity;
     }
 }

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -114,6 +114,10 @@
     @include hover-focus {
         text-decoration: none;
     }
+
+    &:not(:disabled):not(.disabled) {
+        cursor: pointer;
+    }
 }
 
 // Generate series of `.navbar-expand-*` responsive classes for configuring

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -35,6 +35,7 @@
     position: relative;
     color: $pagination-color;
     text-decoration: none;
+    cursor: pointer;
 
     &:hover,
     &:focus {
@@ -54,7 +55,7 @@
     &.disabled {
         color: $pagination-disabled-color;
         pointer-events: none;
-        cursor: $cursor-disabled;
+        cursor: auto;
         background-color: $pagination-disabled-bg;
     }
 }

--- a/scss/component/_slider.scss
+++ b/scss/component/_slider.scss
@@ -6,6 +6,7 @@
 
 .slider-track {
     position: absolute;
+    cursor: pointer;
     background-color: $slider-track-bg;
     @include border-radius($slider-track-border-radius);
 

--- a/scss/component/_switch.scss
+++ b/scss/component/_switch.scss
@@ -13,6 +13,7 @@
     @include font-size($font-size-base);
     line-height: $input-line-height;
     vertical-align: middle;
+    cursor: pointer;
     background-color: $switch-control-bg;
     background-image: none;
     background-clip: padding-box;
@@ -66,7 +67,7 @@
 
     &:disabled {
         ~ .switch-control {
-            cursor: $switch-disabled-cursor;
+            cursor: auto;
             opacity: $switch-disabled-opacity;
 
             &::before {
@@ -76,7 +77,6 @@
 
         ~ .switch-description {
             color: $switch-disabled-description-color;
-            cursor: $switch-disabled-cursor;
             opacity: $switch-disabled-opacity;
         }
     }

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -26,9 +26,12 @@
     &.disabled,
     &:disabled,
     .btn-check-input:disabled ~ & {
-        cursor: $cursor-disabled;
         opacity: $btn-disabled-opacity;
         @include box-shadow(none);
+    }
+
+    &:not(:disabled):not(.disabled) {
+        cursor: pointer;
     }
 
     &:not(:disabled):not(.disabled):active,

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -36,14 +36,12 @@
 
     &:disabled {
         ~ .custom-control-indicator {
-            cursor: $custom-control-disabled-cursor;
             background-color: $custom-control-disabled-indicator-bg;
             border: 0;
         }
 
         ~ .custom-control-description {
             color: $custom-control-disabled-description-color;
-            cursor: $custom-control-disabled-cursor;
         }
     }
 }
@@ -165,7 +163,6 @@
 
     &:disabled {
         color: $input-disabled-color;
-        cursor: $cursor-disabled;
         background-color: $input-disabled-bg;
     }
 

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -53,7 +53,6 @@
 
     &:disabled {
         color: $input-disabled-color;
-        cursor: $cursor-disabled;
     }
 }
 
@@ -189,7 +188,6 @@ textarea.form-control {
     .form-check.disabled &,
     fieldset:disabled & {
         color: $form-check-disabled-color;
-        cursor: $cursor-disabled;
     }
 }
 

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -374,12 +374,6 @@ input[type="radio"],
 input[type="checkbox"] {
     box-sizing: border-box; // 1. Add the correct box sizing in IE 10-
     padding: 0; // 2. Remove the padding in IE 10-
-
-    // Apply a disabled cursor for radios and checkboxes.
-    // Note: Neither radios nor checkboxes can be readonly.
-    &:disabled {
-        cursor: $cursor-disabled;
-    }
 }
 
 input[type="date"],
@@ -468,6 +462,7 @@ output {
 
 summary {
     display: list-item; // Add the correct display in all browsers
+    cursor: pointer;
 }
 
 template {


### PR DESCRIPTION
- Add back `cursor: pointer` to control items
- Drop `cursor: not-allowed`, were  not always shown anyway due to `pointer-events: none`
- Clean up some related doc items