### PR TITLE
add min-width to `.custom-range` when inline

### DIFF
--- a/docs/assets/scss/_player.scss
+++ b/docs/assets/scss/_player.scss
@@ -51,6 +51,7 @@
 }
 .player-seek .slider.slider-horizontal {
     width: 100px;
+    min-width: 100px;
 }
 .player-mute {
     display: inline-block;
@@ -81,6 +82,7 @@
 }
 .player-volume .slider.slider-horizontal {
     width: 80px;
+    min-width: 80px;
 }
 .player-fullscreen {
     display: inline-block;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -777,7 +777,7 @@ $custom-range-thumb-active-bg:              palette($component-active-bg, 600) !
 $custom-range-thumb-disabled-bg:            $uibase-300 !default;
 
 $custom-range-height:               $custom-range-thumb-height + ($custom-range-thumb-focus-box-shadow-width * 2) !default;
-
+$custom-range-min-width:            8rem !default;  // Browser default seems to be 129px/~8rem for IE/Chrome/Safari
 
 // Form validation
 // =====

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -422,6 +422,8 @@
 // with mixins.  Also some additional rules per browser.
 .custom-range {
     width: 100%;
+    // Min width needed for inline use in IE to keep from crushing to unusable width
+    min-width: $custom-range-min-width;
     height: $custom-range-height;
     padding: 0;
     margin: 0;

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -103,6 +103,7 @@ body {
 .player-seek .slider.slider-horizontal,
 .player-seek input[type="range"] {
     width: 100px;
+    min-width: 100px;
 }
 .player-mute {
     display: inline-block;
@@ -134,6 +135,7 @@ body {
 .player-volume .slider.slider-horizontal,
 .player-volume input[type="range"] {
     width: 80px;
+    min-width: 80px;
 }
 .player-fullscreen {
     display: inline-block;


### PR DESCRIPTION
IE seems to crush the range when using `display: inline-block;' into an unusable width inside of a `.form-inline`.

Tests show that Chrome, IE, and Safari all seem to use 129px as the standard width.
New setting of 8rem (128px) to make the range slider usable again.