### PR TITLE
Add relative font-weight utilities

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -21,7 +21,10 @@
     "declaration-empty-line-before": null,
     "declaration-no-important": true,
     "font-family-name-quotes": "always-where-recommended",
-    "font-weight-notation": "numeric",
+    "font-weight-notation": [
+      "numeric", {
+        "ignore": ["relative"]
+    }],
     "function-url-no-scheme-relative": true,
     "function-url-quotes": "always",
     "indentation": 4,

--- a/docs/utilities/typography.md
+++ b/docs/utilities/typography.md
@@ -73,14 +73,25 @@ Transform text in components with text capitalization classes.
 
 Note how `text-capitalize` only changes the first letter of each word, leaving the case of any other letters unaffected.
 
-## Font Weight and Italics
+## Font Weight
 
-Quickly change the weight (boldness) of text or italicize text.
+Quickly change the weight (boldness) of text.
+
+The `.font-weight-lighter` and `.font-weight-bolder` classes are relative by default, with `lighter` and `bolder` values respectively, but can be configured with numeric weights by overriding their values in the `_settings.scss`.
 
 {% example html %}
 <p class="font-weight-light">Light weight text.</p>
 <p class="font-weight-normal">Normal weight text.</p>
 <p class="font-weight-bold">Bold text.</p>
+<p class="font-weight-light">Light weight with <span class="font-weight-bolder">bolder weight</span> text.</p>
+<p class="font-weight-bold">Bold weight with <span class="font-weight-lighter">lighter weight</span> text.</p>
+{% endexample %}
+
+## Italics
+
+Italicize text with `.font-italic`.
+
+{% example html %}
 <p class="font-italic">Italic text.</p>
 {% endexample %}
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -304,9 +304,11 @@ $font-family-base:          $font-family-sans-serif !default;
 $font-size-base:    1rem !default;
 $line-height-base:  1.5 !default;
 
+$font-weight-lighter:   lighter !default;
 $font-weight-light:     300 !default;
-$font-weight-normal:    normal !default;
-$font-weight-bold:      bold !default;
+$font-weight-normal:    400 !default;
+$font-weight-bold:      700 !default;
+$font-weight-bolder:    bolder !default;
 $font-weight-base:      $font-weight-normal !default;
 
 $font-size-h1:  ($font-size-base * 2.5) !default;

--- a/scss/utilities/_typography.scss
+++ b/scss/utilities/_typography.scss
@@ -21,10 +21,12 @@
 .text-capitalize { text-transform: capitalize !important; }
 
 // Weight and italics
-.font-weight-light  { font-weight: $font-weight-light !important; }
-.font-weight-normal { font-weight: $font-weight-normal !important; }
-.font-weight-bold   { font-weight: $font-weight-bold !important; }
-.font-italic        { font-style: italic !important; }
+.font-weight-lighter { font-weight: $font-weight-lighter !important; }
+.font-weight-light   { font-weight: $font-weight-light !important; }
+.font-weight-normal  { font-weight: $font-weight-normal !important; }
+.font-weight-bold    { font-weight: $font-weight-bold !important; }
+.font-weight-bolder  { font-weight: $font-weight-bolder !important; }
+.font-italic         { font-style: italic !important; }
 
 // Font families
 .font-family-sans-serif { font-family: $font-family-sans-serif !important; }


### PR DESCRIPTION
Add `lighter` and `bolder` font weight utils.  They can either be used a relative values, or customized to numeric ones if desired.

Default `font-weight`s are now set using numeric values.