### PR TITLE
extend breadcrumb divider

### DIFF
--- a/docs/assets/scss/_examples.scss
+++ b/docs/assets/scss/_examples.scss
@@ -369,3 +369,14 @@ $custom-file-text: (
         border: $border-width solid rgba(34, 68, 102, .2);
     }
 }
+
+// Breadcrumb
+.breadcrumb-chevron .breadcrumb-item + .breadcrumb-item::before {
+    content: quote(">");
+}
+.breadcrumb-icon .breadcrumb-item + .breadcrumb-item::before {
+    content: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIHZpZXdCb3g9IjAgMCA4IDgiPgogIDxwYXRoIGQ9Ik0xLjUgMGwtMS41IDEuNSAyLjUgMi41LTIuNSAyLjUgMS41IDEuNSA0LTQtNC00eiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMSkiIC8+Cjwvc3ZnPg==");
+}
+.breadcrumb-none .breadcrumb-item + .breadcrumb-item::before {
+    content: none;
+}

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -12,10 +12,6 @@ Indicate the current page's location within a navigational hierarchy.
 * ToC goes here
 {:toc}
 
-## Overview
-
-Separators are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content).
-
 ## Example
 
 {% example html %}
@@ -40,6 +36,50 @@ Separators are automatically added in CSS through [`::before`](https://developer
   </ol>
 </nav>
 {% endexample %}
+
+## Changing the Separator
+
+Separators are automatically added in CSS through [`::before`](https://developer.mozilla.org/en-US/docs/Web/CSS/::before) and [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content). They can be changed by changing `$breadcrumb-divider`. The [quote](http://sass-lang.com/documentation/Sass/Script/Functions.html#quote-instance_method) function is needed to generate the quotes around a string, so if you want `>` as seperator, you can use this:
+
+<div class="cf-example">
+    <nav aria-label="breadcrumb" role="navigation">
+        <ol class="breadcrumb breadcrumb-chevron">
+            <li class="breadcrumb-item"><a href="#">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Library</li>
+        </ol>
+    </nav>
+</div>
+{% highlight scss %}
+$breadcrumb-divider: quote(">");
+{% endhighlight %}
+
+It is also possible to use a **base64 embedded SVG icon**:
+
+<div class="cf-example">
+    <nav aria-label="breadcrumb" role="navigation">
+        <ol class="breadcrumb breadcrumb-icon">
+            <li class="breadcrumb-item"><a href="#">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Library</li>
+        </ol>
+    </nav>
+</div>
+{% highlight scss %}
+$breadcrumb-divider: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI4IiBoZWlnaHQ9IjgiIHZpZXdCb3g9IjAgMCA4IDgiPgogIDxwYXRoIGQ9Ik0xLjUgMGwtMS41IDEuNSAyLjUgMi41LTIuNSAyLjUgMS41IDEuNSA0LTQtNC00eiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMSkiIC8+Cjwvc3ZnPg==");
+{% endhighlight %}
+
+The separator can be removed by setting `$breadcrumb-divider` to `none`:
+
+<div class="cf-example">
+    <nav aria-label="breadcrumb" role="navigation">
+        <ol class="breadcrumb breadcrumb-none">
+            <li class="breadcrumb-item"><a href="#">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Library</li>
+        </ol>
+    </nav>
+</div>
+{% highlight scss %}
+$breadcrumb-divider: none;
+{% endhighlight %}
 
 ## Accessibility
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -800,9 +800,9 @@ $breadcrumb-margin-bottom:      1rem !default;
 
 $breadcrumb-active-color:       $uibase-700 !default;
 
-$breadcrumb-divider-padding-x:  .5rem !default;
+$breadcrumb-item-padding-x:     .5rem !default;
 $breadcrumb-divider-color:      $uibase-300 !default;
-$breadcrumb-divider:            "/" !default;
+$breadcrumb-divider:            quote("/") !default;
 
 
 // Pagination

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -7,12 +7,15 @@
 
 .breadcrumb-item {
     // The separator between breadcrumbs (by default, a forward-slash: "/")
-    + .breadcrumb-item::before {
-        display: inline-block; // Suppress underlining of the separator in modern browsers
-        padding-right: $breadcrumb-divider-padding-x;
-        padding-left: $breadcrumb-divider-padding-x;
-        color: $breadcrumb-divider-color;
-        content: "#{$breadcrumb-divider}";
+    + .breadcrumb-item {
+        padding-left: $breadcrumb-item-padding-x;
+
+        &::before {
+            display: inline-block; // Suppress underlining of the separator in modern browsers
+            padding-right: $breadcrumb-item-padding-x;
+            color: $breadcrumb-divider-color;
+            content: $breadcrumb-divider;
+        }
     }
 
     // IE10-11 hack to properly handle hyperlink underlines for breadcrumbs built


### PR DESCRIPTION
Allow greater flexibility for setting the breadcrumb divider.  Also allows for a `none` option by moving some of the padding to the breadcrumb item instead of keeping it on the `::before` pseudo-element.