### PR TITLE
v4 - Add `prefers-reduced-motion` media query

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -28,6 +28,9 @@
     "length-zero-no-unit": true,
     "max-empty-lines": 2,
     "max-line-length": null,
+    "media-feature-name-no-unknown": [true, {
+      "ignoreMediaFeatureNames": ["prefers-reduced-motion"]
+    }],
     "media-feature-name-no-vendor-prefix": true,
     "media-feature-parentheses-space-inside": "never",
     "media-feature-range-operator-space-after": "always",

--- a/docs/get-started/accessibility.md
+++ b/docs/get-started/accessibility.md
@@ -86,6 +86,10 @@ $('.disabled').on('click', function(e) {
 
 Using color to add meaning only provides a visual indication, which will not be conveyed to users of assistive technologies---such as screen readers---or users that might be colorbind. Ensure that information denoted by the color is either obvious from the content itself (e.g. the visible text), or is included through alternative means, such as additional text hidden with the `.sr-only` class.
 
+## Reduced Motion
+
+Figuration includes support for the [`prefers-reduced-motion` media feature](https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-motion). In browsers/environments that allow the user to specify their preference for reduced motion, most CSS transition effects in Figuration (for instance, when a modal dialog is opened or closed) will be disabled. Currently, support is limited to Safari on macOS and iOS.
+
 ## Additional Resources
 
 - [Web Content Accessibility Guidelines (WCAG) 2.0](https://www.w3.org/TR/WCAG20/)

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -27,15 +27,6 @@
     // iOS Safari bug: https://bugs.webkit.org/show_bug.cgi?id=158342
     // See also https://github.com/twbs/bootstrap/issues/17695
     //-webkit-overflow-scrolling: touch;
-
-    // When fading in the modal, animate it to slide down
-    &.fade .modal-dialog {
-        @if $enable-transitions {
-            transition: $modal-transition;
-            transform: translate(0, -25%);
-        }
-    }
-    &.in .modal-dialog { transform: translate(0, 0); }
 }
 .modal-open .modal {
     overflow-x: hidden;
@@ -50,6 +41,15 @@
     direction: ltr;
     // Allow clicks to pass through for custom click handling to close modal
     pointer-events: none;
+
+    // When fading in the modal, animate it to slide down
+    .modal.fade & {
+        @include transition($modal-transition);
+        transform: translate(0, -25%);
+    }
+    .modal.in & {
+        transform: translate(0, 0);
+    }
 }
 
 .modal-dialog-centered {

--- a/scss/mixins/_transition.scss
+++ b/scss/mixins/_transition.scss
@@ -1,5 +1,9 @@
 @mixin transition($transition...) {
     @if $enable-transitions {
         transition: $transition;
+
+        @media screen and (prefers-reduced-motion: reduce) {
+            transition: none;
+        }
     }
 }

--- a/scss/utilities/_embed.scss
+++ b/scss/utilities/_embed.scss
@@ -25,7 +25,6 @@
         border: 0;
     }
 }
-@warn type-of($embed-fluid-aspect-ratios);
 @if (type-of($embed-fluid-aspect-ratios) == "list" and length($embed-fluid-aspect-ratios) != 0) {
     @each $embed-fluid-aspect-ratio in $embed-fluid-aspect-ratios {
         $embed-fluid-x: nth($embed-fluid-aspect-ratio, 1);


### PR DESCRIPTION
Currently only supported on Safari for macOS and iOS.  Adding in now to future-proof as this should be coming to other browsers in the (near) future.

Here is a good explanation about why this is a good thing:
[CSS Tricks: An Introduction to the Reduced Motion Media Query](https://css-tricks.com/introduction-reduced-motion-media-query/)

More info:
[Specification: Media Queries Level 5](https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-motion)