### PR TITLE
Remove `-webkit-text-decoration-skip`

### DIFF
--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -213,7 +213,6 @@ a {
     color: $link-color;
     text-decoration: $link-decoration;
     background-color: transparent; // Remove the gray background on active links in IE 10.
-    -webkit-text-decoration-skip: objects; // Remove gaps in links underline in iOS 8+ and Safari 8+.
 
     @include hover {
         color: $link-hover-color;


### PR DESCRIPTION
Allow browser/os to determine the underline style.