### PR TITLE
Overhaul tables

### DIFF
--- a/docs/content/tables.md
+++ b/docs/content/tables.md
@@ -13,799 +13,664 @@ Due to the widespread use of tables across third-party widgets like calendars an
 {:toc}
 
 
-## Examples
+All table styles are inherited, meaning any nested tables will be styled in the same manner as the parent.
 
-Using the most basic table markup, here's how `.table`-based tables look in Figuration. All table styles are inherited, meaning any nested tables will be styled in the same manner as the parent.
+## Basic Table
+
+Using the most basic table markup, a `.table` will result in a mostly unstyled table, and will use all available width.
 
 {% example html %}
 <table class="table">
   <thead>
     <tr>
       <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
+      <th scope="col">Header 1</th>
+      <th scope="col">Header 2</th>
+      <th scope="col">Header 3</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
     </tr>
     <tr>
       <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
+      <td colspan="2">Spanned Cell</td>
+      <td>Cell</td>
     </tr>
     <tr>
       <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
     </tr>
   </tbody>
   <tfoot>
     <tr>
       <th scope="col"></th>
-      <th scope="col">Table Footer 1</th>
-      <th scope="col">Table Footer 2</th>
-      <th scope="col">Table Footer 3</th>
+      <th scope="col">Footer 1</th>
+      <th scope="col">Footer 2</th>
+      <th scope="col">Footer 3</th>
     </tr>
   </tfoot>
 </table>
 {% endexample %}
 
-You can also invert the colors---with light text on dark backgrounds---with `.table-inverse`.
+## Styled Tables
 
-{% example html %}
-<table class="table table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
+### Striped Rows
+
+Use `.table-striped-{light/dark}` to add zebra-striping to any table row within the `<tbody>`.  This works by using `background-image` to overlay a solid gradient on top of the `background-color`.
+
+Variants include:
+- `.table-striped-light` - lighten the striped row's background-color
+- `.table-striped-dark` - darken the striped row's background-color
+
+<div class="cf-example">
+  <table class="table table-striped-dark">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-striped-dark">
+  ...
 </table>
-{% endexample %}
+{% endhighlight %}
 
-## Table Head Options
-
-Similar to default and inverse tables, use one of two modifier classes to make `<thead>`s appear light or dark gray.
-
-{% example html %}
-<table class="table">
-  <thead class="thead-inverse">
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
+<div class="cf-example">
+  <table class="table table-striped-light bg-dark text-white">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-striped-light bg-dark text-white">
+  ...
 </table>
+{% endhighlight %}
 
-<table class="table">
-  <thead class="thead-default">
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
+### Hoverable Rows
+
+Add `.table-hover-{light/dark}` to enable a hover state on table rows within a `<tbody>`. This works by using `background-image` to overlay a solid gradient on top of the `background-color`.
+
+Variants include:
+- `.table-hover-light` - lighten the hovered row's background-color
+- `.table-hover-dark` - darken the hovered row's background-color
+
+<div class="cf-example">
+  <table class="table table-hover-dark">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-hover-dark">
+  ...
 </table>
-{% endexample %}
+{% endhighlight %}
 
-## Table Footer Options
-
-Just like the headers, use one of two modifier classes to make `<tfoot>`s appear light or dark gray.
-
-{% example html %}
-<table class="table">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot class="tfoot-inverse">
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
+<div class="cf-example">
+  <table class="table table-hover-light bg-dark text-white">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-hover-light bg-dark text-white">
+  ...
 </table>
+{% endhighlight %}
 
-<table class="table">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot class="tfoot-default">
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-## Striped Rows
-
-Use `.table-striped` to add zebra-striping to any table row within the `<tbody>`.
-
-{% example html %}
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-striped table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-</table>
-{% endexample %}
-
-## Bordered Table
-
-Add `.table-bordered` for borders on all sides of the table and cells.
-
-{% example html %}
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-bordered table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-## Borderless Table
-
-Add `.table-borderless` to remove borders from all sides of the cells, but leave a border between the table's header or footer and the table body.
-
-{% example html %}
-<table class="table table-borderless">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-borderless table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-## Non-Bordered Table
-
-Add `.table-noborder` to remove borders from all sides of the cells, including the border between the table's header or footer and the table body.
-
-{% example html %}
-<table class="table table-noborder">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-noborder table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-## Mixed-Border Table
-
-Mix `.table-bordered` along with `.table-borderless` or `.table-noborder` to vary the table's borders.
-
-{% example html %}
-<table class="table table-bordered table-borderless">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-bordered table-noborder">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
-</table>
-{% endexample %}
-
-## Hoverable Rows
-
-Add `.table-hover` to enable a hover state on table rows within a `<tbody>`.
-
-{% example html %}
-<table class="table table-hover">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-</table>
-{% endexample %}
-
-{% example html %}
-<table class="table table-hover table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-</table>
-{% endexample %}
-
-## Condensed Table
+### Condensed Table
 
 Add `.table-condensed` to make tables more compact by reducing the cell padding.
 
-{% example html %}
+<div class="cf-example">
+  <table class="table table-condensed">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
 <table class="table table-condensed">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
+  ...
 </table>
-{% endexample %}
+{% endhighlight %}
 
-{% example html %}
-<table class="table table-condensed table-inverse">
-  <thead>
-    <tr>
-      <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">2</th>
-      <td colspan="2">table cell</td>
-      <td>table cell</td>
-    </tr>
-    <tr>
-      <th scope="row">3</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
-    </tr>
-  </tbody>
-  <tfoot>
-    <tr>
-      <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
-    </tr>
-  </tfoot>
+### Narrow Table
+
+Use our [sizing utilities]({{ site.baseurl }}/utilities/sizing/), such as `w-auto`, to control a table's width.
+
+<div class="cf-example">
+  <table class="table w-auto">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table w-auto">
+  ...
 </table>
-{% endexample %}
+{% endhighlight %}
 
-## Contextual Classes
+## Table Borders
 
-Use contextual classes to color table rows or individual cells.
+### Divided Table
+
+Add a horizontal border between rows using `.table-divided`.
+
+<div class="cf-example">
+  <table class="table table-divided">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-divided">
+  ...
+</table>
+{% endhighlight %}
+
+### Ruled Table
+
+Put a border on the top and bottom of a table, and between rows using `.table-ruled`.
+
+<div class="cf-example">
+  <table class="table table-ruled">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-ruled">
+  ...
+</table>
+{% endhighlight %}
+
+### Pillared Table
+
+Put a vertical border and between columns using `.table-pillared`.
+
+<div class="cf-example">
+  <table class="table table-pillared">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-pillared">
+  ...
+</table>
+{% endhighlight %}
+
+### Walled Table
+
+Put a border on the sides of a table, and between columns using `.table-walled`.
+
+<div class="cf-example">
+  <table class="table table-walled">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-walled">
+  ...
+</table>
+{% endhighlight %}
+
+### Celled Table
+
+Put horizontal and vertical borders between rows and columns using `.table-celled`.
+
+<div class="cf-example">
+  <table class="table table-celled">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-celled">
+  ...
+</table>
+{% endhighlight %}
+
+### Wrapped Table
+
+Put a border all around the outisde of a table with `.table-wrapped`.
+
+<div class="cf-example">
+  <table class="table table-wrapped">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-wrapped">
+  ...
+</table>
+{% endhighlight %}
+
+### Bordered Table
+
+Put a border around the table and every cell with `.table-bordered`.
+
+<div class="cf-example">
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-bordered">
+  ...
+</table>
+{% endhighlight %}
+
+## Color Variants
+
+Use [color utility classes]({{ site.baseurl }}/utilities/color/) to style tables with color.
 
 {% callout warning %}
 Conveying Meaning to Assistive Technologies
@@ -814,46 +679,263 @@ Conveying Meaning to Assistive Technologies
 Please refer to the [Accessiblity notes about conveying meaning with color]({{ site.baseurl }}/get-started/accessibility/#conveying-meaning-with-color).
 {% endcallout %}
 
-<table class="table table-scroll table-bordered table-striped">
-  <thead>
-    <tr>
-      <th>Class</th>
-      <th>Description</th>
-    </tr>
+### Inverse Table
+
+Easily create an inverted table with light text on a dark background.
+
+<div class="cf-example">
+  <table class="table table-bordered bg-dark border-secondary text-white">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-bordered bg-dark border-secondary text-white">
+  ...
+</table>
+{% endhighlight %}
+
+### Header/Footer Color
+
+Use [text or background utilities]({{ site.baseurl }}/utilities/color/) to alter the look of the header and/or footer.
+
+<div class="cf-example">
+  <table class="table">
+    <thead class="bg-dark text-light">
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot class="bg-light text-dark">
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-bordered bg-dark border-secondary text-white">
+  <thead class "bg-dark text-light">
+    ...
   </thead>
   <tbody>
-    <tr>
-      <th scope="row">
-        <code>.table-active</code>
-      </th>
-      <td>Applies the hover color to a particular row or cell</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-success</code>
-      </th>
-      <td>Indicates a successful or positive action</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-info</code>
-      </th>
-      <td>Indicates a neutral informative change or action</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-warning</code>
-      </th>
-      <td>Indicates a warning that might need attention</td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <code>.table-danger</code>
-      </th>
-      <td>Indicates a dangerous or potentially negative action</td>
-    </tr>
+    ...
   </tbody>
+  <tfoot class="bg-light text-dark">
+    ...
+  </tfoot>
 </table>
+{% endhighlight %}
+
+### Border Color
+
+`.table`s are defined with `border-{side}-color: inherit;`, allowing for easy recoloring of the borders by setting the `border-color` on the `.table` itself.  Setting a `border-color` on a table row or cell will affect the border color for that specific element and it's descendants.
+
+Cells in `<thead>` and `<tbody>` elements use `border-bottom` for their horizontal borders,  while cells in `<tfoot>` use `border-top`, and hide their bottom border.
+All cells use `border-left` for their vertical ones, unless they are the last ones in a row, then they potentially add a `border-right` depending on the modifier used.
+
+<div class="cf-example"
+  <table class="table table-bordered border-primary">
+    <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-bordered border-primary">
+  ...
+</table>
+{% endhighlight %}
+
+<div class="cf-example">
+  <table class="table table-divided">
+    <thead class="border-primary">
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Header 1</th>
+        <th scope="col">Header 2</th>
+        <th scope="col">Header 3</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">1</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">2</th>
+        <td colspan="2">Spanned Cell</td>
+        <td>Cell</td>
+      </tr>
+      <tr>
+        <th scope="row">3</th>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+      </tr>
+    </tbody>
+    <tfoot class="border-danger">
+      <tr>
+        <th></th>
+        <th>Footer 1</th>
+        <th>Footer 2</th>
+        <th>Footer 3</th>
+      </tr>
+    </tfoot>
+  </table>
+</div>
+{% highlight html %}
+<table class="table table-divided">
+  <thead class="border-primary">
+    ...
+  </thead>
+  <tbody>
+    ...
+  </tbody>
+  <tfoot class="border-danger">
+    ...
+  </tfoot>
+</table>
+{% endhighlight %}
+
+### Contextual Classes
+
+Use contextual classes to color table rows or individual cells.
+
+<div class="table-scroll">
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+        <th>Class</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">
+          <code>.table-active</code>
+        </th>
+        <td>Applies the hover color to a particular row or cell</td>
+      </tr>
+      <tr>
+        <th scope="row">
+          <code>.table-success</code>
+        </th>
+        <td>Indicates a successful or positive action</td>
+      </tr>
+      <tr>
+        <th scope="row">
+          <code>.table-info</code>
+        </th>
+        <td>Indicates a neutral informative change or action</td>
+      </tr>
+      <tr>
+        <th scope="row">
+          <code>.table-warning</code>
+        </th>
+        <td>Indicates a warning that might need attention</td>
+      </tr>
+      <tr>
+        <th scope="row">
+          <code>.table-danger</code>
+        </th>
+        <td>Indicates a dangerous or potentially negative action</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 <div class="cf-example">
   <table class="table">
@@ -950,7 +1032,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
 </tr>
 {% endhighlight %}
 
-Regular table background variants are not available with the inverse table, however, you may use [text or background utilities]({{ site.baseurl }}/utilities/color/) to achieve similar styles.
+You may also use [text or background utilities]({{ site.baseurl }}/utilities/color/).
 
 <div class="cf-example">
   <table class="table table-inverse">
@@ -1051,20 +1133,20 @@ You can also use [text or background utilities]({{ site.baseurl }}/utilities/col
 
 {% example html %}
 <table class="table">
-  <thead class="text-light bg-blue-500">
+  <thead class="text-light bg-primary">
     <tr>
       <th scope="col">#</th>
-      <th scope="col">Table Header 1</th>
-      <th scope="col">Table Header 2</th>
-      <th scope="col">Table Header 3</th>
+      <th scope="col">Header 1</th>
+      <th scope="col">Header 2</th>
+      <th scope="col">Header 3</th>
     </tr>
   </thead>
   <tbody>
-    <tr class="text-cyan-500">
+    <tr class="text-info">
       <th scope="row">1</th>
-      <td>table cell</td>
-      <td>table cell</td>
-      <td>table cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
+      <td>Cell</td>
     </tr>
     <tr>
       <th scope="row">2</th>
@@ -1074,16 +1156,16 @@ You can also use [text or background utilities]({{ site.baseurl }}/utilities/col
     <tr>
       <th scope="row">3</th>
       <td class="text-light bg-success">table cell</td>
-      <td>table cell</td>
-      <td class="text-dark bg-red-100">table cell</td>
+      <td>Cell</td>
+      <td class="text-light bg-danger">table cell</td>
     </tr>
   </tbody>
-  <tfoot class="bg-blue-100">
+  <tfoot class="bg-info text-light">
     <tr>
       <th></th>
-      <th>Table Footer 1</th>
-      <th>Table Footer 2</th>
-      <th>Table Footer 3</th>
+      <th>Footer 1</th>
+      <th>Footer 2</th>
+      <th>Footer 3</th>
     </tr>
   </tfoot>
 </table>
@@ -1129,7 +1211,7 @@ A `<caption>` functions like a heading for a table. It helps users with screen r
 
 ## Scrolling Tables
 
-Having an issue with tables becoming too wide for their containers? Add `.table-scroll` to any `.table` to make them scroll horizontally if they become wider than their container.
+Having an issue with tables becoming too wide for their containers? Add a `.table-scroll` wrapper to any `.table` to make them scroll horizontally if they become wider than their container.
 
 {% callout warning %}
 Vertical Clipping
@@ -1141,205 +1223,347 @@ Scrolling tables make use of `overflow-y: hidden`, which clips off any content t
 ### Always Scrolling
 
 <div class="cf-example">
-  <table class="table table-scroll">
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">1</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">2</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">3</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <th></th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-      </tr>
-    </tfoot>
-  </table>
-
-  <table class="table table-scroll table-bordered">
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">1</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">2</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">3</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <th></th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-      </tr>
-    </tfoot>
-  </table>
+  <div class="table-scroll">
+    <table class="table table-bordered text-nowrap">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Header 1</th>
+          <th scope="col">Header 2</th>
+          <th scope="col">Header 3</th>
+          <th scope="col">Header 4</th>
+          <th scope="col">Header 5</th>
+          <th scope="col">Header 6</th>
+          <th scope="col">Header 7</th>
+          <th scope="col">Header 8</th>
+          <th scope="col">Header 9</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th>Footer 1</th>
+          <th>Footer 2</th>
+          <th>Footer 3</th>
+          <th>Footer 4</th>
+          <th>Footer 5</th>
+          <th>Footer 6</th>
+          <th>Footer 7</th>
+          <th>Footer 8</th>
+          <th>Footer 9</th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
 </div>
 
 {% highlight html %}
-<table class="table table-scroll">
-  ...
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered">
+        ...
+    </table>
+</div>
 {% endhighlight %}
 
 ### Responsive Scrolling
 
-Table scrolling is also available in responsive variants of the form `.table-scroll-*-down`, where the table will horizontally scroll when the table is wider than it's container and when the viewport is at the given breakpoint or smaller.
+Table scrolling is also available in responsive variants of the form `.table-scroll-*`, where the table will horizontally scroll when the table is wider than it's container and when the viewport is at the given breakpoint or smaller.
 
 Responsive variants are:
-- `.table-scroll-xs-down`
-- `.table-scroll-sm-down`
-- `.table-scroll-md-down`
-- `.table-scroll-lg-down`
+- `.table-scroll-xs`
+- `.table-scroll-sm`
+- `.table-scroll-md`
+- `.table-scroll-lg`
 
-**Heads up!** There is no `.table-scroll-*-down` class created for the largest breakpoint, `.table-scroll-xl-down`, since it is functionally equivalent to using `.table-scroll`.
+**Heads up!** There is no `.table-scroll-*` class created for the largest breakpoint, `.table-scroll-xl`, since it is functionally equivalent to using `.table-scroll`.
 
-{% example html %}
-  <table class="table table-scroll-md-down">
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-        <th scope="col">Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th scope="row">1</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">2</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <th scope="row">3</th>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <th></th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-        <th>Table footer</th>
-      </tr>
-    </tfoot>
-  </table>
-{% endexample %}
+<div class="cf-example">
+  <div class="table-scroll-xs">
+    <table class="table table-bordered text-nowrap">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Header 1</th>
+          <th scope="col">Header 2</th>
+          <th scope="col">Header 3</th>
+          <th scope="col">Header 4</th>
+          <th scope="col">Header 5</th>
+          <th scope="col">Header 6</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th>Footer 1</th>
+          <th>Footer 2</th>
+          <th>Footer 3</th>
+          <th>Footer 4</th>
+          <th>Footer 5</th>
+          <th>Footer 6</th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <div class="table-scroll-sm">
+    <table class="table table-bordered text-nowrap">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Header 1</th>
+          <th scope="col">Header 2</th>
+          <th scope="col">Header 3</th>
+          <th scope="col">Header 4</th>
+          <th scope="col">Header 5</th>
+          <th scope="col">Header 6</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th>Footer 1</th>
+          <th>Footer 2</th>
+          <th>Footer 3</th>
+          <th>Footer 4</th>
+          <th>Footer 5</th>
+          <th>Footer 6</th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <div class="table-scroll-md">
+    <table class="table table-bordered text-nowrap">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Header 1</th>
+          <th scope="col">Header 2</th>
+          <th scope="col">Header 3</th>
+          <th scope="col">Header 4</th>
+          <th scope="col">Header 5</th>
+          <th scope="col">Header 6</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th>Footer 1</th>
+          <th>Footer 2</th>
+          <th>Footer 3</th>
+          <th>Footer 4</th>
+          <th>Footer 5</th>
+          <th>Footer 6</th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <div class="table-scroll-lg">
+    <table class="table table-bordered text-nowrap">
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Header 1</th>
+          <th scope="col">Header 2</th>
+          <th scope="col">Header 3</th>
+          <th scope="col">Header 4</th>
+          <th scope="col">Header 5</th>
+          <th scope="col">Header 6</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">1</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">2</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+        <tr>
+          <th scope="row">3</th>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+          <td>Cell</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th></th>
+          <th>Footer 1</th>
+          <th>Footer 2</th>
+          <th>Footer 3</th>
+          <th>Footer 4</th>
+          <th>Footer 5</th>
+          <th>Footer 6</th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>
+
+{% highlight html %}
+<div class="table-scroll-xs">
+    <table class="table table-bordered">
+        ...
+    </table>
+</div>
+
+<div class="table-scroll-sm">
+    <table class="table table-bordered">
+        ...
+    </table>
+</div>
+
+<div class="table-scroll-md">
+    <table class="table table-bordered">
+        ...
+    </table>
+</div>
+
+<div class="table-scroll-lg">
+    <table class="table table-bordered">
+        ...
+    </table>
+</div>
+{% endhighlight %}
+

--- a/docs/content/typography.md
+++ b/docs/content/typography.md
@@ -226,36 +226,38 @@ Possible drawbacks include:
 
 ### Common Settings
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td><code>$responsive-font-size-minimum-size</code></td>
-        <td>font size in <code>px</code> or <code>rem</code></td>
-        <td>1em</td>
-        <td>
-            <p>Calculated font sizes will never be smaller than this size. However, you can still pass a smaller font size, but then it won't be responsively sized.</p>
-            <p>For example: <code>font-size(1.5rem)</code> will trigger responsive sizing, with <code>font-size(.875rem)</code> will remain staticly sized at <code>.875rem</code>.</p>
-        </td>
-    </tr>
-    <tr>
-        <td><code>$responsive-font-size-generate-static</code></td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>
-            <p>Generates the <code>.font-size-static</code> utility classes to disable the responsive font sizes for an element and it's descendant elements. This does not apply to font sizes which are inherited from parent elements.</p>
-            <p>If you are not using these utilities, it would be worthwhile to disable this setting to stop the generation of a potentially large amount of unused CSS.</p>
-        </td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$responsive-font-size-minimum-size</code></td>
+                <td>font size in <code>px</code> or <code>rem</code></td>
+                <td>1em</td>
+                <td>
+                    <p>Calculated font sizes will never be smaller than this size. However, you can still pass a smaller font size, but then it won't be responsively sized.</p>
+                    <p>For example: <code>font-size(1.5rem)</code> will trigger responsive sizing, with <code>font-size(.875rem)</code> will remain staticly sized at <code>.875rem</code>.</p>
+                </td>
+            </tr>
+            <tr>
+                <td><code>$responsive-font-size-generate-static</code></td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>
+                    <p>Generates the <code>.font-size-static</code> utility classes to disable the responsive font sizes for an element and it's descendant elements. This does not apply to font sizes which are inherited from parent elements.</p>
+                    <p>If you are not using these utilities, it would be worthwhile to disable this setting to stop the generation of a potentially large amount of unused CSS.</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Fluid Responsive Typography
 
@@ -284,37 +286,38 @@ Will generate the CSS output:
 
 #### Settings
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td><code>$responsive-font-size-fluid-breakpoint</code></td>
-        <td><code>em</code> unit breakpoint dimension</td>
-        <td>75em</td>
-        <td>Above this breakpoint, the font size will be equal to the font size you passed to the mixin; below the breakpoint, the font size will dynamically scale.</td>
-    </tr>
-    <tr>
-        <td><code>$responsive-font-size-fluid-factor</code></td>
-        <td>integer</td>
-        <td>5</td>
-        <td>This value determines the strength of font size resizing. The higher $rfs-factor, the less difference there is between font sizes on small screens. The lower the factor, the less influence the responsive scaling has, which results in bigger font sizes for small screens. <code>$responsive-font-size-fluid-factor</code> must be greater than 1, and setting it to 1 will disable responsive scaling.</td>
-    </tr>
-    <tr>
-        <td><code>$responsive-font-size-fluid-two-dimensional</code></td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Enabling the two dimensional media queries will determine the font size based on the smallest side of the screen with <code>vmin</code>. This prevents the font size from changing if the device toggles between portrait and landscape mode.</td>
-    </tr>
-</tbody>
-</table>
-
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$responsive-font-size-fluid-breakpoint</code></td>
+                <td><code>em</code> unit breakpoint dimension</td>
+                <td>75em</td>
+                <td>Above this breakpoint, the font size will be equal to the font size you passed to the mixin; below the breakpoint, the font size will dynamically scale.</td>
+            </tr>
+            <tr>
+                <td><code>$responsive-font-size-fluid-factor</code></td>
+                <td>integer</td>
+                <td>5</td>
+                <td>This value determines the strength of font size resizing. The higher $rfs-factor, the less difference there is between font sizes on small screens. The lower the factor, the less influence the responsive scaling has, which results in bigger font sizes for small screens. <code>$responsive-font-size-fluid-factor</code> must be greater than 1, and setting it to 1 will disable responsive scaling.</td>
+            </tr>
+            <tr>
+                <td><code>$responsive-font-size-fluid-two-dimensional</code></td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Enabling the two dimensional media queries will determine the font size based on the smallest side of the screen with <code>vmin</code>. This prevents the font size from changing if the device toggles between portrait and landscape mode.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 #### Safari Issue
 There is a known issue with Safari where it does not always recalculate the value of vw in a calc()-function for font-sizes in iframes.

--- a/docs/get-started/browsers-devices.md
+++ b/docs/get-started/browsers-devices.md
@@ -41,82 +41,86 @@ browsers: [
 
 Generally speaking, Figuration supports the latest versions of each major platform's default browsers. Note that proxy browsers (such as Opera Mini, Opera Mobile's Turbo mode, UC Browser Mini, Amazon Silk) are not supported.
 
-<table class="table table-scroll table-bordered table-striped">
-  <thead>
-    <tr>
-      <td></td>
-      <th>Chrome</th>
-      <th>Firefox</th>
-      <th>Safari</th>
-      <th>Android Browser &amp; WebView</th>
-      <th>Microsoft Edge</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">Android</th>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-success">Android v5.0+ supported</td>
-      <td class="text-success">Supported</td>
-    </tr>
-    <tr>
-      <th scope="row">iOS</th>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-success">Supported</td>
-    </tr>
-    <tr>
-      <th scope="row">Windows 10 Mobile</th>
-      <td class="text-muted">N/A</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-success">Supported</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <td></td>
+                <th>Chrome</th>
+                <th>Firefox</th>
+                <th>Safari</th>
+                <th>Android Browser &amp; WebView</th>
+                <th>Microsoft Edge</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">Android</th>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-success">Android v5.0+ supported</td>
+                <td class="text-success">Supported</td>
+            </tr>
+            <tr>
+                <th scope="row">iOS</th>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-success">Supported</td>
+            </tr>
+            <tr>
+                <th scope="row">Windows 10 Mobile</th>
+                <td class="text-muted">N/A</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-success">Supported</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Desktop Browsers
 
 Similarly, the latest versions of most desktop browsers are supported.
 
-<table class="table table-scroll table-bordered table-striped">
-  <thead>
-    <tr>
-      <td></td>
-      <th>Chrome</th>
-      <th>Firefox</th>
-      <th>Internet Explorer</th>
-      <th>Microsoft Edge</th>
-      <th>Opera</th>
-      <th>Safari</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row">Mac</th>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-muted">N/A</td>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-    </tr>
-    <tr>
-      <th scope="row">Windows</th>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported, IE11+</td>
-      <td class="text-success">Supported</td>
-      <td class="text-success">Supported</td>
-      <td class="text-danger">Not supported</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <td></td>
+                <th>Chrome</th>
+                <th>Firefox</th>
+                <th>Internet Explorer</th>
+                <th>Microsoft Edge</th>
+                <th>Opera</th>
+                <th>Safari</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">Mac</th>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-muted">N/A</td>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+            </tr>
+            <tr>
+                <th scope="row">Windows</th>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported, IE11+</td>
+                <td class="text-success">Supported</td>
+                <td class="text-success">Supported</td>
+                <td class="text-danger">Not supported</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 For Firefox, in addition to the latest normal stable release, we also support the latest [Extended Support Release (ESR)](https://www.mozilla.org/en-US/firefox/organizations/faq/) version of Firefox.
 

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -65,76 +65,78 @@ See how aspects of the Figuration grid system work across multiple devices with 
 
 The example pixel values are calculated based upon assumption where the average user has a 16px root font size.
 
-<table class="table table-scroll table-bordered table-striped">
-  <thead>
-    <tr>
-      <th></th>
-      <th class="text-center">
-        Extra small<br>
-        <small>&lt;576px</small><br>
-        <small>&lt;36em</small>
-      </th>
-      <th class="text-center">
-        Small<br>
-        <small>&ge;576px</small><br>
-        <small>&ge;36em</small>
-      </th>
-      <th class="text-center">
-        Medium<br>
-        <small>&ge;768px</small><br>
-        <small>&ge;48em</small>
-      </th>
-      <th class="text-center">
-        Large<br>
-        <small>&ge;992px</small><br>
-        <small>&ge;62em</small>
-      </th>
-      <th class="text-center">
-        Extra large<br>
-        <small>&ge;1200px</small><br>
-        <small>&ge;75em</small>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th class="text-nowrap" scope="row">Max container width</th>
-      <td>None (auto)</td>
-      <td>544px (33.75rem)</td>
-      <td>720px (45rem)</td>
-      <td>960px (60rem)</td>
-      <td>1152px (72rem)</td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row">Class prefix</th>
-      <td><code>.col-</code></td>
-      <td><code>.col-sm-</code></td>
-      <td><code>.col-md-</code></td>
-      <td><code>.col-lg-</code></td>
-      <td><code>.col-xl-</code></td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row"># of columns</th>
-      <td colspan="5">12</td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row">Gutter width</th>
-      <td colspan="5">2rem / 32px (16px on each side of a column)</td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row">Nestable</th>
-      <td colspan="5">Yes</td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row">Offsets</th>
-      <td colspan="5">Yes</td>
-    </tr>
-    <tr>
-      <th class="text-nowrap" scope="row">Column ordering</th>
-      <td colspan="5">Yes</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th></th>
+                <th class="text-center">
+                    Extra small<br>
+                    <small>&lt;576px</small><br>
+                    <small>&lt;36em</small>
+                </th>
+                <th class="text-center">
+                    Small<br>
+                    <small>&ge;576px</small><br>
+                    <small>&ge;36em</small>
+                </th>
+                <th class="text-center">
+                    Medium<br>
+                    <small>&ge;768px</small><br>
+                    <small>&ge;48em</small>
+                </th>
+                <th class="text-center">
+                    Large<br>
+                    <small>&ge;992px</small><br>
+                    <small>&ge;62em</small>
+                </th>
+                <th class="text-center">
+                    Extra large<br>
+                    <small>&ge;1200px</small><br>
+                    <small>&ge;75em</small>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th class="text-nowrap" scope="row">Max container width</th>
+                <td>None (auto)</td>
+                <td>544px (33.75rem)</td>
+                <td>720px (45rem)</td>
+                <td>960px (60rem)</td>
+                <td>1152px (72rem)</td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row">Class prefix</th>
+                <td><code>.col-</code></td>
+                <td><code>.col-sm-</code></td>
+                <td><code>.col-md-</code></td>
+                <td><code>.col-lg-</code></td>
+                <td><code>.col-xl-</code></td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row"># of columns</th>
+                <td colspan="5">12</td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row">Gutter width</th>
+                <td colspan="5">2rem / 32px (16px on each side of a column)</td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row">Nestable</th>
+                <td colspan="5">Yes</td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row">Offsets</th>
+                <td colspan="5">Yes</td>
+            </tr>
+            <tr>
+                <th class="text-nowrap" scope="row">Column ordering</th>
+                <td colspan="5">Yes</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ## Auto-Layout Columns
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -17,7 +17,7 @@ Some changes will most likely have been missed, so please refer to the documenta
 
 ## Color
 - Reworked the colors, internal palette system, and consolidated the re-used component colors.
-- Added functions to check, and/or determine the best color, these can be found in '/scss/functions/_color-util.scss`.
+- Added functions to check, and/or determine the best color, these can be found in '/scss/functions/_color-util.scss'.
 - Extended the contextual colors with light and dark contextual variants.  **These variants are not available** as palettes by default.
 
 ## Typography
@@ -25,6 +25,11 @@ Some changes will most likely have been missed, so please refer to the documenta
   - Ratio scaling - variable sizing based on viewport dimension
   - Stepped scaling - one defined size per breakpoint
 - Inline lists, `.list-inline`, has been dropped and replaced with the `.list-horizontal` modifier in the new [List component]({{ site.baseurl }}/components/lists/).
+
+## Table
+- `.table` now creates a visually simple table, borders are controlled through a selection of modifier classes.
+- `.table-hover` and `.table-striped` now use a solid gradient color overlayed using `background-image` to create their visual state.
+- `.table-scroll-*` has dropped the `down` portion of the class name, and is now meant to used as a wrapper to prevent conflict with screen-readers due to the use of `display: block`.
 
 {% comment %}
 ## Sizing
@@ -38,10 +43,10 @@ Some changes will most likely have been missed, so please refer to the documenta
 ### Breadbcrumb
 - Removed `padding`, `background-color` and `border-radius` from parent `.breadcrumb` element.
 
-### Buttons
+### Button
 - Added support for CSS checkbox and radio buttons, using `.btn-check` and `.btn-check-input` classes.
 
-### Cards
+### Card
 - Contextually colored cards have been removed. Now you will need to use the with text, background, and border color utilities.
 - Cards have been converted to flexbox layout.
 - Images now need to be wrapped with `.card-img` to keep aspect ratio and scaling in check due to flexbox.
@@ -49,7 +54,7 @@ Some changes will most likely have been missed, so please refer to the documenta
 ### List Group
 - The List Group is no longer a stand-alone component, and is now modifier within the new [List component]({{ site.baseurl }}/components/lists/).
 
-### Lists
+### List
 - A new component that allows for greater styling options for lists, or pseudo-lists using `<div>`s.
 
 ## Utilities

--- a/docs/utilities/display.md
+++ b/docs/utilities/display.md
@@ -66,107 +66,109 @@ Try to use these on a limited basis and avoid creating entirely different versio
 
 **Heads up!** There is no `.d-*-down-none` class created for the largest breakpoint, `.d-xl-down-none`, since it is functionally equivalent to using `.d-none`.
 
-<table class="table table-scroll table-bordered responsive-utilities">
-  <thead>
-    <tr>
-      <th></th>
-      <th>
-        Extra small devices
-        <small>Portrait phones (&lt;576px)</small>
-      </th>
-      <th>
-        Small devices
-        <small>Landscape phones (&ge;576px - &lt;768px)</small>
-      </th>
-      <th>
-        Medium devices
-        <small>Tablets (&ge;768px - &lt;992px)</small>
-      </th>
-      <th>
-        Large devices
-        <small>Desktops (&ge;992px - &lt;1200px)</small>
-      </th>
-      <th>
-        Extra large devices
-        <small>Desktops (&ge;1200px)</small>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th scope="row"><code>.d-xs-down-none</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-sm-down-none</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-md-down-none</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-lg-down-none</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-none</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-sm-none</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-md-none</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-lg-none</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-    <tr>
-      <th scope="row"><code>.d-xl-none</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered responsive-utilities">
+        <thead>
+            <tr>
+                <th></th>
+                <th>
+                    Extra small devices
+                    <small>Portrait phones (&lt;576px)</small>
+                </th>
+                <th>
+                    Small devices
+                    <small>Landscape phones (&ge;576px - &lt;768px)</small>
+                </th>
+                <th>
+                    Medium devices
+                    <small>Tablets (&ge;768px - &lt;992px)</small>
+                </th>
+                <th>
+                    Large devices
+                    <small>Desktops (&ge;992px - &lt;1200px)</small>
+                </th>
+                <th>
+                    Extra large devices
+                    <small>Desktops (&ge;1200px)</small>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row"><code>.d-xs-down-none</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-sm-down-none</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-md-down-none</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-lg-down-none</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-none</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-sm-none</code></th>
+                <td class="is-visible">Visible</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-md-none</code></th>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-lg-none</code></th>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+            <tr>
+                <th scope="row"><code>.d-xl-none</code></th>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-visible">Visible</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Test Cases
 
@@ -243,49 +245,51 @@ Green checkmarks indicate the element **is visible** in your current viewport.
 
 These utilities only affect the `display` property.  You will need to take into account any other CSS properties, such as `visibility`, that might cause issues for the print layout.
 
-<table class="table table-scroll table-bordered responsive-utilities">
-  <thead>
-    <tr>
-      <th>Class</th>
-      <th>Screen</th>
-      <th>Print</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th><code>.print-only-block</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
-    </tr>
-    <tr>
-      <th><code>.print-only-inline</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
-    </tr>
-    <tr>
-      <th><code>.print-only-inline-block</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
-    </tr>
-    <tr>
-      <th><code>.print-hide</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-    </tr>
-    <tr>
-      <th><code>.print-show-block</code></th>
-      <td>Any</td>
-      <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
-    </tr>
-    <tr>
-      <th><code>.print-show-inline</code></th>
-      <td>Any</td>
-      <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
-    </tr>
-    <tr>
-      <th><code>.print-show-inline-block</code></th>
-      <td>Any</td>
-      <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
-    </tr>
-  </tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered responsive-utilities">
+        <thead>
+            <tr>
+                <th>Class</th>
+                <th>Screen</th>
+                <th>Print</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th><code>.print-only-block</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
+            </tr>
+            <tr>
+                <th><code>.print-only-inline</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
+            </tr>
+            <tr>
+                <th><code>.print-only-inline-block</code></th>
+                <td class="is-hidden">Hidden</td>
+                <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
+            </tr>
+            <tr>
+                <th><code>.print-hide</code></th>
+                <td class="is-visible">Visible</td>
+                <td class="is-hidden">Hidden</td>
+            </tr>
+            <tr>
+                <th><code>.print-show-block</code></th>
+                <td>Any</td>
+                <td class="is-visible">Visible<br>(as <code>display: block</code>)</td>
+            </tr>
+            <tr>
+                <th><code>.print-show-inline</code></th>
+                <td>Any</td>
+                <td class="is-visible">Visible<br>(as <code>display: inline</code>)</td>
+            </tr>
+            <tr>
+                <th><code>.print-show-inline-block</code></th>
+                <td>Any</td>
+                <td class="is-visible">Visible<br>(as <code>display: inline-block</code>)</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/widgets/accordion.md
+++ b/docs/widgets/accordion.md
@@ -125,17 +125,19 @@ Event callbacks happen on the accordion element.
 
 You can also get the collapse events as indicated in the [Collapse widget]({{ site.baseurl}}/widgets/collapse/) due to event bubbling.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td><code>init.cfw.accordion</code></td>
-        <td>This event fires after the accordion item is initialized.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>init.cfw.accordion</code></td>
+                <td>This event fires after the accordion item is initialized.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/widgets/affix.md
+++ b/docs/widgets/affix.md
@@ -58,36 +58,38 @@ $('#myAffix').CFW_Affix({
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-affix-`, as in `data-cfw-affix-top="200"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 100px;">type</th>
-        <th style="width: 50px;">default</th>
-        <th>description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>top</td>
-        <td>number | function</td>
-        <td>0</td>
-        <td>Pixel offset from top of the `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
-    </tr>
-    <tr>
-        <td>bottom</td>
-        <td>number | function</td>
-        <td>0</td>
-        <td>Pixel offset from bottom of `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
-    </tr>
-    <tr>
-        <td>target</td>
-        <td>selector | node | jQuery element</td>
-        <td>the `window` object</td>
-        <td>Specifies the target element of the affix.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 100px;">type</th>
+                <th style="width: 50px;">default</th>
+                <th>description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>top</td>
+                <td>number | function</td>
+                <td>0</td>
+                <td>Pixel offset from top of the `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
+            </tr>
+            <tr>
+                <td>bottom</td>
+                <td>number | function</td>
+                <td>0</td>
+                <td>Pixel offset from bottom of `window` or `target` when calculating position of scroll. Use a function when you need to dynamically calculate an offset.</td>
+            </tr>
+            <tr>
+                <td>target</td>
+                <td>selector | node | jQuery element</td>
+                <td>the `window` object</td>
+                <td>Specifies the target element of the affix.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -120,44 +122,46 @@ Disables the affix functionality and removes any `.affix`, `.affix-top`, or `.af
 
 CFW's affix widget exposes a few events for hooking into affix functionality.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.affix</td>
-        <td>This event is fired after the affix element has been initialized.</td>
-    </tr>
-    <tr>
-        <td>affix.cfw.affix</td>
-        <td>This event is immediately before after the element is affixed.</td>
-    </tr>
-    <tr>
-        <td>affixed.cfw.affix</td>
-        <td>This event is after after the element has been affixed.</td>
-    </tr>
-    <tr>
-        <td>affix-top.cfw.affix</td>
-        <td>This event is fired immediately before the element is affixed-top.</td>
-    </tr>
-    <tr>
-        <td>affixed-top.cfw.affix</td>
-        <td>This event is fired after the element has been affixed-top.</td>
-    </tr>
-    <tr>
-        <td>affix-bottom.cfw.affix</td>
-        <td>This event is immediately before after the element is affixed-bottom.</td>
-    </tr>
-    <tr>
-        <td>affixed-bottom.cfw.affix</td>
-        <td>This event is fired after the element has been affixed-bottom.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.affix</td>
+                <td>This event is fired after the affix element has been initialized.</td>
+            </tr>
+            <tr>
+                <td>affix.cfw.affix</td>
+                <td>This event is immediately before after the element is affixed.</td>
+            </tr>
+            <tr>
+                <td>affixed.cfw.affix</td>
+                <td>This event is after after the element has been affixed.</td>
+            </tr>
+            <tr>
+                <td>affix-top.cfw.affix</td>
+                <td>This event is fired immediately before the element is affixed-top.</td>
+            </tr>
+            <tr>
+                <td>affixed-top.cfw.affix</td>
+                <td>This event is fired after the element has been affixed-top.</td>
+            </tr>
+            <tr>
+                <td>affix-bottom.cfw.affix</td>
+                <td>This event is immediately before after the element is affixed-bottom.</td>
+            </tr>
+            <tr>
+                <td>affixed-bottom.cfw.affix</td>
+                <td>This event is fired after the element has been affixed-bottom.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myAffix').on('affix.cfw.affix', function () {

--- a/docs/widgets/alert.md
+++ b/docs/widgets/alert.md
@@ -64,30 +64,32 @@ $(".alert").CFW_Alert();
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-alert`, as in `data-cfw-alert-animate="false"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target item to be dismissed.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If alert targets should fade out.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target item to be dismissed.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If alert targets should fade out.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -116,24 +118,26 @@ Removes the click event listener from a trigger. This will not disable a dismiss
 
 Event callbacks happen on the target alert container.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>beforeClose.cfw.alert</td>
-        <td>This event is fired immediately when the <code>close</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterClose.cfw.alert</td>
-        <td>This event is fired when an alert has been closed (will wait for CSS transitions to complete).</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>beforeClose.cfw.alert</td>
+                <td>This event is fired immediately when the <code>close</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterClose.cfw.alert</td>
+                <td>This event is fired when an alert has been closed (will wait for CSS transitions to complete).</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myAlert').on('beforeClose.cfw.alert', function () {

--- a/docs/widgets/collapse.md
+++ b/docs/widgets/collapse.md
@@ -96,42 +96,44 @@ $('#myCollapse').CFW_Collapse();
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-collapse`, as in `data-cfw-collapse-animate="false"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target collapse item.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If collapse targets should expand and contract.</td>
-    </tr>
-    <tr>
-        <td>follow</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If browser focus should move when a collapse trigger is activated.</td>
-    </tr>
-    <tr>
-        <td>horizontal</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Use a horizontal transition instead of the default vertical transition.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target collapse item.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If collapse targets should expand and contract.</td>
+            </tr>
+            <tr>
+                <td>follow</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If browser focus should move when a collapse trigger is activated.</td>
+            </tr>
+            <tr>
+                <td>horizontal</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Use a horizontal transition instead of the default vertical transition.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -171,36 +173,38 @@ Disables the collapse control functionality for a given element, leaving the col
 
 Event callbacks happen on the toggle/trigger element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.collapse</td>
-        <td>This event fires after the collapse item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.collapse</td>
-        <td>This event is fired immediately when the <code>show</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.collapse</td>
-        <td>This event is fired when a collapse element has been made visible to the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.collapse</td>
-        <td>This event is fired immediately when the <code>hide</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.collapse</td>
-        <td>This event is fired when a collapse element has been hidden from the user (will wait for CSS transitions to complete).</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.collapse</td>
+                <td>This event fires after the collapse item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.collapse</td>
+                <td>This event is fired immediately when the <code>show</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.collapse</td>
+                <td>This event is fired when a collapse element has been made visible to the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.collapse</td>
+                <td>This event is fired immediately when the <code>hide</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.collapse</td>
+                <td>This event is fired when a collapse element has been hidden from the user (will wait for CSS transitions to complete).</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myCollapse').on('afterHide.cfw.collapse', function () {

--- a/docs/widgets/drag.md
+++ b/docs/widgets/drag.md
@@ -33,27 +33,29 @@ $('#myDrag').CFW_Drag({
 
 Options can be passed via JavaScript.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>handle</td>
-        <td>integer</td>
-        <td>null</td>
-        <td>
-            <p>The selector (jQuery style) for the element where dragging is allow to begin.</p>
-            <p>The handle must be a descendant of the element where the drag is attached.</p>
-        </td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>handle</td>
+                <td>integer</td>
+                <td>null</td>
+                <td>
+                    <p>The selector (jQuery style) for the element where dragging is allow to begin.</p>
+                    <p>The handle must be a descendant of the element where the drag is attached.</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -71,32 +73,34 @@ Disables the drag functionality.
 
 Event callbacks happen on the item where the drag is attached.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.drag</td>
-        <td>This event fires after the drag widget is initialized.</td>
-    </tr>
-    <tr>
-        <td>dragStart.cfw.drag</td>
-        <td>This event fires when the drag item or handle is activated.</td>
-    </tr>
-    <tr>
-        <td>drag.cfw.drag</td>
-        <td>This event fires as the item is being moved.</td>
-    </tr>
-    <tr>
-        <td>dragEnd.cfw.drag</td>
-        <td>This event fires when the drag item or handle is released.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.drag</td>
+                <td>This event fires after the drag widget is initialized.</td>
+            </tr>
+            <tr>
+                <td>dragStart.cfw.drag</td>
+                <td>This event fires when the drag item or handle is activated.</td>
+            </tr>
+            <tr>
+                <td>drag.cfw.drag</td>
+                <td>This event fires as the item is being moved.</td>
+            </tr>
+            <tr>
+                <td>dragEnd.cfw.drag</td>
+                <td>This event fires when the drag item or handle is released.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myDrag').on('drag.cfw.drag', function () {
@@ -108,53 +112,55 @@ $('#myDrag').on('drag.cfw.drag', function () {
 
 Each event callback, except for `init.cfw.drag`, returns the following additional properties.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Name</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>startX</td>
-        <td>The horizontal location of the <code>dragStart.cfw.drag</code> event.</td>
-    </tr>
-    <tr>
-        <td>startY</td>
-        <td>The vertical location of the <code>dragStart.cfw.drag</code> event.</td>
-    </tr>
-    <tr>
-        <td>pageX</td>
-        <td>The horizontal location of the <code>drag.cfw.drag</code> event.</td>
-    </tr>
-    <tr>
-        <td>pageY</td>
-        <td>The vertical location of the <code>drag.cfw.drag</code> event.</td>
-    </tr>
-    <tr>
-        <td>deltaX</td>
-        <td>The horizontal distance moved from <code>startX</code>.</td>
-    </tr>
-    <tr>
-        <td>deltaY</td>
-        <td>The vertical distance moved from <code>startX</code>.</td>
-    </tr>
-    <tr>
-        <td>originalX</td>
-        <td>The starting horizontal position of the drag "target" element..</td>
-    </tr>
-    <tr>
-        <td>originalY</td>
-        <td>The starting vertical position of the drag "target" element.</td>
-    </tr>
-    <tr>
-        <td>offsetX</td>
-        <td>The moved horizontal position of the drag "target" element..</td>
-    </tr>
-    <tr>
-        <td>offsetY</td>
-        <td>The moved vertical position of the drag "target" element.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Name</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>startX</td>
+                <td>The horizontal location of the <code>dragStart.cfw.drag</code> event.</td>
+            </tr>
+            <tr>
+                <td>startY</td>
+                <td>The vertical location of the <code>dragStart.cfw.drag</code> event.</td>
+            </tr>
+            <tr>
+                <td>pageX</td>
+                <td>The horizontal location of the <code>drag.cfw.drag</code> event.</td>
+            </tr>
+            <tr>
+                <td>pageY</td>
+                <td>The vertical location of the <code>drag.cfw.drag</code> event.</td>
+            </tr>
+            <tr>
+                <td>deltaX</td>
+                <td>The horizontal distance moved from <code>startX</code>.</td>
+            </tr>
+            <tr>
+                <td>deltaY</td>
+                <td>The vertical distance moved from <code>startX</code>.</td>
+            </tr>
+            <tr>
+                <td>originalX</td>
+                <td>The starting horizontal position of the drag "target" element..</td>
+            </tr>
+            <tr>
+                <td>originalY</td>
+                <td>The starting vertical position of the drag "target" element.</td>
+            </tr>
+            <tr>
+                <td>offsetX</td>
+                <td>The moved horizontal position of the drag "target" element..</td>
+            </tr>
+            <tr>
+                <td>offsetY</td>
+                <td>The moved vertical position of the drag "target" element.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -560,63 +560,65 @@ $('#myDropdown').CFW_Dropdown();
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-dropdown`, as in `data-cfw-dropdown-backlink="true"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>Either the selector (jQuery style), or the string related to the target dropdown having a <code>data-cfw-dropdown-target</code> attribute.</td>
-    </tr>
-    <tr>
-        <td>delay</td>
-        <td>integer</td>
-        <td>350</td>
-        <td>Delay for hiding menu on loss of focus or hover when not in click only mode (milliseconds).</td>
-    </tr>
-    <tr>
-        <td>hover</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If hover style navigation should be enabled in addition to click/key navigation.  If a touch capable device is found, this setting is overruled.</td>
-    </tr>
-    <tr>
-        <td>backlink</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Insert back links into submenus.</td>
-    </tr>
-    <tr>
-        <td>backtop</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If back links should be applied at the top level menu as opposed to only submenus.</td>
-    </tr>
-    <tr>
-        <td>backtext</td>
-        <td>string</td>
-        <td>Back</td>
-        <td>Text to be used for back links.</td>
-    </tr>
-    <tr>
-        <td>container</td>
-        <td>string | false</td>
-        <td>false</td>
-        <td>
-            <p>Appends the dropdown menu to a specific element. Example: <code>container: 'body'</code></p>
-            <p>This does not apply when the dropdown is inside of a `.navbar-collapse`.</p>
-        </td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>Either the selector (jQuery style), or the string related to the target dropdown having a <code>data-cfw-dropdown-target</code> attribute.</td>
+            </tr>
+            <tr>
+                <td>delay</td>
+                <td>integer</td>
+                <td>350</td>
+                <td>Delay for hiding menu on loss of focus or hover when not in click only mode (milliseconds).</td>
+            </tr>
+            <tr>
+                <td>hover</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If hover style navigation should be enabled in addition to click/key navigation.  If a touch capable device is found, this setting is overruled.</td>
+            </tr>
+            <tr>
+                <td>backlink</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Insert back links into submenus.</td>
+            </tr>
+            <tr>
+                <td>backtop</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If back links should be applied at the top level menu as opposed to only submenus.</td>
+            </tr>
+            <tr>
+                <td>backtext</td>
+                <td>string</td>
+                <td>Back</td>
+                <td>Text to be used for back links.</td>
+            </tr>
+            <tr>
+                <td>container</td>
+                <td>string | false</td>
+                <td>false</td>
+                <td>
+                    <p>Appends the dropdown menu to a specific element. Example: <code>container: 'body'</code></p>
+                    <p>This does not apply when the dropdown is inside of a `.navbar-collapse`.</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -655,36 +657,38 @@ Hides the root menu element and disconnect all the event listeners and data from
 
 Event callbacks for the root menu happen on the toggle element. Callbacks for the submenus occur on the submenu's sibling anchor (toggle).
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.dropdown</td>
-        <td>This event fires after the menu item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.dropdown</td>
-        <td>This event is fired immediately when the internal <code>showMenu</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.dropdown</td>
-        <td>This event is fired when a menu element has been made visible to the user.</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.dropdown</td>
-        <td>This event is fired immediately when the internal <code>hideMenu</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.dropdown</td>
-        <td>This event is fired when a menu element has been hidden from the user.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.dropdown</td>
+                <td>This event fires after the menu item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.dropdown</td>
+                <td>This event is fired immediately when the internal <code>showMenu</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.dropdown</td>
+                <td>This event is fired when a menu element has been made visible to the user.</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.dropdown</td>
+                <td>This event is fired immediately when the internal <code>hideMenu</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.dropdown</td>
+                <td>This event is fired when a menu element has been hidden from the user.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#mDropdown').on('afterHide.cfw.dropdown', function () {

--- a/docs/widgets/equalize.md
+++ b/docs/widgets/equalize.md
@@ -216,51 +216,53 @@ $('#myContainer').CFW_Equalize({
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-equalize`, as in `data-cfw-equalize-stack=false`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>
-            <p>Either the selector (jQuery style), or the string related to the target containers having a <code>data-cfw-equalize-group</code> attribute.</p>
-            <p>The containers to be equalized are scoped by the calling container, so same selector/groupID can be resused if needed.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>throttle</td>
-        <td>integer</td>
-        <td>250</td>
-        <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through resize events.</td>
-    </tr>
-    <tr>
-        <td>stack</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Whether or not the specified containers should be equalized in height when they become stacked, either due to responsive reflow, or wrapping.  Otherwise, the specified containers all need to have the same top offset in order to be equalized.</td>
-    </tr>
-    <tr>
-        <td>row</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Whether or not the specified containers should be equalized in height by rows, by determining each container in a row by their top offset.</td>
-    </tr>
-    <tr>
-        <td>minimum</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If set to true, the specified containers will be equalized to the shortest container.  In this case, you may want to use <code>overflow: hidden;</code> to deal with the overflowing content.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>
+                    <p>Either the selector (jQuery style), or the string related to the target containers having a <code>data-cfw-equalize-group</code> attribute.</p>
+                    <p>The containers to be equalized are scoped by the calling container, so same selector/groupID can be resused if needed.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>throttle</td>
+                <td>integer</td>
+                <td>250</td>
+                <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through resize events.</td>
+            </tr>
+            <tr>
+                <td>stack</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Whether or not the specified containers should be equalized in height when they become stacked, either due to responsive reflow, or wrapping.  Otherwise, the specified containers all need to have the same top offset in order to be equalized.</td>
+            </tr>
+            <tr>
+                <td>row</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Whether or not the specified containers should be equalized in height by rows, by determining each container in a row by their top offset.</td>
+            </tr>
+            <tr>
+                <td>minimum</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If set to true, the specified containers will be equalized to the shortest container.  In this case, you may want to use <code>overflow: hidden;</code> to deal with the overflowing content.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -289,28 +291,30 @@ Remove the data and global event listener for a given instance of equalize.  Thi
 
 Event callbacks happen on the parent equalize element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.equalize</td>
-        <td>This event fires after the equalize widget is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeEqual.cfw.equalize</td>
-        <td>This event fires before the container heights are reset and the heights are adjusted.</td>
-    </tr>
-    <tr>
-        <td>afterEqual.cfw.equalize</td>
-        <td>This event fires after the container heights are adjusted.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.equalize</td>
+                <td>This event fires after the equalize widget is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeEqual.cfw.equalize</td>
+                <td>This event fires before the container heights are reset and the heights are adjusted.</td>
+            </tr>
+            <tr>
+                <td>afterEqual.cfw.equalize</td>
+                <td>This event fires after the container heights are adjusted.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myContainer').on('afterEqual.cfw.equalize', function () {

--- a/docs/widgets/lazy.md
+++ b/docs/widgets/lazy.md
@@ -61,78 +61,80 @@ $('#myImg').CFW_Lazy();
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-lazy`, as in `data-cfw-lazy-src=image.png`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>src</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The URL or path for the source image to be displayed.</td>
-    </tr>
-    <tr>
-        <td>throttle</td>
-        <td>integer</td>
-        <td>250</td>
-        <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll or resize events.</td>
-    </tr>
-    <tr>
-        <td>trigger</td>
-        <td>string</td>
-        <td>'scroll resize'</td>
-        <td>
-            <p>How lazy load is triggered. You may pass multiple triggers; separate them with a space.</p>
-            <p>Custom event names are supported when standard browser events are not applicable.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>delay</td>
-        <td>integer</td>
-        <td>0</td>
-        <td>Delay time (milliseconds) to wait before loading image once the `show` method has been called.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the image should appear with a fade-in animation when loaded.</td>
-    </tr>
-    <tr>
-        <td>threshold</td>
-        <td>integer</td>
-        <td>0</td>
-        <td>
-            Pixel offset from the viewport to use when calculating the invoking of the <code>show</code> method. Can be of positive of negative value.
-            For example, setting threshold to 200 causes image to load 200 pixels before it appears within the viewport.
-        </td>
-    </tr>
-    <tr>
-        <td>container</td>
-        <td>string | node</td>
-        <td>the <code>window</code> object</td>
-        <td>Specifies a containing element, such as div with scrollbar, where the <code>trigger</code> event callbacks should be listened for.</td>
-    </tr>
-    <tr>
-        <td>invisible</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>
-            <p>There are cases when you have images which are in viewport but not <code>:visible</code>. To improve performance the lazy widget ignores <code>.not(":visible")</code> by default. If you want to load these images set <code>invisible</code> to <code>true</code>.</p>
-            <div class="cf-callout cf-callout-info">
-                <h4>Browser Note</h4>
-                <p>Webkit browsers will report images with without <code>width</code> and <code>height</code> as not <code>.not(":visible")</code>. This causes images to appear only when you scroll a bit. Either fix your image tags or set <code>invisible</code> to <code>true</code>.</p>
-            </div>
-        </td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>src</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The URL or path for the source image to be displayed.</td>
+            </tr>
+            <tr>
+                <td>throttle</td>
+                <td>integer</td>
+                <td>250</td>
+                <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll or resize events.</td>
+            </tr>
+            <tr>
+                <td>trigger</td>
+                <td>string</td>
+                <td>'scroll resize'</td>
+                <td>
+                    <p>How lazy load is triggered. You may pass multiple triggers; separate them with a space.</p>
+                    <p>Custom event names are supported when standard browser events are not applicable.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>delay</td>
+                <td>integer</td>
+                <td>0</td>
+                <td>Delay time (milliseconds) to wait before loading image once the `show` method has been called.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the image should appear with a fade-in animation when loaded.</td>
+            </tr>
+            <tr>
+                <td>threshold</td>
+                <td>integer</td>
+                <td>0</td>
+                <td>
+                    Pixel offset from the viewport to use when calculating the invoking of the <code>show</code> method. Can be of positive of negative value.
+                    For example, setting threshold to 200 causes image to load 200 pixels before it appears within the viewport.
+                </td>
+            </tr>
+            <tr>
+                <td>container</td>
+                <td>string | node</td>
+                <td>the <code>window</code> object</td>
+                <td>Specifies a containing element, such as div with scrollbar, where the <code>trigger</code> event callbacks should be listened for.</td>
+            </tr>
+            <tr>
+                <td>invisible</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>
+                    <p>There are cases when you have images which are in viewport but not <code>:visible</code>. To improve performance the lazy widget ignores <code>.not(":visible")</code> by default. If you want to load these images set <code>invisible</code> to <code>true</code>.</p>
+                    <div class="cf-callout cf-callout-info">
+                        <h4>Browser Note</h4>
+                        <p>Webkit browsers will report images with without <code>width</code> and <code>height</code> as not <code>.not(":visible")</code>. This causes images to appear only when you scroll a bit. Either fix your image tags or set <code>invisible</code> to <code>true</code>.</p>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -156,28 +158,30 @@ Load the specified image source.
 
 Event callbacks happen on the image element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.lazy</td>
-        <td>This event fires after the image item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.lazy</td>
-        <td>This event is fired immediately when the <code>show</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.lazy</td>
-        <td>This event is fired when a lazy loaded image source has been made visible to the user (will wait for specified <code>effect</code> to complete).</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.lazy</td>
+                <td>This event fires after the image item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.lazy</td>
+                <td>This event is fired immediately when the <code>show</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.lazy</td>
+                <td>This event is fired when a lazy loaded image source has been made visible to the user (will wait for specified <code>effect</code> to complete).</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myImg').on('afterShow.cfw.lazy', function () {

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -536,63 +536,65 @@ There is also an additional special classname that the modal widget will look fo
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-modal-`, as in `data-cfw-modal-animate=false`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target modal.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If modal targets should fade and slide in.</td>
-    </tr>
-    <tr>
-        <td>unlink</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the `unlink` method should be called when the modal is hidden.  This leaves the modal behind in the DOM.</td>
-    </tr>
-    <tr>
-        <td>dispose</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the `dispose` method should be called when the modal is hidden. This will remove the modal from the DOM.</td>
-    </tr>
-    <tr>
-        <td>backdrop</td>
-        <td>boolean or the string `'static'`</td>
-        <td>true</td>
-        <td>
-            <p>Includes a modal-backdrop element. Alternatively, specify `static` for a backdrop which doesn't close the modal on click.</p>
-            <p>The backdrop is the semi-opaque overlay used to visually seperate the modal from the page content.</p>
-         </td>
-    </tr>
-    <tr>
-        <td>keyboard</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>Closes the modal when escape key is pressed</td>
-    </tr>
-    <tr>
-        <td>show</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Shows the modal when initialized.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target modal.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If modal targets should fade and slide in.</td>
+            </tr>
+            <tr>
+                <td>unlink</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the `unlink` method should be called when the modal is hidden.  This leaves the modal behind in the DOM.</td>
+            </tr>
+            <tr>
+                <td>dispose</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the `dispose` method should be called when the modal is hidden. This will remove the modal from the DOM.</td>
+            </tr>
+            <tr>
+                <td>backdrop</td>
+                <td>boolean or the string `'static'`</td>
+                <td>true</td>
+                <td>
+                    <p>Includes a modal-backdrop element. Alternatively, specify `static` for a backdrop which doesn't close the modal on click.</p>
+                    <p>The backdrop is the semi-opaque overlay used to visually seperate the modal from the page content.</p>
+                 </td>
+            </tr>
+            <tr>
+                <td>keyboard</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>Closes the modal when escape key is pressed</td>
+            </tr>
+            <tr>
+                <td>show</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Shows the modal when initialized.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -635,56 +637,58 @@ Calls the `unlink` method, and then removes the modal from the DOM.
 
 Event callbacks happen on the target `<div class="modal">` element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.modal</td>
-        <td>This event fires after the modal item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.modal</td>
-        <td>This event is fired immediately when the <code>show</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>scrollbarSet.cfw.modal</td>
-        <td>This event is fired immediately when the <code>&lt;body&gt;</code> padding is adjusted for the scrollbar width.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.modal</td>
-        <td>This event is fired when a modal dialog has been made visible to the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>scrollbarReset.cfw.modal</td>
-        <td>This event is fired immediately when the <code>&lt;body&gt;</code> padding adjustment for the scrollbar is removed.</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.modal</td>
-        <td>This event is fired immediately when the <code>hide</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.modal</td>
-        <td>This event is fired when a modal dialog has been hidden from the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>beforeUnlink.cfw.modal</td>
-        <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the `beforeHide` event if set to automatically unlink, or before if called via method.</td>
-    </tr>
-    <tr>
-        <td>afterUnlink.cfw.modal</td>
-        <td>This event is fired when a modal item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
-    </tr>
-    <tr>
-        <td>dispose.cfw.modal</td>
-        <td>This event is fired immediately before the modal item is removed from the DOM.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.modal</td>
+                <td>This event fires after the modal item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.modal</td>
+                <td>This event is fired immediately when the <code>show</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>scrollbarSet.cfw.modal</td>
+                <td>This event is fired immediately when the <code>&lt;body&gt;</code> padding is adjusted for the scrollbar width.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.modal</td>
+                <td>This event is fired when a modal dialog has been made visible to the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>scrollbarReset.cfw.modal</td>
+                <td>This event is fired immediately when the <code>&lt;body&gt;</code> padding adjustment for the scrollbar is removed.</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.modal</td>
+                <td>This event is fired immediately when the <code>hide</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.modal</td>
+                <td>This event is fired when a modal dialog has been hidden from the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>beforeUnlink.cfw.modal</td>
+                <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the `beforeHide` event if set to automatically unlink, or before if called via method.</td>
+            </tr>
+            <tr>
+                <td>afterUnlink.cfw.modal</td>
+                <td>This event is fired when a modal item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+            </tr>
+            <tr>
+                <td>dispose.cfw.modal</td>
+                <td>This event is fired immediately before the modal item is removed from the DOM.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myModal').on('afterHide.cfw.modal', function () {

--- a/docs/widgets/player.md
+++ b/docs/widgets/player.md
@@ -434,128 +434,130 @@ Note: If the player uses sliders, the slider keyboard commands will take precend
 
 Regions and controls are specified by data attributes `data-cfw-player="name"` to seperate functionality from layout.  See the following table for the names:
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>player</td>
-        <td>The main player container element.</td>
-    </tr>
-    <tr>
-        <td>control</td>
-        <td>Wraps the play, pause, and stop control buttons.</td>
-    </tr>
-    <tr>
-        <td>play</td>
-        <td>Play control button.</td>
-    </tr>
-    <tr>
-        <td>pause</td>
-        <td>Pause control button.</td>
-    </tr>
-    <tr>
-        <td>stop</td>
-        <td>Stop control button.</td>
-    </tr>
-    <tr>
-        <td>time</td>
-        <td>Wraps the time displays and seek progress bar or slider.</td>
-    </tr>
-    <tr>
-        <td>current</td>
-        <td>Current time location.</td>
-    </tr>
-    <tr>
-        <td>remainder</td>
-        <td>Remaining playback time.</td>
-    </tr>
-    <tr>
-        <td>duration</td>
-        <td>Time playback duration.</td>
-    </tr>
-    <tr>
-        <td>seek</td>
-        <td>
-            <p>Container for the seek progress bar or slider.</p>
-            <p>If container has a class of <code>progress</code> a progress bar will be assumed. There must be a chlid <code>.progress-bar</code> element in order for the progress bar to display.  For example <code>&lt;span class="progress-bar" role="progressbar" data-cfw-player="seek-current"&gt;&lt;/span&gt;</code></p>
-            <p>If container has a child <code>input</code> element, then a slider will be used.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>seek-current</td>
-        <td>Used for seek progress bar to display current time location.</td>
-    </tr>
-    <tr>
-        <td>seek-buffer</td>
-        <td>Unused.</td>
-    </tr>
-    <tr>
-        <td>mute</td>
-        <td>
-            <p>Mute toggle button.</p>
-            <p class="small mb-0">
-                Some mobile devices do not allow for mute or volume control, citing user should have preference through physical hardware controls.  Mostly this applies to iOS devices.
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>volume</td>
-        <td>
-            <p>Volume control.</p>
-            <p>If container has a child <code>input</code> element, then a slider will be inserted.</p>
-            <p class="small mb-0">
-                Some mobile devices do not allow for mute or volume control, citing user should have preference through physical hardware controls.  Mostly this applies to iOS devices.
-            </p>
-        </td>
-    </tr>
-    <tr>
-        <td>loop</td>
-        <td>Loop toggle button.</td>
-    </tr>
-    <tr>
-        <td>caption</td>
-        <td>
-            <p>Caption menu toggle button. Currently only supported for <code>&lt;video&gt;</code> elements.</p>
-            <p>The menu is dynamically generated based on the <code>&lt;track&gt;</code> elements, and associated with the button automatically.</p>
-            <p>Only tracks with a <code>kind</code> property of <strong>captions</strong> or <strong>subtitles</strong> will be added to the menu.</p>
-            <p>If there is only one valid track, then the button will act as a toggle button and not display the menu when clicked.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>caption-display</td>
-        <td>
-            <p>Container for custom styling of captions.</p>
-            <p>If this container is present, the default browser captions will be hidden. The currently active caption content will be displayed in this container, allowing for custom styling or placement of the captions.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>transcript</td>
-        <td>
-            <p>Transcript menu toggle button. Transcript text content is genereated from selected track item.</p>
-            <p>The menu is dynamically generated based on the <code>&lt;track&gt;</code> elements, and associated with the button automatically.</p>
-            <p>Only tracks with a <code>kind</code> property of <strong>captions</strong> or <strong>subtitles</strong> will be added to the menu.</p>
-            <p>If there is only one valid track, and the <code>transcriptOption</code> setting is false, then the button will act as a toggle button and not display the menu when clicked.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>description</td>
-        <td>Audio description, using an alternate video source, toggle button.</td>
-    </tr>
-    <tr>
-        <td>textdescription</td>
-        <td>Audio description, using text-based description content, toggle button.</td>
-    </tr>
-    <tr>
-        <td>fullscreen</td>
-        <td>Fullscreen toggle button. Currently only supported for <code>&lt;video&gt;</code> elements.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>player</td>
+                <td>The main player container element.</td>
+            </tr>
+            <tr>
+                <td>control</td>
+                <td>Wraps the play, pause, and stop control buttons.</td>
+            </tr>
+            <tr>
+                <td>play</td>
+                <td>Play control button.</td>
+            </tr>
+            <tr>
+                <td>pause</td>
+                <td>Pause control button.</td>
+            </tr>
+            <tr>
+                <td>stop</td>
+                <td>Stop control button.</td>
+            </tr>
+            <tr>
+                <td>time</td>
+                <td>Wraps the time displays and seek progress bar or slider.</td>
+            </tr>
+            <tr>
+                <td>current</td>
+                <td>Current time location.</td>
+            </tr>
+            <tr>
+                <td>remainder</td>
+                <td>Remaining playback time.</td>
+            </tr>
+            <tr>
+                <td>duration</td>
+                <td>Time playback duration.</td>
+            </tr>
+            <tr>
+                <td>seek</td>
+                <td>
+                    <p>Container for the seek progress bar or slider.</p>
+                    <p>If container has a class of <code>progress</code> a progress bar will be assumed. There must be a chlid <code>.progress-bar</code> element in order for the progress bar to display.  For example <code>&lt;span class="progress-bar" role="progressbar" data-cfw-player="seek-current"&gt;&lt;/span&gt;</code></p>
+                    <p>If container has a child <code>input</code> element, then a slider will be used.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>seek-current</td>
+                <td>Used for seek progress bar to display current time location.</td>
+            </tr>
+            <tr>
+                <td>seek-buffer</td>
+                <td>Unused.</td>
+            </tr>
+            <tr>
+                <td>mute</td>
+                <td>
+                    <p>Mute toggle button.</p>
+                    <p class="small mb-0">
+                        Some mobile devices do not allow for mute or volume control, citing user should have preference through physical hardware controls.  Mostly this applies to iOS devices.
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <td>volume</td>
+                <td>
+                    <p>Volume control.</p>
+                    <p>If container has a child <code>input</code> element, then a slider will be inserted.</p>
+                    <p class="small mb-0">
+                        Some mobile devices do not allow for mute or volume control, citing user should have preference through physical hardware controls.  Mostly this applies to iOS devices.
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <td>loop</td>
+                <td>Loop toggle button.</td>
+            </tr>
+            <tr>
+                <td>caption</td>
+                <td>
+                    <p>Caption menu toggle button. Currently only supported for <code>&lt;video&gt;</code> elements.</p>
+                    <p>The menu is dynamically generated based on the <code>&lt;track&gt;</code> elements, and associated with the button automatically.</p>
+                    <p>Only tracks with a <code>kind</code> property of <strong>captions</strong> or <strong>subtitles</strong> will be added to the menu.</p>
+                    <p>If there is only one valid track, then the button will act as a toggle button and not display the menu when clicked.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>caption-display</td>
+                <td>
+                    <p>Container for custom styling of captions.</p>
+                    <p>If this container is present, the default browser captions will be hidden. The currently active caption content will be displayed in this container, allowing for custom styling or placement of the captions.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>transcript</td>
+                <td>
+                    <p>Transcript menu toggle button. Transcript text content is genereated from selected track item.</p>
+                    <p>The menu is dynamically generated based on the <code>&lt;track&gt;</code> elements, and associated with the button automatically.</p>
+                    <p>Only tracks with a <code>kind</code> property of <strong>captions</strong> or <strong>subtitles</strong> will be added to the menu.</p>
+                    <p>If there is only one valid track, and the <code>transcriptOption</code> setting is false, then the button will act as a toggle button and not display the menu when clicked.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>description</td>
+                <td>Audio description, using an alternate video source, toggle button.</td>
+            </tr>
+            <tr>
+                <td>textdescription</td>
+                <td>Audio description, using text-based description content, toggle button.</td>
+            </tr>
+            <tr>
+                <td>fullscreen</td>
+                <td>Fullscreen toggle button. Currently only supported for <code>&lt;video&gt;</code> elements.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Via Data Attributes
 
@@ -573,66 +575,68 @@ $('#myPlayer').CFW_Player();
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-player`, as in `data-cfw-player-transcript-scroll=true`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>mediaDescribe</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Use the description media source.</td>
-    </tr>
-    <tr>
-        <td>textDescribe</td>
-        <td>integer</td>
-        <td>-1</td>
-        <td>Turn on the text-based description. The integer value reflects the track count (starting from 0) for the desired <code>&lt;track&gt;</code> element to enable.  Default value is -1 which leaves the description turned off. Currently only tracks of <strong>kind="descriptions"</strong> is supported.</td>
-    </tr>
-    <tr>
-        <td>textDescribeAnnounce</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>When a text-based description is selected, allow the description text to be announced by a screen reader.</td>
-    </tr>
-    <tr>
-        <td>textDescribeVisible</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>When a text-based description is selected, display the description text.</td>
-    </tr>
-    <tr>
-        <td>transcript</td>
-        <td>integer</td>
-        <td>-1</td>
-        <td>Turn on the interactive transcript by default.  The integer value reflects the track count (starting from 0) for the desired <code>&lt;track&gt;</code> element to enable.  Default value is -1 which leaves the transcript turned off. Currently only tracks of type <strong>caption</strong> or <strong>subtitles</strong> are supported.</td>
-    </tr>
-    <tr>
-        <td>transcriptScroll</td>
-        <td>booelan</td>
-        <td>true</td>
-        <td>If the transcript should automatically scroll to keep the current caption in the visible area.</td>
-    </tr>
-    <tr>
-        <td>transcriptDescribe</td>
-        <td>booelan</td>
-        <td>true</td>
-        <td>If the transcript should show the matching <code>descriptions</code> track for the currently active transcript.</td>
-    </tr>
-    <tr>
-        <td>transcriptOption</td>
-        <td>booelan</td>
-        <td>true</td>
-        <td>If the transcript options should be shown in the transcript menu.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>mediaDescribe</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Use the description media source.</td>
+            </tr>
+            <tr>
+                <td>textDescribe</td>
+                <td>integer</td>
+                <td>-1</td>
+                <td>Turn on the text-based description. The integer value reflects the track count (starting from 0) for the desired <code>&lt;track&gt;</code> element to enable.  Default value is -1 which leaves the description turned off. Currently only tracks of <strong>kind="descriptions"</strong> is supported.</td>
+            </tr>
+            <tr>
+                <td>textDescribeAnnounce</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>When a text-based description is selected, allow the description text to be announced by a screen reader.</td>
+            </tr>
+            <tr>
+                <td>textDescribeVisible</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>When a text-based description is selected, display the description text.</td>
+            </tr>
+            <tr>
+                <td>transcript</td>
+                <td>integer</td>
+                <td>-1</td>
+                <td>Turn on the interactive transcript by default.  The integer value reflects the track count (starting from 0) for the desired <code>&lt;track&gt;</code> element to enable.  Default value is -1 which leaves the transcript turned off. Currently only tracks of type <strong>caption</strong> or <strong>subtitles</strong> are supported.</td>
+            </tr>
+            <tr>
+                <td>transcriptScroll</td>
+                <td>booelan</td>
+                <td>true</td>
+                <td>If the transcript should automatically scroll to keep the current caption in the visible area.</td>
+            </tr>
+            <tr>
+                <td>transcriptDescribe</td>
+                <td>booelan</td>
+                <td>true</td>
+                <td>If the transcript should show the matching <code>descriptions</code> track for the currently active transcript.</td>
+            </tr>
+            <tr>
+                <td>transcriptOption</td>
+                <td>booelan</td>
+                <td>true</td>
+                <td>If the transcript options should be shown in the transcript menu.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -712,52 +716,54 @@ Remove any associated transcript, sliders, dropdowns, data, and event listeners 
 
 Event callbacks happen on the `<audio>`/`<video>` element, but will bubble up through the DOM and can be captured on the `data-cfw="player"` wrapping container if needed.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>noSupport.cfw.player</td>
-        <td>This event fires if it is determined the browser does not support HTML5 audio or the specified MIME type.</td>
-    </tr>
-    <tr>
-        <td>ready.cfw.player</td>
-        <td>This event fires after the player item is initialized.</td>
-    </tr>
-    <tr>
-        <td>error.cfw.player</td>
-        <td>This event fires when there is an error that cannot be handled.</td>
-    </tr>
-    <tr>
-        <td>beforeTranscriptShow.cfw.player</td>
-        <td>This event fires before the transcript is shown.</td>
-    </tr>
-    <tr>
-        <td>afterTranscriptShow.cfw.player</td>
-        <td>This event fires after the transcript is shown.</td>
-    </tr>
-    <tr>
-        <td>beforeTranscriptHide.cfw.player</td>
-        <td>This event fires before the transcript is hidden/disabled.</td>
-    </tr>
-    <tr>
-        <td>afterTranscriptHide.cfw.player</td>
-        <td>This event fires after the transcript is hidden/disabled.</td>
-    </tr>
-    <tr>
-        <td>enterFullscreen.cfw.player</td>
-        <td>This event fires after the player is put into fullscreen mode.</td>
-    </tr>
-    <tr>
-        <td>exitFullscreen.cfw.player</td>
-        <td>This event fires after the player exits fullscreen mode.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>noSupport.cfw.player</td>
+                <td>This event fires if it is determined the browser does not support HTML5 audio or the specified MIME type.</td>
+            </tr>
+            <tr>
+                <td>ready.cfw.player</td>
+                <td>This event fires after the player item is initialized.</td>
+            </tr>
+            <tr>
+                <td>error.cfw.player</td>
+                <td>This event fires when there is an error that cannot be handled.</td>
+            </tr>
+            <tr>
+                <td>beforeTranscriptShow.cfw.player</td>
+                <td>This event fires before the transcript is shown.</td>
+            </tr>
+            <tr>
+                <td>afterTranscriptShow.cfw.player</td>
+                <td>This event fires after the transcript is shown.</td>
+            </tr>
+            <tr>
+                <td>beforeTranscriptHide.cfw.player</td>
+                <td>This event fires before the transcript is hidden/disabled.</td>
+            </tr>
+            <tr>
+                <td>afterTranscriptHide.cfw.player</td>
+                <td>This event fires after the transcript is hidden/disabled.</td>
+            </tr>
+            <tr>
+                <td>enterFullscreen.cfw.player</td>
+                <td>This event fires after the player is put into fullscreen mode.</td>
+            </tr>
+            <tr>
+                <td>exitFullscreen.cfw.player</td>
+                <td>This event fires after the player exits fullscreen mode.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myPlayer').on('ready.cfw.player', function () {

--- a/docs/widgets/popover.md
+++ b/docs/widgets/popover.md
@@ -265,50 +265,51 @@ Draggable popovers will force the following settings:
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-popover`, as in `data-cfw-popover-placement="forward"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target popover.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If popover items should fade in and out.</td>
-    </tr>
-    <tr>
-        <td>placement</td>
-        <td>string | object | function</td>
-        <td>'top'</td>
-        <td>
-            <p>
-                <strong>string:</strong><br />
-                How to position the popover - top | bottom | reverse | forward | auto.
-                <br />
-                When "auto" is specified, it will dynamically reorient the popover. For example, if placement is "auto reverse", the popover will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
-            </p>
-            <p>
-                <strong>object:</strong><br />
-                This is a way to custom position a popover in a specific place not handled by the standard placement locations.
-                A custom positioned popover is forced to using the <code>&lt;body&gt;</code> as the container to make positioning easier.
-                Object structure is: <code>placement: { top: 5, left: 10 }</code>, the same as jQuery offset.
-            </p>
-            <p>
-                <strong>function:</strong><br />
-                A function call can return either a string or object placement type.
-                The function allows access to the complete popover data-api, as well as passing the popover target and trigger as arguments.
-            </p>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target popover.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If popover items should fade in and out.</td>
+            </tr>
+            <tr>
+                <td>placement</td>
+                <td>string | object | function</td>
+                <td>'top'</td>
+                <td>
+                    <p>
+                        <strong>string:</strong><br />
+                        How to position the popover - top | bottom | reverse | forward | auto.
+                        <br />
+                        When "auto" is specified, it will dynamically reorient the popover. For example, if placement is "auto reverse", the popover will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
+                    </p>
+                    <p>
+                        <strong>object:</strong><br />
+                        This is a way to custom position a popover in a specific place not handled by the standard placement locations.
+                        A custom positioned popover is forced to using the <code>&lt;body&gt;</code> as the container to make positioning easier.
+                        Object structure is: <code>placement: { top: 5, left: 10 }</code>, the same as jQuery offset.
+                    </p>
+                    <p>
+                        <strong>function:</strong><br />
+                        A function call can return either a string or object placement type.
+                        The function allows access to the complete popover data-api, as well as passing the popover target and trigger as arguments.
+                    </p>
 <pre>
 function myPopoverAlign(tip, trigger) {
     // this - popover data-api
@@ -316,119 +317,120 @@ function myPopoverAlign(tip, trigger) {
     // trigger -> popover trigger
 }
 </pre>
-        </td>
-    </tr>
-    <tr>
-        <td>trigger</td>
-        <td>string</td>
-        <td>'hover focus'</td>
-        <td>How popover is triggered - click | hover | focus | manual. You may pass multiple triggers; separate them with a space. <code>manual</code> cannot be combined with any other trigger.</td>
-    </tr>
-    <tr>
-        <td>delay</td>
-        <td>number| object</td>
-        <td>show:0, hide:250</td>
-        <td>
-            <p>Delay showing and hiding the popover (ms) - does not apply to manual trigger type.</p>
-            <p>If a number is supplied, delay is applied to both hide/show.</p>
-            Object structure is: <code>delay: { show: 500, hide: 100 }</code>
-        </td>
-    </tr>
-    <tr>
-        <td>container</td>
-        <td>string | false</td>
-        <td>false</td>
-        <td>Appends the popover to a specific element. Example: <code>container: 'body'</code></td>
-    </tr>
-    <tr>
-        <td>viewport</td>
-        <td>string | function</td>
-        <td>'body'</td>
-        <td>
-            <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
-            <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the popover instance.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>padding</td>
-        <td>integer</td>
-        <td>0</td>
-        <td>Spacing, in pixels, to keep the popover away from the viewport edge.</td>
-    </tr>
-    <tr>
-        <td>html</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Insert HTML into the popover. If false, jQuery's <code>text</code> method will be used to insert content into the DOM. Use text if you're worried about XSS attacks.</td>
-    </tr>
-    <tr>
-        <td>closetext</td>
-        <td>string</td>
-        <td>'&lt;span aria-hidden="true" &gt;&amp;times;&lt;/span&gt;'</td>
-        <td>Visible text for close links when using option <code>trigger: 'click'</code></td>
-    </tr>
-    <tr>
-        <td>closesrtext</td>
-        <td>string</td>
-        <td>'Close'</td>
-        <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
-    </tr>
-    <tr>
-        <td>title</td>
-        <td>string | function</td>
-        <td>''</td>
-        <td>Default title value if <code>title</code> attribute isn't present.</td>
-    </tr>
-    <tr>
-        <td>content</td>
-        <td>string | function</td>
-        <td>''</td>
-        <td>Default title value if <code>data-cfw-popover-content</code> attribute isn't present.</td>
-    </tr>
-    <tr>
-        <td>unlink</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the <code>unlink</code> method should be called when the popover is hidden.  This leaves the popover behind in the DOM.</td>
-    </tr>
-    <tr>
-        <td>dispose</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the <code>dispose</code> method should be called when the popover is hidden. This will remove the popover from the DOM.</td>
-    </tr>
-    <tr>
-        <td>drag</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the popover should have a drag handle inserted.</td>
-    </tr>
-    <tr>
-        <td>dragtext</td>
-        <td>string</td>
-        <td>'&lt;span aria-hidden="true" &gt;+&lt;/span&gt;'</td>
-        <td>Visible text for the auto-inserted drag handle.</td>
-    </tr>
-    <tr>
-        <td>dragsrtext</td>
-        <td>string</td>
-        <td>'Drag'</td>
-        <td>Screen reader only text alternative for the auto-inserted drag handle.</td>
-    </tr>
-    <tr>
-        <td>dragstep</td>
-        <td>integer</td>
-        <td>10</td>
-        <td>Pixel increment to move the popover when using arrow keys on a drag handle.</td>
-    </tr>
-    <tr>
-        <td>show</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Show the popover automatically at the end of initialization. This will force the <code>trigger</code> option to a setting of <code>'click'</code>.</td>
-    </tr>
-</tbody>
-</table>
+                </td>
+            </tr>
+            <tr>
+                <td>trigger</td>
+                <td>string</td>
+                <td>'hover focus'</td>
+                <td>How popover is triggered - click | hover | focus | manual. You may pass multiple triggers; separate them with a space. <code>manual</code> cannot be combined with any other trigger.</td>
+            </tr>
+            <tr>
+                <td>delay</td>
+                <td>number| object</td>
+                <td>show:0, hide:250</td>
+                <td>
+                    <p>Delay showing and hiding the popover (ms) - does not apply to manual trigger type.</p>
+                    <p>If a number is supplied, delay is applied to both hide/show.</p>
+                    Object structure is: <code>delay: { show: 500, hide: 100 }</code>
+                </td>
+            </tr>
+            <tr>
+                <td>container</td>
+                <td>string | false</td>
+                <td>false</td>
+                <td>Appends the popover to a specific element. Example: <code>container: 'body'</code></td>
+            </tr>
+            <tr>
+                <td>viewport</td>
+                <td>string | function</td>
+                <td>'body'</td>
+                <td>
+                    <p>Keeps the popover within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
+                    <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the popover instance.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>padding</td>
+                <td>integer</td>
+                <td>0</td>
+                <td>Spacing, in pixels, to keep the popover away from the viewport edge.</td>
+            </tr>
+            <tr>
+                <td>html</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Insert HTML into the popover. If false, jQuery's <code>text</code> method will be used to insert content into the DOM. Use text if you're worried about XSS attacks.</td>
+            </tr>
+            <tr>
+                <td>closetext</td>
+                <td>string</td>
+                <td>'&lt;span aria-hidden="true" &gt;&amp;times;&lt;/span&gt;'</td>
+                <td>Visible text for close links when using option <code>trigger: 'click'</code></td>
+            </tr>
+            <tr>
+                <td>closesrtext</td>
+                <td>string</td>
+                <td>'Close'</td>
+                <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
+            </tr>
+            <tr>
+                <td>title</td>
+                <td>string | function</td>
+                <td>''</td>
+                <td>Default title value if <code>title</code> attribute isn't present.</td>
+            </tr>
+            <tr>
+                <td>content</td>
+                <td>string | function</td>
+                <td>''</td>
+                <td>Default title value if <code>data-cfw-popover-content</code> attribute isn't present.</td>
+            </tr>
+            <tr>
+                <td>unlink</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the <code>unlink</code> method should be called when the popover is hidden.  This leaves the popover behind in the DOM.</td>
+            </tr>
+            <tr>
+                <td>dispose</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the <code>dispose</code> method should be called when the popover is hidden. This will remove the popover from the DOM.</td>
+            </tr>
+            <tr>
+                <td>drag</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the popover should have a drag handle inserted.</td>
+            </tr>
+            <tr>
+                <td>dragtext</td>
+                <td>string</td>
+                <td>'&lt;span aria-hidden="true" &gt;+&lt;/span&gt;'</td>
+                <td>Visible text for the auto-inserted drag handle.</td>
+            </tr>
+            <tr>
+                <td>dragsrtext</td>
+                <td>string</td>
+                <td>'Drag'</td>
+                <td>Screen reader only text alternative for the auto-inserted drag handle.</td>
+            </tr>
+            <tr>
+                <td>dragstep</td>
+                <td>integer</td>
+                <td>10</td>
+                <td>Pixel increment to move the popover when using arrow keys on a drag handle.</td>
+            </tr>
+            <tr>
+                <td>show</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Show the popover automatically at the end of initialization. This will force the <code>trigger</code> option to a setting of <code>'click'</code>.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -472,60 +474,62 @@ Calls the `unlink` method, and then removes the popover from the DOM.
 
 Event callbacks happen on the toggle/trigger element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.popover</td>
-        <td>This event fires after the popover item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.popover</td>
-        <td>This event is fired immediately when the <code>show</code> method is called.  If the popover container is not present, it is created just after this event is called.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.popover</td>
-        <td>This event is fired when a popover has been made visible to the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.popover</td>
-        <td>This event is fired immediately when the <code>hide</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.popover</td>
-        <td>This event is fired when a popover has been hidden from the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>inserted.cfw.popover</td>
-        <td>This event is fired after the <code>beforeShow.cfw.popover</code> event when the popover has been added to the DOM.</td>
-    </tr>
-    <tr>
-        <td>dragStart.cfw.popover</td>
-        <td>This event is fired at the start of the drag action.</td>
-    </tr>
-    <tr>
-        <td>dragEnd.cfw.popover</td>
-        <td>This event is fired at the end of the drag action.</td>
-    </tr>
-    <tr>
-        <td>beforeUnlink.cfw.popover</td>
-        <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the <code>beforeHide</code> event if set to automatically unlink, or before if called via method.</td>
-    </tr>
-    <tr>
-        <td>afterUnlink.cfw.popover</td>
-        <td>This event is fired when a popover item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
-    </tr>
-    <tr>
-        <td>dispose.cfw.popover</td>
-        <td>This event is fired immediately before the popover item is removed from the DOM.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.popover</td>
+                <td>This event fires after the popover item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.popover</td>
+                <td>This event is fired immediately when the <code>show</code> method is called.  If the popover container is not present, it is created just after this event is called.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.popover</td>
+                <td>This event is fired when a popover has been made visible to the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.popover</td>
+                <td>This event is fired immediately when the <code>hide</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.popover</td>
+                <td>This event is fired when a popover has been hidden from the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>inserted.cfw.popover</td>
+                <td>This event is fired after the <code>beforeShow.cfw.popover</code> event when the popover has been added to the DOM.</td>
+            </tr>
+            <tr>
+                <td>dragStart.cfw.popover</td>
+                <td>This event is fired at the start of the drag action.</td>
+            </tr>
+            <tr>
+                <td>dragEnd.cfw.popover</td>
+                <td>This event is fired at the end of the drag action.</td>
+            </tr>
+            <tr>
+                <td>beforeUnlink.cfw.popover</td>
+                <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the <code>beforeHide</code> event if set to automatically unlink, or before if called via method.</td>
+            </tr>
+            <tr>
+                <td>afterUnlink.cfw.popover</td>
+                <td>This event is fired when a popover item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+            </tr>
+            <tr>
+                <td>dispose.cfw.popover</td>
+                <td>This event is fired immediately before the popover item is removed from the DOM.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myPopover').on('afterHide.cfw.popover', function () {

--- a/docs/widgets/scrollspy.md
+++ b/docs/widgets/scrollspy.md
@@ -283,36 +283,38 @@ $('body').CFW_Scrollspy({ target: '#navbar-example' });
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-scrollspy`, as in `data-cfw-scrollspy-target="#navbar-example"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) for the target container.</td>
-    </tr>
-    <tr>
-        <td>offset</td>
-        <td>integer</td>
-        <td>10</td>
-        <td>Pixels to offset from top when calculating position of scroll.</td>
-    </tr>
-    <tr>
-        <td>throttle</td>
-        <td>integer</td>
-        <td>100</td>
-        <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll event.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) for the target container.</td>
+            </tr>
+            <tr>
+                <td>offset</td>
+                <td>integer</td>
+                <td>10</td>
+                <td>Pixels to offset from top when calculating position of scroll.</td>
+            </tr>
+            <tr>
+                <td>throttle</td>
+                <td>integer</td>
+                <td>100</td>
+                <td>Timeout rate (milliseconds) for the throttle function helps to decrease function calls through scroll event.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -347,24 +349,26 @@ Removes the associated event listener for the given scrollspy element, leaving t
 
 Event callbacks happen on the or designated scrolling region (for `init.cfw.scrollspy`) or the activated navigation element (for `activate.cfw.scrollspy`).
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.scrollspy</td>
-        <td>This event fires after the scrollspy is initialized.</td>
-    </tr>
-    <tr>
-        <td>activate.cfw.scrollspy</td>
-        <td>This event fires whenever a new item becomes activated by the scrollspy.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.scrollspy</td>
+                <td>This event fires after the scrollspy is initialized.</td>
+            </tr>
+            <tr>
+                <td>activate.cfw.scrollspy</td>
+                <td>This event fires whenever a new item becomes activated by the scrollspy.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myScrollspy').on('activate.cfw.scrollspy', function () {

--- a/docs/widgets/slider.md
+++ b/docs/widgets/slider.md
@@ -165,63 +165,65 @@ $('#mySlider').CFW_Slider({
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-slider`, as in `data-cfw-slider-step=5`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>min</td>
-        <td>integer | float</td>
-        <td>null</td>
-        <td>Numerical value for the minimum values in the range</td>
-    </tr>
-    <tr>
-        <td>max</td>
-        <td>integer | float</td>
-        <td>null</td>
-        <td>Numerical value for the maximum values in the range.</td>
-    </tr>
-    <tr>
-        <td>step</td>
-        <td>integer | float</td>
-        <td>1</td>
-        <td>The minimum movement size.  This value must be a positive, non-zero value.</td>
-    </tr>
-    <tr>
-        <td>chunk</td>
-        <td>integer | float</td>
-        <td>null</td>
-        <td>
-            <p>The 'large step' size used for PgUp/PgDown keyboard navigation.</p>
-            <p>If not defined, the chunk will be auto determined based on the size of the step and the range.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>vertical</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>The orientation of the slider in a horizontal (default), or vertical layout.</td>
-    </tr>
-    <tr>
-        <td>reversed</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the selection, thumbs, and movement should all be revsersed.</td>
-    </tr>
-    <tr>
-        <td>enabled</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If the slider is enabled or disabled at creation.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>min</td>
+                <td>integer | float</td>
+                <td>null</td>
+                <td>Numerical value for the minimum values in the range</td>
+            </tr>
+            <tr>
+                <td>max</td>
+                <td>integer | float</td>
+                <td>null</td>
+                <td>Numerical value for the maximum values in the range.</td>
+            </tr>
+            <tr>
+                <td>step</td>
+                <td>integer | float</td>
+                <td>1</td>
+                <td>The minimum movement size.  This value must be a positive, non-zero value.</td>
+            </tr>
+            <tr>
+                <td>chunk</td>
+                <td>integer | float</td>
+                <td>null</td>
+                <td>
+                    <p>The 'large step' size used for PgUp/PgDown keyboard navigation.</p>
+                    <p>If not defined, the chunk will be auto determined based on the size of the step and the range.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>vertical</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>The orientation of the slider in a horizontal (default), or vertical layout.</td>
+            </tr>
+            <tr>
+                <td>reversed</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the selection, thumbs, and movement should all be revsersed.</td>
+            </tr>
+            <tr>
+                <td>enabled</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If the slider is enabled or disabled at creation.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -256,28 +258,30 @@ Detach the listen events and data for the slider, and remove the slider controls
 
 Event callbacks happen on the created slider element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.slider</td>
-        <td>This event fires after the slider item is initialized.</td>
-    </tr>
-    <tr>
-        <td>slid.cfw.slider</td>
-        <td>This event is fired when a thumb item is manually moved.</td>
-    </tr>
-    <tr>
-        <td>changed.cfw.slider</td>
-        <td>This event is fired when one of the associated input values has been changed.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.slider</td>
+                <td>This event fires after the slider item is initialized.</td>
+            </tr>
+            <tr>
+                <td>slid.cfw.slider</td>
+                <td>This event is fired when a thumb item is manually moved.</td>
+            </tr>
+            <tr>
+                <td>changed.cfw.slider</td>
+                <td>This event is fired when one of the associated input values has been changed.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#mySlider').on('slid.cfw.slider', function () {

--- a/docs/widgets/slideshow.md
+++ b/docs/widgets/slideshow.md
@@ -358,25 +358,26 @@ Disable the slideshow navigation controls and listeners.  This will leave the ta
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-slideshow`, as in `data-cfw-slideshow-loop="false"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>loop</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Enable looping from the last slide to the first slide, and vice versa.</td>
-    </tr>
-</tbody>
-</table>
-
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>loop</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Enable looping from the last slide to the first slide, and vice versa.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Events
 
@@ -384,29 +385,31 @@ Event callbacks happen on the slideshow element.
 
 You can also get the tab events as indicated in the [Tab widget]({{ site.baseurl }}/widgets/tab/) due to event bubbling.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.slideshow</td>
-        <td>This event fires after the slideshow item is initialized.</td>
-    </tr>
-    <tr>
-        <td>prev.cfw.slideshow</td>
-        <td>This event fires before the call to activate the previous slide.</td>
-    </tr>
-    <tr>
-        <td>next.cfw.slideshow</td>
-        <td>This event fires before the call to activate the next slide.</td>
-    </tr>
-    <tr>
-        <td>update.cfw.slideshow</td>
-        <td>This event fires after the state of the navigation controls is updated.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.slideshow</td>
+                <td>This event fires after the slideshow item is initialized.</td>
+            </tr>
+            <tr>
+                <td>prev.cfw.slideshow</td>
+                <td>This event fires before the call to activate the previous slide.</td>
+            </tr>
+            <tr>
+                <td>next.cfw.slideshow</td>
+                <td>This event fires before the call to activate the next slide.</td>
+            </tr>
+            <tr>
+                <td>update.cfw.slideshow</td>
+                <td>This event fires after the state of the navigation controls is updated.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/widgets/tab-responsive.md
+++ b/docs/widgets/tab-responsive.md
@@ -135,24 +135,26 @@ None.
 {% comment %}
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tabResponsive`, as in `data-cfw-tabResponsive-active=true`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>active</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the collapse item in the default tab should be opened on initialization. Mostly useful for mobile devices depending on CSS.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>active</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the collapse item in the default tab should be opened on initialization. Mostly useful for mobile devices depending on CSS.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 {% endcomment %}
 
 ### Methods
@@ -172,17 +174,19 @@ Event callbacks happen on the responsive tab element.
 
 You can also get the collapse and tab events as indicated in the [Collapse]({{ site.baseurl }}/widgets/collapse/) and [Tab]({{ site.baseurl }}/widgets/tab/) widgets due to event bubbling.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.tabResponsive</td>
-        <td>This event fires after the responsive tab item is initialized.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.tabResponsive</td>
+                <td>This event fires after the responsive tab item is initialized.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/widgets/tab.md
+++ b/docs/widgets/tab.md
@@ -210,24 +210,26 @@ $('#myTab a:nth-child(3)').CFW_Tab('show')      // Select third tab
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tab`, as in `data-cfw-tab-animate="false"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If the tab pane target should fade in and out.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If the tab pane target should fade in and out.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -262,36 +264,38 @@ When showing a new tab, the events fire in the following order:
 - `afterHidden.cfw.tab` (on the previous active tab, the same one as for the `beforeHide.cfw.tab` event)
 - `afterShow.cfw.tab` (on the newly-active just-shown tab, the same one as for the `beforeShow.cfw.tab` event)
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.tab</td>
-        <td>This event fires after the tab item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.tab</td>
-        <td>This event fires on tab show, but before the new tab has been shown. Use <code>event.target</code> and <code>event.relatedTarget</code> to target the active tab and the previous active tab (if available) respectively.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.tab</td>
-        <td>This event fires on tab show after a tab has been shown. Use <code>event.target</code> and <code>event.relatedTarget</code> to target the active tab and the previous active tab (if available) respectively.</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.tab</td>
-        <td>This event fires when a new tab is to be shown (and thus the previous active tab is to be hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the current active tab and the new soon-to-be-active tab, respectively.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.tab</td>
-        <td>This event fires after a new tab is shown (and thus the previous active tab is hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the previous active tab and the new active tab, respectively.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.tab</td>
+                <td>This event fires after the tab item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.tab</td>
+                <td>This event fires on tab show, but before the new tab has been shown. Use <code>event.target</code> and <code>event.relatedTarget</code> to target the active tab and the previous active tab (if available) respectively.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.tab</td>
+                <td>This event fires on tab show after a tab has been shown. Use <code>event.target</code> and <code>event.relatedTarget</code> to target the active tab and the previous active tab (if available) respectively.</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.tab</td>
+                <td>This event fires when a new tab is to be shown (and thus the previous active tab is to be hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the current active tab and the new soon-to-be-active tab, respectively.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.tab</td>
+                <td>This event fires after a new tab is shown (and thus the previous active tab is hidden). Use <code>event.target</code> and <code>event.relatedTarget</code> to target the previous active tab and the new active tab, respectively.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('a[data-cfw="tab"]').on('afterShow.cfw.tab', function(e) {

--- a/docs/widgets/tooltip.md
+++ b/docs/widgets/tooltip.md
@@ -183,50 +183,51 @@ Any element with a data attribute of `data-cfw-dismiss="tooltip"` within the too
 
 Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-tooltip`, as in `data-cfw-tooltip-placement="forward"`.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 100px;">Name</th>
-        <th style="width: 50px;">Type</th>
-        <th style="width: 50px;">Default</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target popover.</td>
-    </tr>
-    <tr>
-        <td>animate</td>
-        <td>boolean</td>
-        <td>true</td>
-        <td>If tooltip items should fade in and out.</td>
-    </tr>
-    <tr>
-        <td>placement</td>
-        <td>string | object | function</td>
-        <td>'top'</td>
-        <td>
-            <p>
-                <strong>string:</strong><br />
-                How to position the tooltip - top | bottom | reverse | forward| auto.
-                <br />
-                When "auto" is specified, it will dynamically reorient the tooltip. For example, if placement is "auto reverse", the tooltip will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
-            </p>
-            <p>
-                <strong>object:</strong><br />
-                This is a way to custom position a tooltip in a specific place not handled by the standard placement locations.
-                A custom positioned tooltip is forced to using the <code>&lt;body&gt;</code> as the container to make positioning easier.
-                Object structure is: <code>placement: { top: 5, left: 10 }</code>, the same as jQuery offset.
-            </p>
-            <p>
-                <strong>function:</strong><br />
-                A function call can return either a string or object placement type.
-                The function allows access to the complete tooltip data-api, as well as passing the tooltip target and trigger as arguments.
-            </p>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target popover.</td>
+            </tr>
+            <tr>
+                <td>animate</td>
+                <td>boolean</td>
+                <td>true</td>
+                <td>If tooltip items should fade in and out.</td>
+            </tr>
+            <tr>
+                <td>placement</td>
+                <td>string | object | function</td>
+                <td>'top'</td>
+                <td>
+                    <p>
+                        <strong>string:</strong><br />
+                        How to position the tooltip - top | bottom | reverse | forward| auto.
+                        <br />
+                        When "auto" is specified, it will dynamically reorient the tooltip. For example, if placement is "auto reverse", the tooltip will display to the left when possible, otherwise it will display right. (Opposite horizontal directions apply for <code>rtl</code> mode.)
+                    </p>
+                    <p>
+                        <strong>object:</strong><br />
+                        This is a way to custom position a tooltip in a specific place not handled by the standard placement locations.
+                        A custom positioned tooltip is forced to using the <code>&lt;body&gt;</code> as the container to make positioning easier.
+                        Object structure is: <code>placement: { top: 5, left: 10 }</code>, the same as jQuery offset.
+                    </p>
+                    <p>
+                        <strong>function:</strong><br />
+                        A function call can return either a string or object placement type.
+                        The function allows access to the complete tooltip data-api, as well as passing the tooltip target and trigger as arguments.
+                    </p>
 <pre>
 function myTipAlign(tip, trigger) {
     // this - tooltip data-api
@@ -234,98 +235,99 @@ function myTipAlign(tip, trigger) {
     // trigger -> tooltip trigger
 }
 </pre>
-        </td>
-    </tr>
-    <tr>
-        <td>trigger</td>
-        <td>string</td>
-        <td>'hover focus'</td>
-        <td>How tooltip is triggered - click | hover | focus | manual. You may pass multiple triggers; separate them with a space. <code>manual</code> cannot be combined with any other trigger.</td>
-    </tr>
-    <tr>
-        <td>delay</td>
-        <td>number| object</td>
-        <td>show:0, hide:250</td>
-        <td>
-            <p>Delay showing and hiding the tooltip (ms) - does not apply to manual trigger type.</p>
-            <p>If a number is supplied, delay is applied to both hide/show.</p>
-            Object structure is: <code>delay: { show: 500, hide: 100 }</code>
-        </td>
-    </tr>
-    <tr>
-        <td>container</td>
-        <td>string | false</td>
-        <td>false</td>
-        <td>Appends the tooltip to a specific element. Example: <code>container: 'body'</code></td>
-    </tr>
-    <tr>
-        <td>viewport</td>
-        <td>string | function</td>
-        <td>'body'</td>
-        <td>
-            <p>Keep the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
-            <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the tooltip instance.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>padding</td>
-        <td>integer</td>
-        <td>0</td>
-        <td>Spacing, in pixels, to keep the tooltip away from the viewport edge.</td>
-    </tr>
-    <tr>
-        <td>html</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>
-            <p>Allow HTML in the tooltip.</p>
-            <p>If false, jQuery's <code>text</code> method will be used to insert content into the DOM. Use text if you're worried about XSS attacks.</p>
-        </td>
-    </tr>
-    <tr>
-        <td>closetext</td>
-        <td>string</td>
-        <td>'&lt;span aria-hidden="true" &gt;&amp;times;&lt;/span&gt;'</td>
-        <td>Visible text for close links when using option <code>trigger: 'click'</code></td>
-    </tr>
-    <tr>
-        <td>closesrtext</td>
-        <td>string</td>
-        <td>'Close'</td>
-        <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
-    </tr>
-    <tr>
-        <td>target</td>
-        <td>string</td>
-        <td>null</td>
-        <td>The selector (jQuery style) of the target tooltip.</td>
-    </tr>
-    <tr>
-        <td>title</td>
-        <td>string | function</td>
-        <td>''</td>
-        <td>Default title value if <code>title</code> attribute isn't present.</td>
-    </tr>
-    <tr>
-        <td>unlink</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the <code>unlink</code> method should be called when the tooltip is hidden.  This leaves the tooltip behind in the DOM.</td>
-    </tr>
-    <tr>
-        <td>dispose</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>If the <code>dispose</code> method should be called when the tooltip is hidden. This will remove the tooltip from the DOM.</td>
-    </tr>
-    <tr>
-        <td>show</td>
-        <td>boolean</td>
-        <td>false</td>
-        <td>Show the tooltip automatically at the end of initialization. This will force the <code>trigger</code> option to a setting of <code>'click'</code>.</td>
-    </tr>
-</tbody>
-</table>
+                </td>
+            </tr>
+            <tr>
+                <td>trigger</td>
+                <td>string</td>
+                <td>'hover focus'</td>
+                <td>How tooltip is triggered - click | hover | focus | manual. You may pass multiple triggers; separate them with a space. <code>manual</code> cannot be combined with any other trigger.</td>
+            </tr>
+            <tr>
+                <td>delay</td>
+                <td>number| object</td>
+                <td>show:0, hide:250</td>
+                <td>
+                    <p>Delay showing and hiding the tooltip (ms) - does not apply to manual trigger type.</p>
+                    <p>If a number is supplied, delay is applied to both hide/show.</p>
+                    Object structure is: <code>delay: { show: 500, hide: 100 }</code>
+                </td>
+            </tr>
+            <tr>
+                <td>container</td>
+                <td>string | false</td>
+                <td>false</td>
+                <td>Appends the tooltip to a specific element. Example: <code>container: 'body'</code></td>
+            </tr>
+            <tr>
+                <td>viewport</td>
+                <td>string | function</td>
+                <td>'body'</td>
+                <td>
+                    <p>Keep the tooltip within the bounds of this element. Example: <code>viewport: '#viewport'</code>.</p>
+                    <p>If a function is given, it is called with the triggering element DOM node as its only argument. The <code>this</code> context is set to the tooltip instance.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>padding</td>
+                <td>integer</td>
+                <td>0</td>
+                <td>Spacing, in pixels, to keep the tooltip away from the viewport edge.</td>
+            </tr>
+            <tr>
+                <td>html</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>
+                    <p>Allow HTML in the tooltip.</p>
+                    <p>If false, jQuery's <code>text</code> method will be used to insert content into the DOM. Use text if you're worried about XSS attacks.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>closetext</td>
+                <td>string</td>
+                <td>'&lt;span aria-hidden="true" &gt;&amp;times;&lt;/span&gt;'</td>
+                <td>Visible text for close links when using option <code>trigger: 'click'</code></td>
+            </tr>
+            <tr>
+                <td>closesrtext</td>
+                <td>string</td>
+                <td>'Close'</td>
+                <td>Screen reader only text alternative for close links when using option <code>trigger: 'click'</code></td>
+            </tr>
+            <tr>
+                <td>target</td>
+                <td>string</td>
+                <td>null</td>
+                <td>The selector (jQuery style) of the target tooltip.</td>
+            </tr>
+            <tr>
+                <td>title</td>
+                <td>string | function</td>
+                <td>''</td>
+                <td>Default title value if <code>title</code> attribute isn't present.</td>
+            </tr>
+            <tr>
+                <td>unlink</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the <code>unlink</code> method should be called when the tooltip is hidden.  This leaves the tooltip behind in the DOM.</td>
+            </tr>
+            <tr>
+                <td>dispose</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>If the <code>dispose</code> method should be called when the tooltip is hidden. This will remove the tooltip from the DOM.</td>
+            </tr>
+            <tr>
+                <td>show</td>
+                <td>boolean</td>
+                <td>false</td>
+                <td>Show the tooltip automatically at the end of initialization. This will force the <code>trigger</code> option to a setting of <code>'click'</code>.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 ### Methods
 
@@ -369,52 +371,54 @@ Calls the `unlink` method, and then removes the tooltip from the DOM.
 
 Event callbacks happen on the toggle/trigger element.
 
-<table class="table table-scroll table-bordered table-striped">
-<thead>
-    <tr>
-        <th style="width: 150px;">Event Type</th>
-        <th>Description</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <td>init.cfw.tooltip</td>
-        <td>This event fires after the tooltip item is initialized.</td>
-    </tr>
-    <tr>
-        <td>beforeShow.cfw.tooltip</td>
-        <td>This event is fired immediately when the <code>show</code> method is called.  If the tooltip container is not present, it is created just after this event is called.</td>
-    </tr>
-    <tr>
-        <td>afterShow.cfw.tooltip</td>
-        <td>This event is fired when a tooltip has been made visible to the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>beforeHide.cfw.tooltip</td>
-        <td>This event is fired immediately when the <code>hide</code> method is called.</td>
-    </tr>
-    <tr>
-        <td>afterHide.cfw.tooltip</td>
-        <td>This event is fired when a tooltip has been hidden from the user (will wait for CSS transitions to complete).</td>
-    </tr>
-    <tr>
-        <td>inserted.cfw.tooltip</td>
-        <td>This event is fired after the <code>beforeShow.cfw.tooltip</code> event when the tooltip has been added to the DOM.</td>
-    </tr>
-    <tr>
-        <td>beforeUnlink.cfw.tooltip</td>
-        <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the <code>beforeHide</code> event if set to automatically unlink, or before if called via method.</td>
-    </tr>
-    <tr>
-        <td>afterUnlink.cfw.tooltip</td>
-        <td>This event is fired when a tooltip item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
-    </tr>
-    <tr>
-        <td>dispose.cfw.tooltip</td>
-        <td>This event is fired immediately before the tooltip item is removed from the DOM.</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 150px;">Event Type</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>init.cfw.tooltip</td>
+                <td>This event fires after the tooltip item is initialized.</td>
+            </tr>
+            <tr>
+                <td>beforeShow.cfw.tooltip</td>
+                <td>This event is fired immediately when the <code>show</code> method is called.  If the tooltip container is not present, it is created just after this event is called.</td>
+            </tr>
+            <tr>
+                <td>afterShow.cfw.tooltip</td>
+                <td>This event is fired when a tooltip has been made visible to the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>beforeHide.cfw.tooltip</td>
+                <td>This event is fired immediately when the <code>hide</code> method is called.</td>
+            </tr>
+            <tr>
+                <td>afterHide.cfw.tooltip</td>
+                <td>This event is fired when a tooltip has been hidden from the user (will wait for CSS transitions to complete).</td>
+            </tr>
+            <tr>
+                <td>inserted.cfw.tooltip</td>
+                <td>This event is fired after the <code>beforeShow.cfw.tooltip</code> event when the tooltip has been added to the DOM.</td>
+            </tr>
+            <tr>
+                <td>beforeUnlink.cfw.tooltip</td>
+                <td>This event is fired immediately when the <code>unlink</code> method is called. This event can occur after the <code>beforeHide</code> event if set to automatically unlink, or before if called via method.</td>
+            </tr>
+            <tr>
+                <td>afterUnlink.cfw.tooltip</td>
+                <td>This event is fired when a tooltip item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+            </tr>
+            <tr>
+                <td>dispose.cfw.tooltip</td>
+                <td>This event is fired immediately before the tooltip item is removed from the DOM.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 {% highlight js %}
 $('#myTooltip').on('afterHide.cfw.tooltip', function () {

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -322,9 +322,9 @@ $component-active-hover-bg:     map-deep-get($context-themes, "primary", "contro
 $component-disabled-color:      $uibase-400 !default;
 $component-disabled-bg:         transparent !default;
 
-$component-overlay-border-color:    rgba($uibase-900, .3) !default;
+$component-overlay-border-color:    rgba($uibase-900, .4) !default;
 $component-section-bg:              rgba($uibase-900, .0875) !default;
-$component-section-border-color:    rgba($uibase-900, .2) !default;
+$component-section-border-color:    rgba($uibase-900, .3) !default;
 
 
 // Component sizes
@@ -468,24 +468,24 @@ $table-cell-padding:            .75rem !default;
 $table-condensed-cell-padding:  .3125rem .5rem !default;
 $table-caption-color:           $uibase-500 !default;
 
-$table-bg:                  transparent !default;
+$table-bg:                  $component-bg !default;
 $table-bg-accent:           $component-section-bg !default;
 $table-bg-hover:            $component-hover-bg !default;
 $table-bg-active:           $table-bg-hover !default;
 $table-bg-active-hover:     $uibase-200 !default;
 
-$table-head-color:          $uibase-900 !default;
-$table-head-bg:             $component-section-bg !default;
-
-$table-inverse-color:       map-get($inverse-color, "color") !default;
-$table-inverse-bg:          map-get($inverse-color, "bg") !default;
-$table-inverse-border:      map-get($inverse-color, "border") !default;
-$table-inverse-bg-accent:   map-get($inverse-color, "active") !default;
-$table-inverse-bg-hover:    map-get($inverse-color, "hover-bg") !default;
-
 $table-border-width:        $border-width !default;
 $table-border-color:        $component-border-color !default;
+$table-head-border-width:   2 * $table-border-width !default;
+$table-body-border-width:   2 * $table-border-width !default;
+$table-foot-border-width:   2 * $table-border-width !default;
 
+$table-striped-selector:    odd !default;
+$table-striped-bgi-light:   linear-gradient(0deg, rgba($white, .125) 0%, rgba($white, .125) 100%) !default;
+$table-striped-bgi-dark:    linear-gradient(0deg, rgba($uibase-900, .075) 0%, rgba($uibase-900, .075) 100%) !default;
+
+$table-hover-bgi-light:     linear-gradient(0deg, rgba($white, .2) 0%, rgba($white, .2) 100%) !default;
+$table-hover-bgi-dark:      linear-gradient(0deg, rgba($uibase-900, .125) 0%, rgba($uibase-900, .125) 100%) !default;
 
 // Buttons
 // =====

--- a/scss/core/_tables.scss
+++ b/scss/core/_tables.scss
@@ -4,32 +4,167 @@
     max-width: 100%;
     margin-bottom: $table-margin-bottom;
     background-color: $table-bg; // Reset for nesting within parents with `background-color`.
+    border: 0 solid;
+    border-color: $table-border-color;
+
+    // Allow border color to inherit all the way down.
+    // Only use `border-*-width` later to turn border on/off.
+    thead,
+    tbody,
+    tfoot,
+    tr,
+    th,
+    td {
+        border: 0 solid;
+        border-color: inherit;
+    }
 
     th,
     td {
         padding: $table-cell-padding;
         vertical-align: top;
-        border-top: $table-border-width solid $table-border-color;
     }
 
-    thead th {
-        vertical-align: bottom;
-        border-bottom: (2 * $table-border-width) solid $table-border-color;
+    thead {
+        th {
+            vertical-align: bottom;
+        }
+    }
+
+    .table {
+        background-color: inherit;
+        border-color: inherit;
+    }
+}
+
+// Horizontal borders
+.table-bordered,
+.table-celled,
+.table-divided,
+.table-ruled {
+    th,
+    td {
+        border-bottom-width: $table-border-width;
+    }
+
+    thead {
+        th,
+        td {
+            border-bottom-width: $table-head-border-width;
+        }
     }
 
     tbody + tbody {
-        border-top: (2 * $table-border-width) solid $table-border-color;
+        border-top-width: $table-body-border-width;
     }
 
     tfoot {
         th,
         td {
-            border-top: (2 * $table-border-width) solid $table-border-color;
+            border-top-width: $table-foot-border-width;
+            border-bottom-width: 0;
         }
     }
+}
 
-    .table {
-        background-color: $table-bg;
+// stylelint-disable selector-max-type
+.table-celled,
+.table-divided {
+    tbody {
+        tr:last-child  {
+            > th,
+            > td {
+                border-bottom-width: 0;
+            }
+        }
+    }
+}
+// stylelint-enable selector-max-type
+
+.table-bordered,
+.table-ruled {
+    tfoot {
+        th,
+        td {
+            border-bottom-width: $table-border-width;
+        }
+    }
+}
+
+.table-bordered,
+.table-wrapped,
+.table-ruled {
+    &,
+    & .table {
+        border-top-width: $table-border-width;
+        border-bottom-width: $table-border-width;
+    }
+}
+
+// Vertical borders
+.table-bordered,
+.table-celled,
+.table-pillared,
+.table-walled {
+    th,
+    td {
+        border-left-width: $table-border-width;
+
+        &:last-child {
+            border-right-width: $table-border-width;
+        }
+    }
+}
+
+.table-pillared,
+.table-celled {
+    th,
+    td {
+        &:first-child  {
+            border-left-width: 0;
+        }
+        &:last-child {
+            border-right-width: 0;
+        }
+    }
+}
+
+.table-bordered,
+.table-wrapped,
+.table-walled {
+    &,
+    & .table {
+        border-right-width: $table-border-width;
+        border-left-width: $table-border-width;
+    }
+}
+
+// Striped table
+.table-striped-light {
+    tbody tr:nth-of-type(#{$table-striped-selector}) {
+        background-image: $table-striped-bgi-light;
+    }
+}
+.table-striped-dark {
+    tbody tr:nth-of-type(#{$table-striped-selector}) {
+        background-image: $table-striped-bgi-dark;
+    }
+}
+
+// Hover effect
+// Needs to be after striped table in order to overrule background.
+.table-hover-light {
+    tbody tr {
+        @include hover {
+            background-image: $table-hover-bgi-light;
+        }
+    }
+}
+.table-hover-dark {
+    tbody tr {
+        @include hover {
+            background-image: $table-hover-bgi-dark;
+        }
     }
 }
 
@@ -41,83 +176,6 @@
         padding: $table-condensed-cell-padding;
     }
 }
-
-// Bordered table
-.table-bordered {
-    border: $table-border-width solid $table-border-color;
-
-    th,
-    td {
-        border: $table-border-width solid $table-border-color;
-    }
-
-    thead {
-        th,
-        td {
-            border-bottom-width: (2 * $table-border-width);
-        }
-    }
-
-    tfoot {
-        th,
-        td {
-            border-top-width: (2 * $table-border-width);
-        }
-    }
-}
-
-// Borderless table
-.table-borderless {
-    th,
-    td {
-        border: 0;
-    }
-}
-
-// Table with no borders
-.table-noborder {
-    th,
-    td {
-        border: 0;
-    }
-
-    thead,
-    tfoot {
-        th,
-        td {
-            border: 0;
-        }
-    }
-}
-
-// Striped table
-.table-striped {
-    tbody tr:nth-of-type(odd) {
-        background-color: $table-bg-accent;
-    }
-
-    &.table-inverse tbody tr:nth-of-type(odd) {
-        background-color: $table-inverse-bg-accent;
-    }
-}
-
-
-// Hover effect
-// Needs to be after striped table in order to overrule background
-.table-hover {
-    tbody tr {
-        @include hover {
-            background-color: $table-bg-hover;
-        }
-    }
-
-    &.table-inverse tbody tr {
-        @include hover {
-            background-color: $table-inverse-bg-hover;
-        }
-    }
-}
-
 
 // Table backgrounds
 // Active variant
@@ -140,46 +198,16 @@
 }
 
 // Responsive scrolling table
+// Tables will no longet scroll when breakpoint is larger than the one designated.
 @each $bp in map-keys($grid-breakpoints) {
     $bprule: breakpoint-designator($bp);
 
     // Skip largest breakpoint for down (equivalent to `.table-scroll`)
     @if breakpoint-max($bp, $grid-breakpoints) != null {
-        .table-scroll-#{$bp}-down {
+        .table-scroll-#{$bp} {
             @include media-breakpoint-down($bp) {
                 @include table-scroll();
             }
         }
-    }
-}
-
-// Table color variants
-.thead-inverse,
-.tfoot-inverse {
-    th {
-        color: $table-inverse-color;
-        background-color: $table-inverse-bg;
-    }
-}
-.thead-default,
-.tfoot-default {
-    th {
-        color: $table-head-color;
-        background-color: $table-head-bg;
-    }
-}
-.table-inverse {
-    color: $table-inverse-color;
-    background-color: $table-inverse-bg;
-
-    &.table-bordered {
-        border: 0;
-    }
-
-    th,
-    td,
-    thead th,
-    tfoot th {
-        border-color: $table-inverse-border;
     }
 }

--- a/scss/mixins/_tables.scss
+++ b/scss/mixins/_tables.scss
@@ -30,12 +30,11 @@
 @mixin table-scroll() {
     display: block;
     width: 100%;
+    margin-bottom: $table-margin-bottom;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-    -ms-overflow-style: -ms-autohiding-scrollbar;
 
-    // Prevent double border on horizontal scroll due to `display: block;`
-    &.table-bordered {
-        border: 0;
+    > .table {
+        margin-bottom: 0;
     }
 }

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -397,8 +397,8 @@ Showing a <kbd>kdb sample</kbd>
 </tbody>
 </table>
 
-<h3>Inverse Table</h3>
-<table class="table table-inverse">
+<h3>Striped Table</h3>
+<table class="table table-striped-dark">
 <thead>
     <tr>
       <th>#</th>
@@ -428,8 +428,7 @@ Showing a <kbd>kdb sample</kbd>
 </tbody>
 </table>
 
-<h3>Striped Table</h3>
-<table class="table table-striped">
+<table class="table bg-dark border-light text-white table-striped-light">
 <thead>
     <tr>
       <th>#</th>
@@ -491,7 +490,37 @@ Showing a <kbd>kdb sample</kbd>
 </table>
 
 <h3>Hoverable Table</h3>
-<table class="table table-striped table-hover">
+<table class="table table-striped-dark table-hover-dark">
+<thead>
+    <tr>
+      <th>#</th>
+      <th>Table Header 1</th>
+      <th>Table Header 2</th>
+      <th>Table Header 3</th>
+    </tr>
+</thead>
+<tbody>
+    <tr>
+        <th scope="row">1</th>
+        <td>table cell</td>
+        <td>table cell</td>
+        <td>table cell</td>
+    </tr>
+    <tr>
+        <th scope="row">2</th>
+        <td colspan="2">table cell</td>
+        <td>table cell</td>
+    </tr>
+    <tr>
+        <th scope="row">3</th>
+        <td>table cell</td>
+        <td>table cell</td>
+        <td>table cell</td>
+    </tr>
+</tbody>
+</table>
+
+<table class="table bg-dark border-light text-white table-striped-light table-hover-light">
 <thead>
     <tr>
       <th>#</th>
@@ -552,154 +581,120 @@ Showing a <kbd>kdb sample</kbd>
 </tbody>
 </table>
 
-<h3>Table head options</h3>
-<table class="table">
-<thead class="thead-inverse">
-    <tr>
-      <th>#</th>
-      <th>Table Header 1</th>
-      <th>Table Header 2</th>
-      <th>Table Header 3</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th scope="row">1</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-</tbody>
-</table>
-
-<table class="table">
-<thead class="thead-default">
-    <tr>
-      <th>#</th>
-      <th>Table Header 1</th>
-      <th>Table Header 2</th>
-      <th>Table Header 3</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th scope="row">1</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-</tbody>
-</table>
 
 <h3>Scrolling Table</h3>
-<table class="table table-scroll text-nowrap">
-<thead>
-    <tr>
-      <th>#</th>
-      <th>Table Header 1</th>
-      <th>Table Header 2</th>
-      <th>Table Header 3</th>
-      <th>Table Header 4</th>
-      <th>Table Header 5</th>
-      <th>Table Header 6</th>
-      <th>Table Header 7</th>
-      <th>Table Header 8</th>
-      <th>Table Header 9</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th scope="row">1</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-    <tr>
-        <th scope="row">2</th>
-        <td colspan="2">table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-    <tr>
-        <th scope="row">3</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+  <table class="table text-nowrap">
+  <thead>
+      <tr>
+        <th>#</th>
+        <th>Table Header 1</th>
+        <th>Table Header 2</th>
+        <th>Table Header 3</th>
+        <th>Table Header 4</th>
+        <th>Table Header 5</th>
+        <th>Table Header 6</th>
+        <th>Table Header 7</th>
+        <th>Table Header 8</th>
+        <th>Table Header 9</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <th scope="row">1</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">2</th>
+          <td colspan="2">table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">3</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+  </tbody>
+  </table>
+</div>
 
 <h3>Bordered scrolling table</h3>
-<table class="table table-scroll table-bordered text-nowrap">
-<thead>
-    <tr>
-      <th>#</th>
-      <th>Table Header 1</th>
-      <th>Table Header 2</th>
-      <th>Table Header 3</th>
-      <th>Table Header 4</th>
-      <th>Table Header 5</th>
-      <th>Table Header 6</th>
-      <th>Table Header 7</th>
-      <th>Table Header 8</th>
-      <th>Table Header 9</th>
-    </tr>
-</thead>
-<tbody>
-    <tr>
-        <th scope="row">1</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-    <tr>
-        <th scope="row">2</th>
-        <td colspan="2">table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-    <tr>
-        <th scope="row">3</th>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-        <td>table cell</td>
-    </tr>
-</tbody>
-</table>
+<div class="table-scroll">
+  <table class="table table-bordered text-nowrap">
+  <thead>
+      <tr>
+        <th>#</th>
+        <th>Table Header 1</th>
+        <th>Table Header 2</th>
+        <th>Table Header 3</th>
+        <th>Table Header 4</th>
+        <th>Table Header 5</th>
+        <th>Table Header 6</th>
+        <th>Table Header 7</th>
+        <th>Table Header 8</th>
+        <th>Table Header 9</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <th scope="row">1</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">2</th>
+          <td colspan="2">table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">3</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+  </tbody>
+  </table>
+</div>
 
 <h3>Contextual table</h3>
 <table class="table table-bordered">
@@ -776,6 +771,29 @@ Showing a <kbd>kdb sample</kbd>
         <td>Hidden</td>
     </tr>
     </tbody>
+</table>
+
+<h3>Nested Table</h3>
+<table class="table table-striped">
+  <tbody>
+    <tr>
+      <td>
+        Row One
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td> Inner Table Row One: Styled with parent table style</td>
+          </tr>
+          <tr>
+            <td> Inner Table Rwo Two </td>
+          </td>
+        </table>
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 <h3>Default Form</h3>
@@ -1615,7 +1633,7 @@ Anchor variants:<br />
     <div class="progress-bar bg-danger" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
 
-<h3>Stripped Progress bars</h3>
+<h3>Striped Progress bars</h3>
 <div class="progress mb-1">
     <div class="progress-bar progress-bar-striped" role="progressbar" style="width: 10%" aria-valuenow="10" aria-valuemin="0" aria-valuemax="100"></div>
 </div>

--- a/test/visual/list.html
+++ b/test/visual/list.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<title>Figuration - Tooltip</title>
+<title>Figuration - List</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 

--- a/test/visual/table.html
+++ b/test/visual/table.html
@@ -1,0 +1,773 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<title>Figuration - Table</title>
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
+
+<script type="text/javascript" src="../../docs/assets/js/vendor/jquery.slim.min.js"></script>
+<script type="text/javascript" src="../../dist/js/figuration.js"></script>
+</head>
+<body>
+
+<div class="container">
+
+<h1>Tables</h1>
+
+<h2>Standard</h2>
+<table class="table">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Divided</h2>
+<table class="table table-divided">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Ruled</h2>
+<table class="table table-ruled">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Pillared</h2>
+<table class="table table-pillared">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Walled</h2>
+<table class="table table-walled">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Celled</h2>
+<table class="table table-celled">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Wrapped</h2>
+<table class="table table-wrapped">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Bordered</h2>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Striped</h2>
+<table class="table table-striped-dark">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<table class="table table-striped-light bg-dark border-light text-white">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Hover</h2>
+<table class="table table-hover-dark">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<table class="table table-hover-light bg-dark border-light text-white">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Hover &amp; Striped</h2>
+<table class="table table-striped-dark table-hover-dark">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<table class="table table-striped-light table-hover-light bg-dark border-light text-white">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Scrolling</h2>
+<div class="table-scroll">
+  <table class="table table-bordered text-nowrap">
+  <thead>
+      <tr>
+        <th>#</th>
+        <th>Table Header 1</th>
+        <th>Table Header 2</th>
+        <th>Table Header 3</th>
+        <th>Table Header 4</th>
+        <th>Table Header 5</th>
+        <th>Table Header 6</th>
+        <th>Table Header 7</th>
+        <th>Table Header 8</th>
+        <th>Table Header 9</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr>
+          <th scope="row">1</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">2</th>
+          <td colspan="2">table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+      <tr>
+          <th scope="row">3</th>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+          <td>table cell</td>
+      </tr>
+  </tbody>
+  </table>
+</div>
+
+<h2>Color</h2>
+<table class="table table-bordered border-primary">
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<table class="table table-bordered">
+    <thead>
+        <tr class="bg-danger text-white">
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td class="bg-info text-light">Cell</td>
+            <td>Cell</td>
+            <td class="bg-success">Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot>
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<table class="table table-bordered bg-info text-light">
+    <thead class="text-white">
+        <tr>
+            <th>#</th>
+            <th>Header 1</th>
+            <th>Header 2</th>
+            <th>Header 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td colspan="2">Spanned Cell</td>
+            <td>Cell</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>Cell</td>
+            <td>Cell</td>
+            <td>Cell</td>
+        </tr>
+    </tbody>
+    <tfoot class="text-white">
+        <tr>
+            <th>#</th>
+            <th>Footer 1</th>
+            <th>Footer 2</th>
+            <th>Footer 3</th>
+        </tr>
+    </tfoot>
+</table>
+
+<h2>Nested Table</h2>
+<table class="table">
+    <tr>
+        <td> 1 </td>
+        <td> 2 </td>
+    </tr>
+    <tr>
+        <td> 3 </td>
+        <td>
+            <table class="table">
+                <tr>
+                    <td>
+                        <table class="table">
+                            <tr>
+                                <td> 4 </td>
+                                <td> 5 </td>
+                            </tr>
+                            <tr>
+                                <td> 7 </td>
+                                <td> 8 </td>
+                            </tr>
+                        </table>
+                    </td>
+                    <td> 6 </td>
+                    </tr>
+                <tr>
+                    <td> 9 </td>
+                    <td> 10 </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Turn the `.table` into more of a component that builds from a simple base with modifiers to alter the vidual design.

- Table now starts with a basic, simplified, layout.
- Updated border variants with new horizontal and vertical options.
- Borders now use `border-*-color: inherit` to allow for use of color utilities.
- Put `.table-scroll-*` back to the wrapper, so the `display: block;` override does not mess with screen-readers.
- Dropped the `-down` portion from `.table-scroll-*`.

Long term plan is to remove contextual colors and go to a more utility based color system.