### PR TITLE
adjust drag and close coloring, add more settings

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -470,11 +470,17 @@ $close-font-size:       ($font-size-base * 1.5) !default;
 $close-font-weight:     $font-weight-bold !default;
 $close-color:           #000 !default;
 $close-text-shadow:     0 .0625rem 0 #fff !default;
+$close-opacity:         .6 !default;
+$close-hover-color:     #000 !default;
+$close-hover-opacity:   .75 !default;
 
 $drag-font-size:        ($font-size-base * 1.5) !default;
 $drag-font-weight:      $font-weight-bold !default;
 $drag-color:            #000 !default;
 $drag-text-shadow:      0 .0625rem 0 #fff !default;
+$drag-opacity:          .6 !default;
+$drag-hover-color:      #000 !default;
+$drag-hover-opacity:    .75 !default;
 
 
 // Transitions
@@ -1050,20 +1056,25 @@ $card-columns-column-gap:   1.25rem !default;
 
 // Tooltips
 // =====
-$tooltip-max-width:     rem(208px) !default;  // 208px=>13rem
-$tooltip-padding-y:     .25rem !default;
-$tooltip-padding-x:     .5rem !default;
-$tooltip-margin:        .2rem !default;
+$tooltip-max-width:             rem(208px) !default;  // 208px=>13rem
+$tooltip-padding-y:             .25rem !default;
+$tooltip-padding-x:             .5rem !default;
+$tooltip-margin:                .2rem !default;
 
-$tooltip-font-size:     ($font-size-base * .875) !default;
-$tooltip-bg:            $uibase-900 !default;
-$tooltip-color:         color-auto-contrast($uibase-900) !default;
-$tooltip-opacity:       .9 !default;
-$tooltip-border-radius: $border-radius !default;
+$tooltip-font-size:             ($font-size-base * .875) !default;
+$tooltip-bg:                    $uibase-900 !default;
+$tooltip-color:                 color-auto-contrast($uibase-900) !default;
+$tooltip-opacity:               .9 !default;
+$tooltip-border-radius:         $border-radius !default;
+
+$tooltip-close-color:           $tooltip-color !default;
+$tooltip-close-opacity:         $close-opacity !default;
+$tooltip-close-hover-color:     $tooltip-color !default;
+$tooltip-close-hover-opacity:   $close-hover-opacity !default;
 
 // Arrow dimension in pixels to get proper visual layout
-$tooltip-arrow-width:   .375rem !default;
-$tooltip-arrow-color:   $tooltip-bg !default;
+$tooltip-arrow-width:           .375rem !default;
+$tooltip-arrow-color:           $tooltip-bg !default;
 
 
 // Popovers

--- a/scss/component/_close.scss
+++ b/scss/component/_close.scss
@@ -6,15 +6,15 @@
     color: $close-color;
     text-decoration: none;
     text-shadow: $close-text-shadow;
-    opacity: .5;
+    opacity: $close-opacity;
 
     &:not(:disabled):not(.disabled) {
         cursor: pointer;
 
         @include hover-focus {
-            color: $close-color;
+            color: $close-hover-color;
             text-decoration: none;
-            opacity: .75;
+            opacity: $close-hover-opacity;
         }
     }
 }

--- a/scss/component/_drag.scss
+++ b/scss/component/_drag.scss
@@ -7,15 +7,15 @@
     text-decoration: none;
     text-shadow: $drag-text-shadow;
     touch-action: none;
-    opacity: .5;
+    opacity: $drag-opacity;
 
     &:not(:disabled):not(.disabled) {
         cursor: move;
 
         @include hover-focus {
-            color: $drag-color;
+            color: $drag-hover-color;
             text-decoration: none;
-            opacity: .75;
+            opacity: $drag-hover-opacity;
         }
     }
 }

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -68,13 +68,16 @@
         position: static;
         padding: $tooltip-padding-y $tooltip-padding-x;
         margin-top: -$tooltip-padding-y;
+        color: $tooltip-close-color;
         @include font-size(1.25rem);
-        color: $white;
         text-shadow: none;
-        opacity: 1;
+        opacity: $tooltip-close-opacity;
 
-        @include hover-focus() {
-            opacity: .75;
+        &:not(:disabled):not(.disabled) {
+            @include hover-focus {
+                color: $tooltip-close-hover-color;
+                opacity: $tooltip-close-hover-opacity;
+            }
         }
     }
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -20,7 +20,7 @@
         @include font-size($tooltip-font-size);
         color: color-auto-contrast($color);
         background-color: rgba($color, $tooltip-opacity);
-        border-radius: $border-radius;
+        border-radius: $tooltip-border-radius;
     }
 
     .form-control,


### PR DESCRIPTION
Add a few more settings for both the close and drag items.

Fixes issue with close hover color in tooltips.