### PR TITLE
reimplement validation icons

### DIFF
--- a/docs/content/forms.md
+++ b/docs/content/forms.md
@@ -1080,7 +1080,9 @@ With that in mind, consider the following demos for our custom form validation s
 
 For custom form validation messages, you'll need to add the `novalidate` boolean attribute to your `<form>`. This disables the browser default feedback tooltips, but still provides access to the form validation APIs in JavaScript. Try to submit the form below; our JavaScript will intercept the submit button and relay feedback to you.
 
-When attempting to submit, you'll see the `:invalid` and `:valid` styles applied to your form controls.
+When attempting to submit, you'll see the `:invalid` and `:valid` styles applied to the form controls.
+
+Custom feedback styles apply custom colors, borders, focus styles, feedback messages, and optional background icons to better communicate feedback. Background icons for `<select>`s are only available with `.custom-select`, and not `.form-control`.
 
 {% example html %}
 <form class="needs-validation" novalidate>
@@ -1264,10 +1266,16 @@ We recommend using client side validation, but in case you require server side, 
 
 ### Supported Elements
 
-Our example forms show native textual `<input>`s above, but form validation styles are available for our custom form controls, too.
+Our example forms show native textual `<input>`s above, but form validation styles are also available for `<textarea>`s and custom form controls.
 
 {% example html %}
 <form class="was-validated">
+  <div class="mb-1">
+    <label for="validate-textarea">Textarea</label>
+    <textarea class="form-control is-invalid" id="validate-textarea" rows="3" placeholder="Required example textarea" required></textarea>
+    <div class="invalid-feedback">Please enter a message in the textarea.</div>
+  </div>
+
   <div class="custom-control custom-checkbox mb-1">
     <input type="checkbox" class="custom-control-input" id="validate-support-1" required>
     <label class="custom-control-indicator" for="validate-support-1"></label>
@@ -1357,6 +1365,74 @@ If your form layout allows it, you can swap the `.{valid|invalid}-feedback` clas
       <div class="invalid-tooltip">Please provide a valid zip.</div>
     </div>
   </div>
+  <button class="btn btn-primary" type="submit">Submit form</button>
+</form>
+{% endexample %}
+
+### Icons
+
+Optional visual icon representations of the validation state can be added to _textual_ `<input class="form-control">`, `<textarea class="form-control">`, and `<select class="custom-select">` elements by adding a `.has-validation-icon` class.
+
+- Validation icons are `url()`s configured via Sass variables that are applied to `background-image` rules for each state.
+- You may use your own base64 PNGs or SVGs by updating the Sass variables and recompiling.
+- Icons can also be disabled entirely by setting the `$enable-validation-icons` variable to `false` in the [Sass global options]({{ site.baseurl }}/get-started/options/#global-options).
+
+{% example html %}
+<form class="needs-validation" novalidate>
+  <div class="form-row">
+    <div class="col-md-4 mb-1">
+      <label for="validate-icon-1">First name</label>
+      <input type="text" class="form-control has-validation-icon" id="validate-icon-1" placeholder="First name" value="John" required>
+      <div class="valid-feedback">Looks good!</div>
+    </div>
+    <div class="col-md-4 mb-1">
+      <label for="validate-icon-2">Last name</label>
+      <input type="text" class="form-control has-validation-icon" id="validate-icon-2" placeholder="Last name" value="Smith" required>
+      <div class="valid-feedback">Looks good!</div>
+    </div>
+    <div class="col-md-4 mb-1">
+      <label for="validate-icon-3">Username</label>
+      <div class="input-group">
+        <div class="input-group-addon">
+          <span class="input-group-text" id="validate-icon-4">@</span>
+        </div>
+        <input type="text" class="form-control has-validation-icon input-group-end" id="validate-icon-3" placeholder="Username" aria-describedby="validate-icon-4" required>
+        <div class="invalid-feedback">Please choose a unique and valid username.</div>
+      </div>
+    </div>
+  </div>
+  <div class="form-row">
+    <div class="col-md-6 mb-1">
+      <label for="validate-icon-5">City</label>
+      <input type="text" class="form-control has-validation-icon" id="validate-icon-5" placeholder="City" required>
+      <div class="invalid-feedback">Please provide a valid city.</div>
+    </div>
+    <div class="col-md-3 mb-1">
+      <label for="validate-icon-6">State</label>
+      <input type="text" class="form-control has-validation-icon" id="validate-icon-6" placeholder="State" required>
+      <div class="invalid-feedback">Please provide a valid state.</div>
+    </div>
+    <div class="col-md-3 mb-1">
+      <label for="validate-icon-7">Zip</label>
+      <input type="text" class="form-control has-validation-icon" id="validate-icon-7" placeholder="Zip" required>
+      <div class="invalid-feedback">Please provide a valid zip.</div>
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="validate-icon-8">Options</label>
+    <select class="custom-select has-validation-icon" id="validate-icon-8" required>
+      <option value="">Choose one...</option>
+      <option value="1">One</option>
+      <option value="2">Two</option>
+      <option value="3">Three</option>
+    </select>
+    <div class="invalid-feedback">Example invalid custom select feedback</div>
+  </div>
+  <div class="form-group">
+    <label for="validate-icon-9">Textarea</label>
+    <textarea class="form-control has-validation-icon" id="validate-icon-9" rows="3" placeholder="Required example textarea" required></textarea>
+    <div class="invalid-feedback">Please enter a message in the textarea.</div>
+    </div>
   <button class="btn btn-primary" type="submit">Submit form</button>
 </form>
 {% endexample %}

--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -163,19 +163,20 @@ $btn-colors: map-remove($btn-colors, "warning", "light", "dark");
 
 You can find and customize these variables for key global options in our `_settings.scss` file.
 
-| Variable               | Values                             | Description                                                                                      |
-| ---------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------|
-| `$spacer`              | `1rem` (default), or any value > 0 | Specifies the default spacer value used to programmatically generate the [Spacing utilities]({{ site.baseurl }}/utilities/spacing/). |
-| `$enable-rounded`      | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                 |
-| `$enable-shadows`      | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                    |
-| `$enable-transitions`  | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                          |
-| `$enable-grid-classes` | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.container`, `.row`, `.col-md-1`, etc.). |
-| `$enable-print-styles` | `true` (default) or `false`        | Enables predefined style overrides used when printing.                                           |
-| `$enable-palette`      | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500`, etc.). |
-| `$enable-sizing`       | `true` (default) or `false`        | Enables the generation of CSS classes for component sizes, and also for some utilites. (e.g. `.btn-small`, `.radius-t-xsmall`, etc.). |
-| `$enable-bp-smallest`  | `true` or `false` (default)        | Enables the generation of CSS classes for breakpoint sizes that include the smallest breakpoint designator. (e.g. `.col-xs-12`).  Also refer to the [Breakpoint Nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) section. |
-| `$enable-rfs-fluid`    | `true` or `false` (default)        | Enables the *fluid* Responsive typography option, , which fluidly scales element's `font-size` based on the dimensions of the viewport.  See the [Responsive Typography]({{ site.baseurl}}/content/typography/#responsive-typography) section for more details. |
-| `$enable-rfs-scale`    | `true` or `false` (default)        | Enabled the *scaled* Responsive typography option, which scales element's `font-size` on a per breakpoint basis.  See the [Responsive Typography]({{ site.baseurl}}/content/typography/#responsive-typography) section for more details. |
+| Variable                   | Values                             | Description                                                                                      |
+| -------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------|
+| `$spacer`                  | `1rem` (default), or any value > 0 | Specifies the default spacer value used to programmatically generate the [Spacing utilities]({{ site.baseurl }}/utilities/spacing/). |
+| `$enable-rounded`          | `true` (default) or `false`        | Enables predefined `border-radius` styles on various components.                                 |
+| `$enable-shadows`          | `true` or `false` (default)        | Enables predefined `box-shadow` styles on various components.                                    |
+| `$enable-transitions`      | `true` (default) or `false`        | Enables predefined `transition`s on various components.                                          |
+| `$enable-grid-classes`     | `true` (default) or `false`        | Enables the generation of CSS classes for the grid system (e.g. `.container`, `.row`, `.col-md-1`, etc.). |
+| `$enable-print-styles`     | `true` (default) or `false`        | Enables predefined style overrides used when printing.                                           |
+| `$enable-palette`          | `true` (default) or `false`        | Enables the generation of CSS classes for the palette color themes (e.g. `.text-blue-500`, etc.). |
+| `$enable-sizing`           | `true` (default) or `false`        | Enables the generation of CSS classes for component sizes, and also for some utilites. (e.g. `.btn-small`, `.radius-t-xsmall`, etc.). |
+| `$enable-bp-smallest`      | `true` or `false` (default)        | Enables the generation of CSS classes for breakpoint sizes that include the smallest breakpoint designator. (e.g. `.col-xs-12`).  Also refer to the [Breakpoint Nomenclature]({{ site.baseurl }}/layout/overview/#breakpoint-nomenclature) section. |
+| `$enable-rfs-fluid`        | `true` or `false` (default)        | Enables the *fluid* Responsive typography option, , which fluidly scales element's `font-size` based on the dimensions of the viewport.  See the [Responsive Typography]({{ site.baseurl}}/content/typography/#responsive-typography) section for more details. |
+| `$enable-rfs-scale`        | `true` or `false` (default)        | Enables the *scaled* Responsive typography option, which scales element's `font-size` on a per breakpoint basis.  See the [Responsive Typography]({{ site.baseurl}}/content/typography/#responsive-typography) section for more details. |
+| `$enable-validation-icons` | `true` (default) or `false`        | Enables the generation of CSS classes for the optional `background-image` icons within textual inputs and some custom forms for validation states. |
 
 ## Component Sizes
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -46,6 +46,8 @@ Some changes will most likely have been missed, so please refer to the documenta
 
 - Added custom styling for `input type="range"`.  At a later point the Slider widget will be removed from Figuration and moved into it's own repository.
 
+- Validation icons have been re-implemented.  The `.form-control-icon` has been replaced with `.has-validation-icon`. The icons are still optional and can now be used with textual `<input class="form-control">`, `<textarea class="form-control">`, and `<select class="custom-select">` elements.  Icons can be used within `.input-groups` but they no longer scale with the input sizing.
+
 {% comment %}
 ## Sizing
 {% endcomment %}

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1,18 +1,18 @@
 // Options
 // =====
 // Quickly modify global styling by enabling or disabling optional features.
-$enable-rounded:        true !default;      // true
-$enable-shadows:        false !default;     // false
-$enable-transitions:    true !default;      // true
-$enable-grid-classes:   true !default;      // true
-$enable-print-styles:   true !default;      // true
-$enable-palette:        true !default;      // true
-$enable-sizing:         true !default;      // true
-$enable-bp-smallest:    false !default;     // false
-$enable-rfs-fluid:      false !default;     // false
-$enable-rfs-scale:      false !default;     // false
-$enable-color-warnings: false !default;     // false
-
+$enable-rounded:            true !default;      // true
+$enable-shadows:            false !default;     // false
+$enable-transitions:        true !default;      // true
+$enable-grid-classes:       true !default;      // true
+$enable-print-styles:       true !default;      // true
+$enable-palette:            true !default;      // true
+$enable-sizing:             true !default;      // true
+$enable-bp-smallest:        false !default;     // false
+$enable-rfs-fluid:          false !default;     // false
+$enable-rfs-scale:          false !default;     // false
+$enable-color-warnings:     false !default;     // false
+$enable-validation-icons:   true !default;      // true
 
 // Palette
 // =====
@@ -739,10 +739,11 @@ $custom-switch-disabled-thumb-bg:           $uibase-200 !default;
 $custom-switch-disabled-checked-thumb-bg:   palette($primary, 200) !default;
 
 // Custom select
-$custom-select-indicator-offset:    .5rem !default;
-$custom-select-indicator-padding:   .75rem !default; // Extra padding to account for the presence of the background-image based indicator
-$custom-select-indicator-size:      8px 10px !default; // In pixels because image dimensions
-$custom-select-indicator:           url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23333' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E") !default;
+$custom-select-indicator-offset:    .375rem !default;
+$custom-select-indicator-width:     10px !default; // In pixels because image dimensions
+$custom-select-indicator-height:    10px !default; // In pixels because image dimensions
+$custom-select-indicator-image:     url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='%23333' d='M3 0l-3 3h6l-3-3zm-3 5l3 3 3-3h-6z'/%3E%3C/svg%3E") !default;
+$custom-select-indicator:           $custom-select-indicator-image no-repeat right $custom-select-indicator-offset center / $custom-select-indicator-width $custom-select-indicator-height !default; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
 
 // Custom file
 $custom-file-button-color:          $uibase-600 !default;
@@ -773,12 +774,23 @@ $custom-range-thumb-disabled-bg:            $uibase-300 !default;
 
 $custom-range-height:               $custom-range-thumb-height + ($custom-range-thumb-focus-box-shadow-width * 2) !default;
 
+
 // Form validation
 // =====
+// Icons from OpenIconic: https://useiconic.com/open
 $form-feedback-margin-top:      $form-text-margin-top !default;
 $form-feedback-font-size:       $small-font-size !default;
 $form-feedback-valid-color:     map-get($base-colors, "success") !default;
 $form-feedback-invalid-color:   map-get($base-colors, "danger") !default;
+
+$form-feedback-icon-offset:         .375rem !default;
+$form-feedback-icon-width:          16px !default; // In pixels because image dimensions
+$form-feedback-icon-height:         16px !default; // In pixels because image dimensions
+
+$form-feedback-icon-valid-color:    $form-feedback-valid-color !default;
+$form-feedback-icon-valid-image:    str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-feedback-icon-valid-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
+$form-feedback-icon-invalid-color:  $form-feedback-invalid-color !default;
+$form-feedback-icon-invalid-image:  str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{palette($danger, 500)}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='#{$form-feedback-icon-invalid-color}' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
 // Progress bars

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -224,11 +224,11 @@
     display: block;
     width: 100%;
     height: $input-height-outer;
-    padding: $input-padding-y ($input-padding-x + $custom-select-indicator-padding) $input-padding-y $input-padding-x;
+    padding: $input-padding-y calc(#{$input-padding-x} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset}) $input-padding-y $input-padding-x;
     color: $input-color;
     vertical-align: middle;
-    background: $input-bg $custom-select-indicator no-repeat right $custom-select-indicator-offset center;
-    background-size: $custom-select-indicator-size;
+    background: $input-bg $custom-select-indicator-image no-repeat right $custom-select-indicator-offset center;
+    background-size: $custom-select-indicator-width $custom-select-indicator-height;
     border: $input-border-width solid $input-border-color;
     @if $enable-rounded {
         border-radius: $input-border-radius;
@@ -282,7 +282,7 @@
         .custom-select-#{$size} {
             height: $sz-outer-height;
             padding: $sz-padding-y $sz-padding-x;
-            padding-right: ($sz-padding-x + $custom-select-indicator-padding);
+            padding-right: calc(#{$sz-padding-x} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
             @include font-size($sz-font-size);
             line-height: $sz-line-height;
             @include border-radius($sz-border-radius);

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -76,7 +76,7 @@ select.form-control {
 }
 
 textarea.form-control {
-    &[rows]:not([rows="1"]) {
+    &:not([rows="1"]) {
         height: auto;
     }
 }
@@ -230,8 +230,8 @@ textarea.form-control {
 // pseudo-classes but also includes `.is-invalid` and `.is-valid` classes for
 // server side validation.
 
-@include form-validation-state("valid", $form-feedback-valid-color);
-@include form-validation-state("invalid", $form-feedback-invalid-color);
+@include form-validation-state("valid", $form-feedback-valid-color, $form-feedback-icon-valid-image);
+@include form-validation-state("invalid", $form-feedback-invalid-color, $form-feedback-icon-invalid-image);
 
 
 // Inline forms

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -1,6 +1,6 @@
 // Form validation states
 // Generate the form validation CSS for valid and invalid states.
-@mixin form-validation-state($state, $color) {
+@mixin form-validation-state($state, $color, $icon) {
     .#{$state}-feedback {
         display: none;
         width: 100%;
@@ -37,6 +37,49 @@
             ~ .#{$state}-feedback,
             ~ .#{$state}-tooltip {
                 display: block;
+            }
+        }
+
+        @if $enable-validation-icons {
+            .was-validated &.has-validation-icon:#{$state},
+            &.has-validation-icon.is-#{$state} {
+                //background: $icon no-repeat right $form-feedback-icon-offset center / $form-feedback-icon-width $form-feedback-icon-height;
+                background-image: $icon;
+                background-repeat: no-repeat;
+                background-position: right $form-feedback-icon-offset center;
+                background-size: $form-feedback-icon-width $form-feedback-icon-height;
+            }
+        }
+    }
+
+    @if $enable-validation-icons {
+        .form-control:not(textarea) {
+            .was-validated &.has-validation-icon:#{$state},
+            &.has-validation-icon.is-#{$state} {
+                padding-right: calc(#{$input-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+            }
+        }
+
+        // Icon is placed on left, what should hopefully be the opposite side of the scrollbar,
+        // otherwise icon can become obscured by the scrollbar.
+        // stylelint-disable-next-line selector-no-qualifying-type
+        textarea.form-control {
+            .was-validated &.has-validation-icon:#{$state},
+            &.has-validation-icon.is-#{$state} {
+                padding-left: calc(#{$input-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+                background-position: left $form-feedback-icon-offset center;
+            }
+        }
+
+        // Apply both the select indicator and validaton icons.
+        .custom-select {
+            .was-validated &.has-validation-icon:#{$state},
+            &.has-validation-icon.is-#{$state} {
+                padding-right: calc(#{$input-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                background-image: $custom-select-indicator-image, $icon;
+                background-repeat: no-repeat, no-repeat;
+                background-position: right $custom-select-indicator-offset center, right calc(#{$form-feedback-icon-offset} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset}) center;
+                background-size: $custom-select-indicator-width $custom-select-indicator-height, $form-feedback-icon-width $form-feedback-icon-height;
             }
         }
     }
@@ -118,6 +161,39 @@
                 ~ .custom-file-label {
                     border-color: $color;
                     box-shadow: $input-focus-box-shadow-size rgba($color, $input-focus-box-shadow-alpha);
+                }
+            }
+        }
+    }
+
+    @if $enable-sizing {
+        @each $size, $dims in $input-sizes {
+            $sz-padding-x:     map-get($dims, "padding-x");
+
+            @if $enable-validation-icons {
+                .form-control-#{$size}:not(textarea),
+                .input-group-#{$size} > .form-control:not(textarea) {
+                    .was-validated &.has-validation-icon:#{$state},
+                    &.has-validation-icon.is-#{$state} {
+                        padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+                    }
+                }
+
+                // stylelint-disable-next-line selector-no-qualifying-type
+                textarea.form-control-#{$size},
+                .input-group-#{$size} > textarea.form-control {
+                    .was-validated &.has-validation-icon:#{$state},
+                    &.has-validation-icon.is-#{$state} {
+                        padding-left: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+                    }
+                }
+
+                .custom-select-#{$size},
+                .input-group-#{$size} > .custom-select {
+                    .was-validated &.has-validation-icon:#{$state},
+                    &.has-validation-icon.is-#{$state} {
+                        padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                    }
                 }
             }
         }

--- a/test/visual/form-validation.html
+++ b/test/visual/form-validation.html
@@ -207,6 +207,11 @@
 
 <h2>Custom Inputs</h2>
 <form class="was-validated">
+    <div class="mb-1">
+        <label for="validate-textarea">Textarea</label>
+        <textarea class="form-control is-invalid" id="validate-textarea" rows="3" placeholder="Required example textarea" required></textarea>
+        <div class="invalid-feedback">Please enter a message in the textarea.</div>
+    </div>
     <div class="custom-control custom-switch mb-1">
         <input type="checkbox" class="custom-control-input" id="customControlValidation0" required>
         <label class="custom-control-indicator" for="customControlValidation0"></label>
@@ -292,6 +297,78 @@
     </div>
 </form>
 
+<h2>Icons</h2>
+<form class="needs-validation" novalidate>
+    <div class="row">
+        <div class="col-md-4 mb-1">
+            <label for="validationIcon01">First name</label>
+            <input type="text" class="form-control has-validation-icon" id="validationIcon01" placeholder="First name" value="John" required>
+            <div class="valid-feedback">Looks good!</div>
+        </div>
+        <div class="col-md-4 mb-1">
+            <label for="validationIcon02">Last name</label>
+            <input type="text" class="form-control has-validation-icon" id="validationIcon02" placeholder="Last name" value="Smith" required>
+            <div class="valid-feedback">Looks good!</div>
+        </div>
+        <div class="col-md-4 mb-1">
+            <label for="validationIconUsername">Username</label>
+            <div class="input-group">
+                <div class="input-group-addon">
+                    <span class="input-group-text" id="validationIconUsernameAddon">@</span>
+                </div>
+                <input type="text" class="form-control has-validation-icon input-group-end" id="validationIconUsername" placeholder="Username" aria-describedby="validationIconUsernameAddon" required>
+                <div class="invalid-feedback">Please choose a unique and valid username.</div>
+            </div>
+        </div>
+    </div>
+    <div class="row form-group">
+        <div class="col-md-6 mb-1">
+            <label for="validationIcon03">City</label>
+            <input type="text" class="form-control has-validation-icon" id="validationIcon03" placeholder="City" required>
+            <div class="invalid-feedback">Please provide a valid city.</div>
+        </div>
+        <div class="col-md-3 mb-1">
+            <label for="validationIcon04">State</label>
+            <input type="text" class="form-control has-validation-icon" id="validationIcon04" placeholder="State" required>
+            <div class="invalid-feedback">Please provide a valid state.</div>
+        </div>
+        <div class="col-md-3 mb-1">
+            <label for="validationIcon05">Zip</label>
+            <input type="text" class="form-control has-validation-icon" id="validationIcon05" placeholder="Zip" required>
+            <div class="invalid-feedback">Please provide a valid zip.</div>
+        </div>
+    </div>
+    <div class="form-group">
+        <select class="custom-select has-validation-icon" required>
+            <option value="">Open this select menu</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+        </select>
+        <div class="invalid-feedback">Example invalid custom select feedback</div>
+    </div>
+    <div class="input-group input-group-large mb-1">
+        <div class="input-group-addon">
+            <span class="input-group-text" for="custom-select-1">Options</span>
+        </div>
+        <select class="custom-select has-validation-icon input-group-end" required>
+            <option value="">Choose...</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+        </select>
+        <div class="invalid-feedback">Example invalid custom select feedback</div>
+    </div>
+    <div class="form-group">
+        <label for="validationIcon06">Textarea</label>
+        <textarea class="form-control has-validation-icon" id="validationIcon06" rows="3" placeholder="Required example textarea" required></textarea>
+        <div class="invalid-feedback">Please enter a message in the textarea.</div>
+    </div>
+
+    <div class="form-group">
+        <button class="btn btn-primary" type="submit">Submit form</button>
+    </div>
+</form>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Optional visual icon representations of the validation state can be added to _textual_ `<input class="form-control">`, `<textarea class="form-control">`, and `<select class="custom-select">` elements by adding a `.has-validation-icon` class.

Icons no longer scale with input size.  Icons can also be used within `.input-group`s on the listed elements.