### PR TITLE
V4 custom range

### DIFF
--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -956,6 +956,29 @@ Please refer to the note regarding browser compatibility in the [color input](#c
 <input class="custom-color" type="color" value="#117dba" id="color">
 {% endexample %}
 
+### Range
+
+Create custom `<input type="range">` controls with `.custom-range`. The track (the background) and thumb (the value) are both styled to appear the same across browsers. As only IE and Firefox support "filling" their track from the left or right of the thumb as a means to visually indicate progress, we do not currently support it.  We also hide the tooltip provided only by IE to maintain cross-browser consistency.
+
+{% example html %}
+<label for="customRange1">Example range</label>
+<input type="range" class="custom-range" id="customRange1">
+{% endexample %}
+
+Range inputs have implicit values for `min` and `max`—`0` and `100`, respectively. You may specify new values for those using the `min` and `max` attributes.
+
+{% example html %}
+<label for="customRange2">Example range</label>
+<input type="range" class="custom-range" min="0" max="5" id="customRange2">
+{% endexample %}
+
+By default, range inputs "snap" to integer values. To change this, you can specify a `step` value. In the example below, we double the number of steps by using `step="0.5"`.
+
+{% example html %}
+<label for="customRange3">Example range</label>
+<input type="range" class="custom-range" min="0" max="5" step="0.5" id="customRange3">
+{% endexample %}
+
 ### File Browser
 
 The file input is the most gnarly of the bunch and requires additional JavaScript if you'd like to hook them up with functional *Choose file...* and selected file name text.

--- a/docs/widgets/slider.md
+++ b/docs/widgets/slider.md
@@ -133,7 +133,7 @@ $('#slider2').CFW_Slider({
 
 ## Usage
 
-The slider will determine the number of thumbs based on the nunber on inputs found within the specified container, up to a maximum of two thumbs.
+The slider will determine the number of thumbs based on the number on inputs found within the specified container, up to a maximum of two thumbs.
 
 If more than two inputs are found, the slider will use the first input found for the first thumb, and the last input found for the second thumb.
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -481,7 +481,7 @@ $transition-collapse-x: width .3s ease !default;
 
 // Component transitions
 $btn-transition:            color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
-$input-transition:          border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$input-transition:          background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 $modal-transition:          transform .3s ease-out !default;
 $progress-bar-transition:   width .3s ease !default;
 $switch-control-transition: background-color .3s ease !default;
@@ -717,6 +717,27 @@ $custom-file-button-disabled-opacity: .6 !default;
 $custom-file-text: (
     en: "Browse"
 ) !default;
+
+// Custom range
+$custom-range-track-height:         .5rem !default;
+$custom-range-track-cursor:         pointer !default;
+$custom-range-track-bg:             $uibase-100 !default;
+$custom-range-track-border:         0 !default;
+$custom-range-track-border-radius:  $custom-range-track-height !default;
+$custom-range-track-box-shadow:     map-get($shadows, "i1") !default;
+
+$custom-range-thumb-width:                  1.125rem !default;
+$custom-range-thumb-height:                 $custom-range-thumb-width !default;
+$custom-range-thumb-bg:                     $component-active-bg !default;
+$custom-range-thumb-border:                 0 !default;
+$custom-range-thumb-border-radius:          50% !default;
+$custom-range-thumb-box-shadow:             map-get($shadows, "d1") !default;
+$custom-range-thumb-focus-box-shadow:       $input-focus-box-shadow !default;
+$custom-range-thumb-focus-box-shadow-width: .1875rem !default;
+$custom-range-thumb-active-bg:              palette($component-active-bg, 600) !default;
+$custom-range-thumb-disabled-bg:            $uibase-300 !default;
+
+$custom-range-height:               $custom-range-thumb-height + ($custom-range-thumb-focus-box-shadow-width * 2) !default;
 
 // Form validation
 // =====
@@ -1103,9 +1124,11 @@ $slider-thumb-height:               1.25rem !default;
 $slider-thumb-border-radius:        50% !default;
 
 $slider-thumb-min-bg:               $primary !default;
-$slider-thumb-min-hover-bg:         palette($primary, 600) !default;
+$slider-thumb-min-focus-box-shadow: $input-focus-box-shadow-size rgba($slider-thumb-min-bg, $input-focus-box-shadow-alpha) !default;
+$slider-thumb-min-active-bg:        palette($primary, 600) !default;
 $slider-thumb-max-bg:               $danger !default;
-$slider-thumb-max-hover-bg:         palette($danger, 600) !default;
+$slider-thumb-max-focus-box-shadow: $input-focus-box-shadow-size rgba($slider-thumb-max-bg, $input-focus-box-shadow-alpha) !default;
+$slider-thumb-max-active-bg:        palette($danger, 600) !default;
 
 $slider-track-bg:                   $uibase-50 !default;
 $slider-track-border-radius:        $border-radius !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -770,7 +770,7 @@ $switch-active-indicator-box-shadow:    $btn-active-box-shadow !default;
 // =====
 $progress-height:               1rem !default;
 $progress-font-size:            ($font-size-base * .75) !default;
-$progress-bg:                   $uibase-50 !default;
+$progress-bg:                   $uibase-100 !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .125rem .125rem rgba($black, .1) !default;
 $progress-bar-color:            $white !default;
@@ -1110,13 +1110,13 @@ $modal-lg-breakpoint:           lg !default; // The minimum breakpoint to allow 
 // =====
 $slider-horizontal-height:          1.25rem !default;
 $slider-horizontal-margin:          .75rem !default;
-$slider-horizontal-track-height:    ($slider-horizontal-height / 2) !default;
+$slider-horizontal-track-height:    .5rem !default;
 $slider-horizontal-track-margin:    (($slider-horizontal-height - $slider-horizontal-track-height) / 2) !default;
 
 $slider-vertical-width:             1.25rem !default;
 $slider-vertical-height:            200px !default;
 $slider-vertical-margin:            .75rem !default;
-$slider-vertical-track-width:       ($slider-vertical-width / 2) !default;
+$slider-vertical-track-width:       .5rem !default;
 $slider-vertical-track-margin:      (($slider-vertical-width - $slider-vertical-track-width) / 2) !default;
 
 $slider-thumb-width:                1.25rem !default;
@@ -1130,7 +1130,7 @@ $slider-thumb-max-bg:               $danger !default;
 $slider-thumb-max-focus-box-shadow: $input-focus-box-shadow-size rgba($slider-thumb-max-bg, $input-focus-box-shadow-alpha) !default;
 $slider-thumb-max-active-bg:        palette($danger, 600) !default;
 
-$slider-track-bg:                   $uibase-50 !default;
+$slider-track-bg:                   $uibase-100 !default;
 $slider-track-border-radius:        $border-radius !default;
 
 $slider-selection-bg:               $uibase-300 !default;

--- a/scss/component/_slider.scss
+++ b/scss/component/_slider.scss
@@ -38,16 +38,28 @@
         box-shadow: $slider-thumb-shadow;
     }
 
-    @include hover-focus {
-        background-color: $slider-thumb-min-hover-bg;
+    &:focus {
+        outline: 0;
+        box-shadow: $slider-thumb-min-focus-box-shadow;
     }
+
+    &:active {
+        background-color: $slider-thumb-min-active-bg;
+    }
+
+
 }
 
 .slider-thumb-max {
     background-color: $slider-thumb-max-bg;
 
-    @include hover-focus {
-        background-color: $slider-thumb-max-hover-bg;
+    &:focus {
+        outline: 0;
+        box-shadow: $slider-thumb-max-focus-box-shadow;
+    }
+
+    &:active {
+        background-color: $slider-thumb-max-active-bg;
     }
 }
 

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -317,3 +317,100 @@
 .custom-color {
     @include transition($input-transition);
 }
+
+// Range
+// Each browser's pseudo-elements need to be seperate and cannot be
+// combined to provide for shared state support. Duplication is handled
+// with mixins.  Also some additional rules per browser.
+.custom-range {
+    width: 100%;
+    height: $custom-range-height;
+    padding: 0;
+    margin: 0;
+    background-color: transparent;
+    appearance: none;
+
+    &:focus {
+        outline: none;
+        &::-webkit-slider-thumb {
+            box-shadow: $custom-range-thumb-focus-box-shadow;
+        }
+        &::-moz-range-thumb {
+            box-shadow: $custom-range-thumb-focus-box-shadow;
+        }
+        &::-ms-thumb {
+            box-shadow: $custom-range-thumb-focus-box-shadow;
+        }
+    }
+
+    &::-moz-focus-outer {
+        border: 0;
+    }
+
+    &::-ms-tooltip {
+        display: none;
+    }
+
+    // Track
+    &::-webkit-slider-runnable-track {
+        @include custom-range-track();
+        background-color: $custom-range-track-bg;
+    }
+    &::-moz-range-track {
+        @include custom-range-track();
+        background-color: $custom-range-track-bg;
+    }
+    &::-ms-track {
+        @include custom-range-track();
+        background-color: transparent;
+    }
+    &::-ms-fill-lower {
+        background-color: $custom-range-track-bg;
+        @include border-radius($custom-range-track-border-radius);
+    }
+    &::-ms-fill-upper {
+        margin-right: $custom-range-thumb-width / 2;
+        background-color: $custom-range-track-bg;
+        @include border-radius($custom-range-track-border-radius);
+    }
+
+    &:not(:disabled) {
+        &::-webkit-slider-runnable-track {
+            cursor: $custom-range-track-cursor;
+        }
+        &::-moz-range-track {
+            cursor: $custom-range-track-cursor;
+        }
+        // Cursor does seem to have affect in IE/Edge so no rules set.
+    }
+
+    // Thumb
+    &::-webkit-slider-thumb {
+        @include custom-range-thumb();
+        // Vertically align thumb
+        margin-top: (($custom-range-track-height - $custom-range-thumb-height) / 2);
+    }
+    &::-moz-range-thumb {
+        @include custom-range-thumb();
+    }
+    &::-ms-thumb {
+        @include custom-range-thumb();
+        // Vertically align thumb
+        margin-top: 0;
+        // Stop clipping focus box-shadow
+        margin-right: $custom-range-thumb-focus-box-shadow-width;
+        margin-left: $custom-range-thumb-focus-box-shadow-width;
+    }
+
+    &:disabled {
+        &::-webkit-slider-thumb {
+            background-color: $custom-range-thumb-disabled-bg;
+        }
+        &::-moz-range-thumb {
+            background-color: $custom-range-thumb-disabled-bg;
+        }
+        &::-ms-thumb {
+            background-color: $custom-range-thumb-disabled-bg;
+        }
+    }
+}

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -271,7 +271,8 @@ textarea.form-control {
 
         // Allow folks to *not* use `.form-group`
         .form-control,
-        .custom-select {
+        .custom-select,
+        .custom-range {
             display: inline-block;
             width: auto; // Prevent labels from stacking above inputs in `.form-group`
             vertical-align: middle;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -147,3 +147,30 @@
     }
 }
 
+// Custom Range
+@mixin custom-range-track() {
+    box-sizing: border-box;
+    width: 100%;
+    height: $custom-range-track-height;
+    margin: 0 $custom-range-thumb-focus-box-shadow-width;
+    color: transparent;
+    border: $custom-range-track-border;
+    @include border-radius($custom-range-track-border-radius);
+    @include box-shadow($custom-range-track-box-shadow);
+}
+
+@mixin custom-range-thumb() {
+    box-sizing: border-box;
+    width: $custom-range-thumb-width;
+    height: $custom-range-thumb-height;
+    background-color: $custom-range-thumb-bg;
+    border: $custom-range-thumb-border;
+    @include border-radius($custom-range-thumb-border-radius);
+    @include box-shadow($custom-range-thumb-box-shadow);
+    @include transition($input-transition);
+    appearance: none;
+
+    &:active {
+        background-color: $custom-range-thumb-active-bg;
+    }
+}

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -100,7 +100,8 @@ body {
 .player-seek label {
     display: none;
 }
-.player-seek .slider.slider-horizontal {
+.player-seek .slider.slider-horizontal,
+.player-seek input[type="range"] {
     width: 100px;
 }
 .player-mute {
@@ -130,7 +131,8 @@ body {
 .player-volume label {
     display: none;
 }
-.player-volume .slider.slider-horizontal {
+.player-volume .slider.slider-horizontal,
+.player-volume input[type="range"] {
     width: 80px;
 }
 .player-fullscreen {
@@ -854,6 +856,49 @@ body {
                     <button type="button" class="btn btn-icon player-fullscreen-off" title="Fullscreen" aria-label="Fullscreen"><span class="fas fa-fw fa-arrows-alt"></span></button>
                 </span>
             </div>
+        </div>
+    </div>
+</div>
+
+<h2 class="h4">Using Range Inputs</h2>
+<div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
+    <div class="embed-fluid">
+        <video poster="../../docs/assets/video/niagara_falls.jpg" controls>
+            <source src="../../docs/assets/video/niagara_falls.mp4">
+            <track src="../../docs/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+            <track src="../../docs/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+        </video>
+    </div>
+    <div class="player-wrapper">
+        <div class="player" data-cfw-player="player">
+            <span class="player-control" data-cfw-player="control">
+                <button type="button" class="btn btn-icon" data-cfw-player="play" title="Play" aria-label="Play"><span class="fas fa-fw fa-play"></span></button>
+                <button type="button" class="btn btn-icon" data-cfw-player="pause" title="Pause" aria-label="Pause"><span class="fas fa-fw fa-pause"></span></button>
+                <button type="button" class="btn btn-icon" data-cfw-player="stop" title="Stop" aria-label="Stop"><span class="fas fa-fw fa-stop"></span></button>
+            </span>
+            <span class="player-time me-0_25" data-cfw-player="time">
+                <span class="player-time-current" data-cfw-player="time-current"></span>
+                <span class="player-seek form-inline" data-cfw-player="seek">
+                	<label for="rangeSeek0">Seek slider</label>
+                	<input type="range" id="rangeSeek0" class="custom-range">
+                </span>
+                <span class="player-time-duration" data-cfw-player="time-duration"></span>
+            </span>
+
+            <span class="player-mute me-0_25" data-cfw-player="mute">
+                <button type="button" class="btn btn-icon player-mute-on" title="Unmute" aria-label="Unmute"><span class="fas fa-fw fa-volume-off"></span></button>
+                <button type="button" class="btn btn-icon player-mute-off" title="Mute" aria-label="Mute"><span class="fas fa-fw fa-volume-up"></span></button>
+            </span>
+            <span class="player-volume form-inline me-0_25" data-cfw-player="volume">
+                <label for="rangeVol0">Seek slider</label>
+                <input type="range" id="rangeVol0" class="custom-range">
+            </span>
+            <button type="button" class="btn btn-icon me-0_25" data-cfw-player="loop" title="Repeat" aria-label="Repeat"><span class="fas fa-fw fa-redo"></span></button>
+            <button type="button" class="btn btn-icon me-0_25" data-cfw-player="caption" title="Closed Captions" aria-label="Closed Captions"><span class="fas fa-fw fa-closed-captioning"></span></button>
+            <span class="player-fullscreen" data-cfw-player="fullscreen">
+                <button type="button" class="btn btn-icon player-fullscreen-on" title="Exit fullscreen" aria-label="Exit fullscreen"><span class="fas fa-fw fa-arrows-alt"></span></button>
+                <button type="button" class="btn btn-icon player-fullscreen-off" title="Fullscreen" aria-label="Fullscreen"><span class="fas fa-fw fa-arrows-alt"></span></button>
+            </span>
         </div>
     </div>
 </div>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -207,6 +207,29 @@ $(window).ready(function() {
 
             <h2 id="slider">Slider:</h2>
 
+            <strong>Range Slider</strong>
+            <div class="slider-sample">
+                <form class="form-inline">
+                    <div id="sliderRange0" class="d-flex flex-items-center" data-cfw="slider" data-cfw-slider-min=0 data-cfw-slider-max=100 data-cfw-slider-step=1>
+                        <div class="form-group">
+                            <label id="sliderRange0_0_Label" for="sliderRange0_0" class="me-0_25">Value</label>
+                            <input id="sliderRange0_0" type="range">
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <strong>Custom Range Slider</strong>
+            <div class="slider-sample">
+                <form class="form-inline">
+                    <div id="sliderRange0" class="d-flex flex-items-center" data-cfw="slider" data-cfw-slider-min=0 data-cfw-slider-max=100 data-cfw-slider-step=1>
+                        <div class="form-group">
+                            <label id="sliderRange0_0_Label" for="sliderRange0_0" class="me-0_25">Value</label>
+                            <input id="sliderRange0_0" type="range" class="custom-range">
+                        </div>
+                    </div>
+                </form>
+            </div>
+
             <strong>Single Slider:</strong>
             <div class="slider-sample">
                 <form class="form-inline">

--- a/test/visual/custom-range.html
+++ b/test/visual/custom-range.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+<title>Figuration - Custom Range</title>
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
+
+<script src="../../docs/assets/js/vendor/jquery.slim.min.js"></script>
+<script src="../../dist/js/figuration.js"></script>
+
+<style>
+.select-sizing .btn {
+    vertical-align: top;
+}
+
+.form-control + .form-control,
+.custom-select + .custom-select {
+    margin-top: .5rem;
+}
+</style>
+
+</head>
+<body>
+
+<div class="container">
+
+<h1>Custom Range</h1>
+
+<div class="mb-1">
+    <div>
+        <label for="browserRange">Browser default range</label>
+    </div>
+    <input type="range" id="browserRange">
+</div>
+<div class="mb-1">
+    <label for="customRange1">Example range</label>
+    <input type="range" class="custom-range" id="customRange1">
+</div>
+<div class="mb-1">
+    <label for="customRange2">Example range - range 0-5</label>
+    <input type="range" class="custom-range" min="0" max="5" value="1" id="customRange2">
+</div>
+<div class="mb-1">
+    <label for="customRange3">Example range - range 0-5 + step 0.5</label>
+    <input type="range" class="custom-range" min="0" max="5" step="0.5" value="2.5" id="customRange3">
+</div>
+<div class="mb-1">
+    <label for="customRange4">Disabled</label>
+    <input type="range" class="custom-range" id="customRange4" disabled>
+</div>
+<div class="for-group form-row">
+    <label for="customRange5" class="col-sm-2 mb-0">Example range</label>
+    <div class="col-sm-10">
+        <input type="range" class="custom-range" id="customRange5">
+    </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Add custom styling for `input type="range"`. 

- Does not currently support validation styling, as this is a bit strange with range inputs anyway. [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#Validation).
- Range does not use a fill as it is not supported by all browsers yet.  
- The tooltip that IE presents is also hidden to keep a more consistent look.


This also allows us to make the Slider widget an optional addon.  Most likely the Slider widget and CSS will be removed from the base Figuration and be placed into its own repository.