### PR TITLE
Fix some animation issues

### DIFF
--- a/docs/widgets/lazy.md
+++ b/docs/widgets/lazy.md
@@ -18,11 +18,11 @@ Lazy delays loading of images outside of the viewport (visible part of the page)
 A lazy loaded image with delay and a fade in animation.
 
 <div class="cf-example">
-    <img data-cfw="lazy" data-cfw-lazy-delay="1000" data-cfw-lazy-effect="fadeIn" data-cfw-lazy-speed="1000" data-cfw-lazy-src="{{ site.basurl}}/assets/img/test.gif" width="360" height="202" alt="Test pattern" />
+    <img data-cfw="lazy" data-cfw-lazy-delay="1000" data-cfw-lazy-animate="true" data-cfw-lazy-src="{{ site.basurl}}/assets/img/test.gif" width="360" height="202" alt="Test pattern" />
 </div>
 
 {% highlight html %}
-<img src="" data-cfw="lazy" data-cfw-lazy-delay="1000" data-cfw-lazy-effect="fadeIn" data-cfw-lazy-speed="1000" data-cfw-lazy-src="test.gif" width="360" height="202" alt="Test pattern" />
+<img src="" data-cfw="lazy" data-cfw-lazy-delay="1000" data-cfw-lazy-animate="true" data-cfw-lazy-src="test.gif" width="360" height="202" alt="Test pattern" />
 {% endhighlight %}
 
 ## Usage
@@ -96,19 +96,13 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>delay</td>
         <td>integer</td>
         <td>0</td>
-        <td>Delay time (milliseconds) to wait before invoking the show animation specified by the <code>effect</code> option.</td>
+        <td>Delay time (milliseconds) to wait before loading image once the `show` method has been called.</td>
     </tr>
     <tr>
-        <td>effect</td>
-        <td>string</td>
-        <td>'show'</td>
-        <td>The function name to be called when the <code>show</code> method has been triggered.  By default the jQuery function <a href="http://api.jquery.com/show/">.show()</a> is used, but in theory any jQuery based effect can be used including ones from jQuery UI.</td>
-    </tr>
-    <tr>
-        <td>speed</td>
-        <td>integer</td>
-        <td>0</td>
-        <td>Speed of animation (milliseconds) - corresponds the desired animation speed of the animation specified by the <code>effect</code> option.</td>
+        <td>animate</td>
+        <td>boolean</td>
+        <td>false</td>
+        <td>If the image should appear with a fade-in animation when loaded.</td>
     </tr>
     <tr>
         <td>threshold</td>

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -30,7 +30,6 @@
     CFW_Widget_Collapse.prototype = {
 
         _init : function() {
-            var $selfRef = this;
             var selector = this.$element.CFW_getSelectorFromChain('collapse', this.settings.target);
             if (!selector) { return; }
             this.$target = $(selector);
@@ -61,10 +60,7 @@
             var dimension = this.dimension();
             if (this.$triggers.hasClass('open')) {
                 this.$triggers.attr('aria-expanded', 'true');
-                this.$target.each(function() {
-                    var flexClass = $selfRef._isFlex(this) ? 'in-flex' : 'in';
-                    $(this).addClass('collapse ' + flexClass)[dimension]('');
-                });
+                this.$target.addClass('collapse in')[dimension]('');
             } else {
                 this.$triggers.attr('aria-expanded', 'false');
                 this.$target.addClass('collapse');
@@ -84,7 +80,7 @@
             if (e && !/input|textarea/i.test(e.target.tagName)) {
                 e.preventDefault();
             }
-            if (this.$element.hasClass('open') || this.$target.hasClass('in') || this.$target.hasClass('in-flex')) {
+            if (this.$element.hasClass('open') || this.$target.hasClass('in')) {
                 this.hide();
             } else {
                 this.show();
@@ -104,7 +100,7 @@
             if (follow === null) { follow = this.settings.follow; }
 
             // Bail if transition in progress
-            if (this.inTransition || this.$target.hasClass('in') || this.$target.hasClass('in-flex')) { return; }
+            if (this.inTransition || this.$target.hasClass('in')) { return; }
 
             // Start open transition
             if (!this.$element.CFW_trigger('beforeShow.cfw.collapse')) {
@@ -134,10 +130,7 @@
                 $selfRef.$triggers.attr('aria-expanded', 'true');
                 $selfRef.$target
                     .removeClass('collapsing')[dimension]('');
-                $selfRef.$target.each(function() {
-                    var flexClass = $selfRef._isFlex(this) ? 'in-flex' : 'in';
-                    $(this).addClass('collapse ' + flexClass);
-                });
+                $selfRef.$target.addClass('collapse in');
                 $selfRef.$target.CFW_mutateTrigger();
                 $selfRef.inTransition = false;
                 if (follow) {
@@ -156,7 +149,7 @@
             if (follow === null) { follow = this.settings.follow; }
 
             // Bail if transition in progress
-            if (this.inTransition || (!this.$target.hasClass('in') && !this.$target.hasClass('in-flex'))) { return; }
+            if (this.inTransition || !this.$target.hasClass('in')) { return; }
 
             // Start close transition
             if (!this.$element.CFW_trigger('beforeHide.cfw.collapse')) {
@@ -173,7 +166,7 @@
                 var $this = $(this);
                 $this[dimension]($this[dimension]())[0].offsetHeight;
             });
-            this.$target.removeClass('collapse in in-flex');
+            this.$target.removeClass('collapse in');
             if (this.settings.animate) {
                 this.$target.addClass('collapsing');
             }
@@ -186,7 +179,7 @@
             function complete() {
                 $selfRef.$triggers.attr('aria-expanded', 'false');
                 $selfRef.$target
-                    .removeClass('collapsing in in-flex')
+                    .removeClass('collapsing in')
                     .addClass('collapse')
                     .CFW_mutateTrigger();
                 $selfRef.inTransition = false;
@@ -206,11 +199,6 @@
 
         animEnable: function() {
             this.settings.animate = true;
-        },
-
-        _isFlex: function(node) {
-            var displayVal = window.getComputedStyle(node, null).getPropertyValue('display');
-            return (displayVal.indexOf('flex') !== -1);
         },
 
         dispose : function() {

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -25,8 +25,7 @@
         throttle  : 250,        // Throttle speed to limit event firing
         trigger   : 'scroll resize mutate',   // Events to trigger loading source
         delay     : 0,          // Delay before loading source
-        effect    : 'show',     // jQuery effect to use for showing source (http://api.jquery.com/category/effects/)
-        speed     : 0,          // Speed of effect (milliseconds)
+        animate   : false,      // Should the image fade in
         threshold : 0,          // Amount of pixels below viewport to triger show
         container : window,     // Where to watch for events
         invisible : false,      // Load sources that are not :visible
@@ -126,16 +125,22 @@
         loadSrc : function() {
             var $selfRef = this;
 
-            // Hide, set src, show w/effect
-            this.$element.hide();
             this.$element.attr('src', this.settings.src);
-            this.$element[this.settings.effect](this.settings.speed);
 
             $.CFW_imageLoaded(this.$element, this.instance, function() {
-                setTimeout(function() {
+                function complete() {
+                    $selfRef.$element.removeClass('lazy in');
                     $selfRef.$element.CFW_trigger('afterShow.cfw.lazy');
                     $selfRef.dispose();
-                }, $selfRef.settings.speed);
+                }
+
+                // Use slight delay when setting `.in` so animation occurs
+                if ($selfRef.settings.animate) { $selfRef.$element.addClass('lazy'); }
+                setTimeout(function() {
+                    $selfRef.$element
+                        .addClass('in')
+                        .CFW_transition(null, complete);
+                }, 15);
             });
         },
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -377,6 +377,7 @@ $drag-text-shadow:      0 .0625rem 0 #fff !default;
 // =====
 // Widget animations
 $transition-fade:       opacity .15s linear !default;
+$transition-lazy-fade:  opacity .3s linear !default;
 $transition-collapse-y: height .3s ease !default;
 $transition-collapse-x: width .3s ease !default;
 

--- a/scss/component/_animation.scss
+++ b/scss/component/_animation.scss
@@ -1,3 +1,14 @@
+.lazy {
+    opacity: 0;
+
+    // Add transition here so that the image can be quickly hidden
+    // before fading back in
+    &.in {
+        opacity: 1;
+        @include transition($transition-lazy-fade);
+    }
+}
+
 .fade {
     opacity: 0;
     @include transition($transition-fade);
@@ -8,30 +19,10 @@
 }
 
 .collapse {
-    display: none;
-
-    &.in {
-        display: block;
-    }
-    &.in-flex {
-        display: flex;
+    &:not(.in) {
+        display: none;
     }
 }
-
-// stylelint-disable selector-no-qualifying-type
-tr {
-    &.collapse.in,
-    &.collapse.in-flex {
-        display: table-row;
-    }
-}
-tbody {
-    &.collapse.in,
-    &.collapse.in-flex {
-        display: table-row-group;
-    }
-}
-// stylelint-enable selector-no-qualifying-type
 
 .collapsing {
     position: relative;

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1750,15 +1750,15 @@ $(window).ready(function() {
             <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" width="320" height="180" />
             <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue; display: none;" width="320" height="180" />
 
-            <div id="lazytest" style="height: 125px; overflow: scroll; margin-bottom: 20px;">
+            <div id="lazytest" class="my-1" style="height: 125px; overflow: scroll;">
                 <p style="margin-top: 65px; margin-bottom: 65px; text-align: center;">
                     \/ Scroll down \/
                 </p>
                 <p>
-                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-effect="fadeIn" data-cfw-lazy-speed=1000 data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-animate="true" data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
                 </p>
                 <p>
-                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-effect="fadeIn" data-cfw-lazy-speed=1000 data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-animate="true" data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
                 </p>
                 <p>
                 <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-src="../../docs/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />


### PR DESCRIPTION
Collapse widget:
- Drop the poorly implemented check for flexbox.
- Only alter CSS rule for display when an item is supposed to be collapsed.

Lazy widget:
- jQuery slim does not have built animation support, so we are dropping that.
- Added an optional fade-in animation