### PR TITLE
Widgets: use function.bind(x) instead of $.proxy(function, x)

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -35,8 +35,8 @@
 
             // Bind events
             this.$target = $(this.settings.target)
-                .on('scroll.cfw.affix',  $.proxy(this.checkPosition, this))
-                .on('click.cfw.affix',  $.proxy(this.checkPositionDelayed, this));
+                .on('scroll.cfw.affix',  this.checkPosition.bind(this))
+                .on('click.cfw.affix',  this.checkPositionDelayed.bind(this));
 
             this.$element.CFW_trigger('init.cfw.affix');
 
@@ -74,7 +74,7 @@
         },
 
         checkPositionDelayed : function() {
-            setTimeout($.proxy(this.checkPosition, this), 1);
+            setTimeout(this.checkPosition.bind(this), 1);
         },
 
         checkPosition : function() {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -72,7 +72,7 @@
 
             // Bind click handler
             this.$element
-                .on('click.cfw.collapse', $.proxy(this.toggle, this))
+                .on('click.cfw.collapse', this.toggle.bind(this))
                 .CFW_trigger('init.cfw.collapse');
         },
 

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -117,7 +117,8 @@
                 this.$target.addClass('collapsing');
             }
 
-            var scrollSize = $.camelCase(['scroll', dimension].join('-'));
+            var capitalizedDimension = dimension[0].toUpperCase() + dimension.slice(1);
+            var scrollSize = 'scroll' + capitalizedDimension;
 
             // Determine/set dimension size for each target (triggers the transition)
             function start() {

--- a/js/drag.js
+++ b/js/drag.js
@@ -47,7 +47,7 @@
         },
 
         _dragStartOn : function() {
-            this.$element.on('mousedown.cfw.dragstart touchstart.cfw.dragstart MSPointerDown.cfw.dragstart', $.proxy(this._dragStart, this));
+            this.$element.on('mousedown.cfw.dragstart touchstart.cfw.dragstart MSPointerDown.cfw.dragstart', this._dragStart.bind(this));
             // prevent image dragging in IE...
             if (this.$element[0].attachEvent) {
                 this.$element[0].attachEvent('ondragstart', this._dontStart);

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -336,7 +336,7 @@
                         }
                     }
 
-                    $(window).on('resize.cfw.dropdown.' + this.instance, $.proxy(this._containerPlacement, this));
+                    $(window).on('resize.cfw.dropdown.' + this.instance, this._containerPlacement.bind(this));
                     this._containerPlacement();
                 }
             }

--- a/js/equalize.js
+++ b/js/equalize.js
@@ -56,10 +56,10 @@
                 this.$target.CFW_mutationListen();
                 this.$element
                     .attr('data-cfw-mutate', '')
-                    .on('mutate.cfw.mutate', $.proxy(this._equalize, this));
+                    .on('mutate.cfw.mutate', this._equalize.bind(this));
             }
 
-            this.$window.on('resize.cfw.equalize.' + this.instance, $.CFW_throttle($.proxy(this._equalize, this), this.settings.throttle));
+            this.$window.on('resize.cfw.equalize.' + this.instance, $.CFW_throttle(this._equalize.bind(this), this.settings.throttle));
 
             this.$element.attr('data-cfw', 'equalize');
             this.$element.CFW_trigger('init.cfw.equalize');

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -53,14 +53,14 @@
             for (var i = eventTypes.length; i--;) {
                 var eventType = eventTypes[i];
                 if (eventType == 'scroll' || eventType == 'resize') {
-                    $(this.settings.container).on(eventType + '.cfw.lazy.' + this.instance, $.CFW_throttle($.proxy(this._handleTrigger, this), this.settings.throttle));
+                    $(this.settings.container).on(eventType + '.cfw.lazy.' + this.instance, $.CFW_throttle(this._handleTrigger.bind(this), this.settings.throttle));
                     checkInitViewport = true;
                 } else if (eventType == 'mutate') {
                     this.$element
                         .attr('data-cfw-mutate', '')
-                        .on('mutate.cfw.mutate', $.proxy(this._handleTrigger, this));
+                        .on('mutate.cfw.mutate', this._handleTrigger.bind(this));
                 } else {
-                    this.$element.on(eventType + '.cfw.lazy', $.proxy(this.show, this));
+                    this.$element.on(eventType + '.cfw.lazy', this.show.bind(this));
                 }
             }
 

--- a/js/modal.js
+++ b/js/modal.js
@@ -71,7 +71,7 @@
             this.$dialog.attr('role', 'document');
 
             // Bind click handler
-            this.$element.on('click.cfw.modal', $.proxy(this.toggle, this));
+            this.$element.on('click.cfw.modal', this.toggle.bind(this));
 
             this.$target.data('cfw.modal', this);
 
@@ -153,7 +153,7 @@
 
             // Use modal dialog, not modal container, since
             // that is where the animation happens
-            this.$dialog.CFW_transition(null, $.proxy(this._hideComplete, this));
+            this.$dialog.CFW_transition(null, this._hideComplete.bind(this));
         },
 
         _showComplete : function() {
@@ -267,7 +267,7 @@
 
         resize : function() {
             if (this.isShown) {
-                $(window).on('resize.cfw.modal', $.proxy(this.handleUpdate, this));
+                $(window).on('resize.cfw.modal', this.handleUpdate.bind(this));
             } else {
                 $(window).off('resize.cfw.modal');
             }
@@ -336,7 +336,7 @@
             }
 
             this.$target
-                .on('touchmove.cfw.modal', $.proxy(this._scrollBlock, this))
+                .on('touchmove.cfw.modal', this._scrollBlock.bind(this))
                 .CFW_trigger('scrollbarSet.cfw.modal');
         },
 

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -32,7 +32,7 @@
 
     CFW_Widget_Scrollspy.prototype = {
         _init : function() {
-            this.$scrollElement.on('scroll.cfw.scrollspy', $.CFW_throttle($.proxy(this.process, this), this.settings.throttle));
+            this.$scrollElement.on('scroll.cfw.scrollspy', $.CFW_throttle(this.process.bind(this), this.settings.throttle));
             this.selector = (this.settings.target || '') + ' a, ' +
                             (this.settings.target || '') + ' [data-cfw-scrollspy-target]';
             this.$scrollElement.CFW_trigger('init.cfw.scrollspy');

--- a/js/scrollspy.js
+++ b/js/scrollspy.js
@@ -50,7 +50,7 @@
             var offsetMethod = 'offset';
             var offsetBase = 0;
 
-            if (!$.isWindow(this.$scrollElement[0])) {
+            if (this.$scrollElement[0] != null && this.$scrollElement[0] !== this.$scrollElement[0].window) {
                 offsetMethod = 'position';
                 offsetBase   = this.$scrollElement.scrollTop();
             }

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -60,7 +60,7 @@
 
             this.settings = this.getSettings(options);
 
-            this.$viewport = this.settings.viewport && $($.isFunction(this.settings.viewport) ? this.settings.viewport.call(this, this.$element) : (this.settings.viewport.selector || this.settings.viewport));
+            this.$viewport = this.settings.viewport && $((typeof(this.settings.viewport) === "function") ? this.settings.viewport.call(this, this.$element) : (this.settings.viewport.selector || this.settings.viewport));
 
             this.inState = { click: false, hover: false, focus: false };
 

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -174,7 +174,7 @@
                     // Click events
                     this.$element
                         .off('click.cfw.' + this.type)
-                        .on('click.cfw.' + this.type, $.proxy(this.toggle, this));
+                        .on('click.cfw.' + this.type, this.toggle.bind(this));
 
                     // Inject close button
                     if (this.$target != null && !this.closeAdded) {
@@ -191,12 +191,12 @@
                     var eventOut = (eventType == 'hover') ? 'mouseleave' : 'focusout';
 
                     if (modeInit) {
-                        this.$element.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
-                        this.$element.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
+                        this.$element.on(eventIn  + '.cfw.' + this.type, this.enter.bind(this));
+                        this.$element.on(eventOut + '.cfw.' + this.type, this.leave.bind(this));
                     } else {
                         this.$target.off('.cfw.' + this.type);
-                        this.$target.on(eventIn  + '.cfw.' + this.type, $.proxy(this.enter, this));
-                        this.$target.on(eventOut + '.cfw.' + this.type, $.proxy(this.leave, this));
+                        this.$target.on(eventIn  + '.cfw.' + this.type, this.enter.bind(this));
+                        this.$target.on(eventOut + '.cfw.' + this.type, this.leave.bind(this));
                     }
                 }
             }
@@ -443,9 +443,9 @@
             }
 
             // Basic resize handler
-            $(window).on('resize.cfw.' + this.type + '.' + this.instance, $.proxy(this.locateTip, this));
+            $(window).on('resize.cfw.' + this.type + '.' + this.instance, this.locateTip.bind(this));
 
-            this.$target.CFW_transition(null, $.proxy(this._showComplete, this));
+            this.$target.CFW_transition(null, this._showComplete.bind(this));
         },
 
         hide : function(force) {
@@ -480,7 +480,7 @@
                 $('body').children().off('mouseover', null, $.noop);
             }
 
-            this.$target.CFW_transition(null, $.proxy(this._hideComplete, this));
+            this.$target.CFW_transition(null, this._hideComplete.bind(this));
 
             this.hoverState = null;
         },

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -60,7 +60,7 @@
 
             this.settings = this.getSettings(options);
 
-            this.$viewport = this.settings.viewport && $((typeof(this.settings.viewport) === "function") ? this.settings.viewport.call(this, this.$element) : (this.settings.viewport.selector || this.settings.viewport));
+            this.$viewport = this.settings.viewport && $((typeof(this.settings.viewport) === 'function') ? this.settings.viewport.call(this, this.$element) : (this.settings.viewport.selector || this.settings.viewport));
 
             this.inState = { click: false, hover: false, focus: false };
 


### PR DESCRIPTION
jQuery.proxy is being deprecated, but not removed, according to:
http://blog.jquery.com/2018/01/19/jquery-3-3-0-a-fragrant-bouquet-of-deprecations-and-is-that-a-new-feature/

Just in case, we can use the standard .bind() instead. 


