### PR TITLE
V4 component breakpoints

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -205,6 +205,26 @@ $grid-breakpoints: (
 @include _assert-ascending($grid-breakpoints, "breakpoint", "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints);
 
+// Component and utility breakpoints
+// =====
+// Each component and utility that uses breakpoints gets its own list
+// of breakpoint keys based upon the master `$grid-breakpoints` map.
+// This way each the CSS for each of the items can be controlled and reduced as needed.
+// The items in the following lists *must* be in the keys for the `$grid-breakpoints` map.
+$card-deck-breakpoints:             map-keys($grid-breakpoints) !default;
+$card-group-breakpoints:            map-keys($grid-breakpoints) !default;
+$card-columns-breakpoints:          map-keys($grid-breakpoints) !default;
+$navbar-expand-breakpoints:         map-keys($grid-breakpoints) !default;
+$table-scroll-breakpoints:          map-keys($grid-breakpoints) !default;
+$utility-border-breakpoints:        map-keys($grid-breakpoints) !default;
+$utility-display-breakpoints:       map-keys($grid-breakpoints) !default;
+$utility-flex-breakpoints:          map-keys($grid-breakpoints) !default;
+$utility-float-breakpoints:         map-keys($grid-breakpoints) !default;
+$utility-position-breakpoints:      map-keys($grid-breakpoints) !default;
+$utility-screen-reader-breakpoints: map-keys($grid-breakpoints) !default;
+$utility-spacing-breakpoints:       map-keys($grid-breakpoints) !default;
+$utility-text-align-breakpoints:    map-keys($grid-breakpoints) !default;
+$utility-valign-breakpoints:        map-keys($grid-breakpoints) !default;
 
 // Grid containers
 // =====

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -145,6 +145,9 @@ $btn-outline-colors:    $base-colors !default;
 $list-colors:           $base-colors !default;
 $switch-colors:         $base-colors !default;
 $table-colors:          $base-colors !default;
+$utility-bg-colors:     $base-colors !default;
+$utility-border-colors: $base-colors !default;
+$utility-text-colors:   $base-colors !default;
 
 $alert-levels:          $level-context !default;
 $badge-levels:          $level-control !default;

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -134,7 +134,8 @@
     flex-direction: column;
 }
 
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $card-deck-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     .card-deck#{$bprule} {
@@ -186,7 +187,8 @@
     flex-direction: column;
 }
 
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $card-group-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     .card-group#{$bprule} {
@@ -250,7 +252,8 @@
 
 
 // Card columns
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $card-columns-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up(#{$breakpoint}) {

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -123,7 +123,8 @@
 // Generate series of `.navbar-expand-*` responsive classes for configuring
 // where your navbar collapses.
 .navbar-expand {
-    @each $bp in map-keys($grid-breakpoints) {
+    // Subset of of `$grid-breakpoints`
+    @each $bp in $navbar-expand-breakpoints {
         $bprule: breakpoint-designator($bp);
         $prev: breakpoint-prev($bp, $grid-breakpoints);
 

--- a/scss/core/_tables.scss
+++ b/scss/core/_tables.scss
@@ -199,7 +199,8 @@
 
 // Responsive scrolling table
 // Tables will no longet scroll when breakpoint is larger than the one designated.
-@each $bp in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $bp in $table-scroll-breakpoints {
     $bprule: breakpoint-designator($bp);
 
     // Skip largest breakpoint for down (equivalent to `.table-scroll`)

--- a/scss/utilities/_background.scss
+++ b/scss/utilities/_background.scss
@@ -1,8 +1,10 @@
 // stylelint-disable declaration-no-important
 
 // Contextual backgrounds
-@each $theme, $color in $base-colors {
-    @include bg-variant(".bg-#{$theme}", $color, $level-delta-hover-bg);
+@if (type-of($utility-bg-colors) == "map" and length($utility-bg-colors) != 0) {
+    @each $theme, $color in $utility-bg-colors {
+        @include bg-variant(".bg-#{$theme}", $color, $level-delta-hover-bg);
+    }
 }
 
 // Palette colors

--- a/scss/utilities/_border.scss
+++ b/scss/utilities/_border.scss
@@ -71,9 +71,11 @@
 
 // Border colors
 // Contextual borders
-@each $theme, $color in $base-colors {
-    .border-#{$theme} {
-        border-color: $color !important;
+@if (type-of($utility-border-colors) == "map" and length($utility-border-colors) != 0) {
+    @each $theme, $color in $utility-border-colors {
+        .border-#{$theme} {
+            border-color: $color !important;
+        }
     }
 }
 

--- a/scss/utilities/_border.scss
+++ b/scss/utilities/_border.scss
@@ -25,7 +25,8 @@
 
 
 // Repsonsive border addition and removal
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $utility-border-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {

--- a/scss/utilities/_display.scss
+++ b/scss/utilities/_display.scss
@@ -1,7 +1,8 @@
 // stylelint-disable declaration-no-important
 
 // Display utilities
-@each $bp in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $bp in $utility-display-breakpoints {
     $bprule: breakpoint-designator($bp);
 
     @include media-breakpoint-up($bp) {

--- a/scss/utilities/_flex.scss
+++ b/scss/utilities/_flex.scss
@@ -3,7 +3,8 @@
 // Flexbox utilities
 // Custom styles for additional flexbox alignment
 
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $utility-flex-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {

--- a/scss/utilities/_float.scss
+++ b/scss/utilities/_float.scss
@@ -1,4 +1,5 @@
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $utility-float-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {

--- a/scss/utilities/_position.scss
+++ b/scss/utilities/_position.scss
@@ -1,7 +1,8 @@
 // stylelint-disable declaration-no-important
 
 // Common positioning
-@each $breakpoint in map-keys($grid-breakpoints) {
+// Subset of of `$grid-breakpoints`
+@each $breakpoint in $utility-position-breakpoints {
     $bprule: breakpoint-designator($breakpoint);
 
     @include media-breakpoint-up($breakpoint) {

--- a/scss/utilities/_typography.scss
+++ b/scss/utilities/_typography.scss
@@ -37,8 +37,10 @@
 }
 
 // Contextual colors
-@each $theme, $color in $base-colors {
-    @include text-emphasis-variant(".text-#{$theme}", $color, $level-delta-hover-color);
+@if (type-of($utility-text-colors) == "map" and length($utility-text-colors) != 0) {
+    @each $theme, $color in $utility-text-colors {
+        @include text-emphasis-variant(".text-#{$theme}", $color, $level-delta-hover-color);
+    }
 }
 
 // Palette colors


### PR DESCRIPTION
Each component and util that generates responsive variants now has a list of defined breakpoints to generate CSS for.  This will allow for smaller generated CSS when using custom settings.  

**The list of *component breakpoints*, such as `$card-deck-breakpoints` must be a subset of the keys in the `$grid-breakpoints` map**.  No adding additional breakpoints here, only removing!

Removals will need to occur after the `_settings.scss` is parsed.

For example, if your site/application only uses card decks at `md` screens or larger, no need to generate all the card deck responsive classes.  If you start to use it at another breakpoint, simply stop removing it from the list.

