### PR TITLE
Enable options and Sass docs for Components

### DIFF
--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -41,7 +41,7 @@ Please refer to the [Accessiblity notes about conveying meaning with color]({{ s
   <strong>Warning!</strong> Something seems to have gone wrong with this item.
 </div>
 <div class="alert alert-danger" role="alert">
-  <strong>Danger!</strong> There is definitaly some error now.
+  <strong>Danger!</strong> There is definitely some error now.
 </div>
 {% endexample %}
 
@@ -66,7 +66,7 @@ Use the `.alert-link` utility class to quickly provide matching colored links wi
   <strong>Warning!</strong> Something seems to have gone <a href="#" class="alert-link">wrong with this item</a>.
 </div>
 <div class="alert alert-danger" role="alert">
-  <strong>Danger!</strong> There is definitaly <a href="#" class="alert-link">some error</a> now.
+  <strong>Danger!</strong> There is definitely <a href="#" class="alert-link">some error</a> now.
 </div>
 {% endexample %}
 
@@ -83,4 +83,228 @@ Alerts can also contain additional HTML elements like headings, paragraphs, and 
 </div>
 {% endexample %}
 
+## SASS Reference
 
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for alerts.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-alert</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert classes.
+                    Smaller segements of the alert classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                Enable the generation of common alert, <code>.alert</code>, rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-close</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert close button rule.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-heading</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert heading override.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-link</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert link styles.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-hr</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert horizontal rule styles.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-alert-colors</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the alert color variants.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-padding-y</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Vertical padding for alert containers.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-padding-x</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Horizontal padding for alert containers.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>$spacer</code></td>
+                <td>
+                    Vertical spacing for alert containers.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Border width for alert containers.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Border radius for alert containers.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-link-font-weight</code></td>
+                <td>string</td>
+                <td><code>$font-weight-bold</code></td>
+                <td>
+                    Font weight adjustment for alert links.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-close-padding-y</code></td>
+                <td>string</td>
+                <td><code>.75rem</code></td>
+                <td>
+                    Vertical padding for alert close buttons.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-close-padding-x</code></td>
+                <td>string</td>
+                <td><code>.75rem</code></td>
+                <td>
+                    Horizontal padding for alert close buttons.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-themes</code></td>
+                <td>map</td>
+                <td><code>()</code></td>
+                <td>
+                    Map of color schemes for alerts.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-colors</code></td>
+                <td>list</td>
+                <td><code>$base-colors</code></td>
+                <td>
+                    Colors to mix and merge into <code>$alert-themes</code>
+                </td>
+            </tr>
+            <tr>
+                <td><code>$alert-levels</code></td>
+                <td>map</td>
+                <td><code>$level-context</code></td>
+                <td>
+                    Levels to mix alert colors with.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+Here are the mixins related to alerts that we use to help generate our CSS. You can also uses these mixins to generate your own custom components or utilities.
+
+#### alert-variant
+{:.no_toc}
+
+Generate an alert color variant.
+
+{% highlight sass %}
+@include alert-variant($color, $bg, $border, $hover-color);
+{% endhighlight %}
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Argument</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$color</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Text color for an alert.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$bg</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Background color for an alert.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$border</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Border and horizontal rule color for an alert.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-color</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Hover state text color for alert links.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -87,7 +87,7 @@ Alerts can also contain additional HTML elements like headings, paragraphs, and 
 
 ### Variables
 
-The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for alerts.
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the alert component.
 
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
@@ -105,8 +105,8 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the alert classes.
-                    Smaller segements of the alert classes can be disabled with the following <code>$enable-*</code> variables.
+                    Enable the generation of the alert component classes.
+                    Smaller segements of the alert component classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/alerts.md
+++ b/docs/components/alerts.md
@@ -110,14 +110,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-alert-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                Enable the generation of common alert, <code>.alert</code>, rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-alert-close</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>

--- a/docs/components/badges.md
+++ b/docs/components/badges.md
@@ -225,14 +225,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-badge-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                Enable the generation of common badge, <code>.badge</code>, rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-badge-close</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>

--- a/docs/components/badges.md
+++ b/docs/components/badges.md
@@ -197,3 +197,366 @@ Group badges together using `.badge-group`.
     <span class="badge badge-outline-primary">9</span>
 </div>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for badges.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-badge</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the badge classes.
+                    Smaller segements of the badge classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                Enable the generation of common badge, <code>.badge</code>, rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-close</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the badge close button rule.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-pill</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the badge pill variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the badge group variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-default</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the default badge color variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-colors</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the badge contextual color variants.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-outline</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the default outline badge color variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-badge-outline-colors</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the outline badge contextual color variants.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-font-size</code></td>
+                <td>string</td>
+                <td><code>75%</code></td>
+                <td>
+                    Badge font size.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-font-weight</code></td>
+                <td>string</td>
+                <td><code>$font-weight-bold</code></td>
+                <td>
+                    Badge font weight.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-line-height</code></td>
+                <td>string</td>
+                <td><code>$line-height-base</code></td>
+                <td>
+                    Badge line height.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-padding-y</code></td>
+                <td>string</td>
+                <td><code>0</code></td>
+                <td>
+                    Badge vertical padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-padding-x</code></td>
+                <td>string</td>
+                <td><code>.375em</code></td>
+                <td>
+                    Badge horizontal padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Badge border width.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-border-radius</code></td>
+                <td>string</td>
+                <td><code>.25em</code></td>
+                <td>
+                    Badge border radius.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-close-padding-x</code></td>
+                <td>string</td>
+                <td><code>.375rem</code></td>
+                <td>
+                    Badge close button horizontal padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-close-font-size</code></td>
+                <td>string</td>
+                <td><code>1.25em</code></td>
+                <td>
+                    Badge close button font size.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-pill-padding-x</code></td>
+                <td>string</td>
+                <td><code>.5em</code></td>
+                <td>
+                    Badge pill variant horizontal padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-pill-border-radius</code></td>
+                <td>string</td>
+                <td><code>10rem</code></td>
+                <td>
+                    Badge pill variant border radius.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-outline-bg</code></td>
+                <td>string</td>
+                <td><code>transparent</code></td>
+                <td>
+                    Background color for outline badge variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-bg</code></td>
+                <td>string</td>
+                <td><code>$white</code></td>
+                <td>
+                    Default badge background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-color</code></td>
+                <td>string</td>
+                <td><code>color-if-contrast($uibase-500, $badge-default-bg)</code></td>
+                <td>
+                    Default badge text color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-border</code></td>
+                <td>string</td>
+                <td><code>$uibase-300</code></td>
+                <td>
+                    Default badge border color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-hover-bg</code></td>
+                <td>string</td>
+                <td><code>$uibase-50</code></td>
+                <td>
+                    Default badge background color for hover and focus states.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-hover-color</code></td>
+                <td>string</td>
+                <td><code>color-if-contrast($uibase-600, $badge-default-hover-bg)</code></td>
+                <td>
+                    Default badge text color for hover and focus states.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-default-hover-border</code></td>
+                <td>string</td>
+                <td><code>$uibase-400</code></td>
+                <td>
+                    Default badge border color for hover and focus states.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-themes</code></td>
+                <td>map</td>
+                <td><code>()</code></td>
+                <td>
+                    Map of color schemes for badges.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-colors</code></td>
+                <td>list</td>
+                <td><code>$base-colors</code></td>
+                <td>
+                    Colors to mix and merge into <code>$badge-themes</code>
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-levels</code></td>
+                <td>map</td>
+                <td><code>$level-context</code></td>
+                <td>
+                    Levels to mix badge colors with.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-outline-themes</code></td>
+                <td>map</td>
+                <td><code>()</code></td>
+                <td>
+                    Map of color schemes for outline badges.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-outline-colors</code></td>
+                <td>list</td>
+                <td><code>$base-colors</code></td>
+                <td>
+                    Colors to mix and merge into <code>$badge-outline-themes</code>
+                </td>
+            </tr>
+            <tr>
+                <td><code>$badge-outline-levels</code></td>
+                <td>map</td>
+                <td><code>$level-control</code></td>
+                <td>
+                    Levels to mix outline badge colors with.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+
+### Mixins
+
+Here are the mixins related to badges that we use to help generate our CSS. You can also uses these mixins to generate your own custom components or utilities.
+
+#### badge-variant
+{:.no_toc}
+
+Generate a badge color variant.
+
+{% highlight sass %}
+@include badge-variant($color, $bg, $border, $hover-color, $hover-bg, $hover-border);
+{% endhighlight %}
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Argument</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$color</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Text color for a badge.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$bg</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Background color for a badge.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$border</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Border color for a badge.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-color</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Text color for a badge in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-bg</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Background color for a badge in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-border</code></td>
+                <td>number</td>
+                <td>none</td>
+                <td>
+                    Border color for a badge in hover or focus state.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/components/badges.md
+++ b/docs/components/badges.md
@@ -202,7 +202,7 @@ Group badges together using `.badge-group`.
 
 ### Variables
 
-The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for badges.
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the badge component.
 
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
@@ -220,8 +220,8 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the badge classes.
-                    Smaller segements of the badge classes can be disabled with the following <code>$enable-*</code> variables.
+                    Enable the generation of the badge component classes.
+                    Smaller segements of the badge component classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -91,7 +91,7 @@ For more information, see the [WAI-ARIA Authoring Practices for the breadcrumb p
 
 ### Variables
 
-The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for breadcrumbs.
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the breadcrumb component.
 
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
@@ -109,7 +109,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the breadcrumb classes.
+                    Enable the generation of the breadcrumb component classes.
                 </td>
             </tr>
             <tr>

--- a/docs/components/breadcrumb.md
+++ b/docs/components/breadcrumb.md
@@ -86,3 +86,76 @@ $breadcrumb-divider: none;
 Since breadcrumbs provide a navigation, it is a good idea to add a meaningful label such as `aria-label="breadcrumb"` to describe the type of navigation provided in the `<nav>` element, as well as applying an `aria-current="page"` to the last item of the set to indicate that it represents the current page.
 
 For more information, see the [WAI-ARIA Authoring Practices for the breadcrumb pattern](https://www.w3.org/TR/wai-aria-practices/#breadcrumb).
+
+# SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for breadcrumbs.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-breadcrumb</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the breadcrumb classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$breadcrumb-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Vertical spacing for breadcrumb.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$breadcrumb-item-padding-x</code></td>
+                <td>string</td>
+                <td><code>.5rem</code></td>
+                <td>
+                    Horizontal spacing for breadcrumb items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$breadcrumb-active-color</code></td>
+                <td>string</td>
+                <td><code>$uibase-700</code></td>
+                <td>
+                    Text color for active breadcrumb items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$breadcrumb-divider</code></td>
+                <td>string</td>
+                <td><code>quote("/")</code></td>
+                <td>
+                    Breadcrumb divider content.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$breadcrumb-divider-color</code></td>
+                <td>string</td>
+                <td><code>$uibase-300</code></td>
+                <td>
+                    Text color of breadcrumb divider.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -260,11 +260,11 @@ In order for assistive technologies (such as screen readers) to convey that a se
 
 In addition, groups and toolbars should be given an explicit label, as most assistive technologies will otherwise not announce them, despite the presence of the correct role attribute. In the examples provided here, we use `aria-label`, but alternatives such as `aria-labelledby` can also be used.
 
-# SASS Reference
+## SASS Reference
 
 ### Variables
 
-The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for button groups and toolbars.
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the button group component.
 
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
@@ -282,8 +282,8 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the button group classes.
-                    Smaller segements of the button group classes can be disabled with the following <code>$enable-*</code> variables.
+                    Enable the generation of the button group component classes.
+                    Smaller segements of the button group component classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -259,3 +259,68 @@ Due to their specific implementation (and some other components), a bit of speci
 In order for assistive technologies (such as screen readers) to convey that a series of buttons is grouped, an appropriate `role` attribute needs to be provided. For button groups, this would be `role="group"`, while toolbars should have a `role="toolbar"`.
 
 In addition, groups and toolbars should be given an explicit label, as most assistive technologies will otherwise not announce them, despite the presence of the correct role attribute. In the examples provided here, we use `aria-label`, but alternatives such as `aria-labelledby` can also be used.
+
+# SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for button groups and toolbars.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-btn-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the button group classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-btn-group-horizontal</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the horizontal button group classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-btn-group-vertical</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the vertical button group classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-btn-group-sizing</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the button group sizing classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-btn-toolbar</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the button toolbar classes.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -283,6 +283,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td><code>true</code></td>
                 <td>
                     Enable the generation of the button group classes.
+                    Smaller segements of the button group classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -990,8 +990,6 @@ Cards can be organized into [Masonry](https://masonry.desandro.com/)-like column
 
 Responsive variants are available with the class syntax of `.card-columns{-breakpoint}`, such as `.card-columns-sm` to enable the columns layout for `sm` screens and above.
 
-**Heads up!** Your mileage with card columns may vary. To prevent cards breaking across columns, we set them to `display: inline-table`, as `column-break-inside: avoid` isn't a fully supported option yet.
-
 {% example html %}
 <div class="card-columns-sm">
   <div class="card">
@@ -1100,3 +1098,421 @@ If you are using responsive variants of the card columns, you may need to includ
   }
 }
 {% endhighlight %}
+
+# SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the card component.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-card</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card component classes.
+                    Smaller segements of the card component classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the base card class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-body</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card body class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-title</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card title class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-subtitle</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card subtitle class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-text</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card text rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-link</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card link rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-list</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card list rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-table</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card table rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-header</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card header rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-footer</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card footer rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-header-tabs</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card header tabs class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-header pills</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card header pills class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-img</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card image rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-img-overlay</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card image overlay class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-horizontal</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the horizontal card rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-deck</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card deck rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-deck-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the non-repsonsive card deck rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-deck-responsive</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the responsive card deck rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card group rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-group-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the non-repsonsive card group rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-group-responsive</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the responsive card group rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-columns</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the card columns rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-columns-common</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the non-repsonsive card columns rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-card-columns-responsive</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the responsive card columns rules.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-padding-y</code></td>
+                <td>string</td>
+                <td><code>.75rem</code></td>
+                <td>
+                    Card body vertical padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-padding-x</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Card body horizontal padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Card vertical spacing.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-bg</code></td>
+                <td>string</td>
+                <td><code>$component-bg</code></td>
+                <td>
+                    Card background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-overlay-border-color</code></td>
+                <td>
+                    Card border color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Card border width.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Card border radius.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-border-radius</code></td>
+                <td>string</td>
+                <td><code>calc(#{$card-border-radius} - #{$card-border-width})</code></td>
+                <td>
+                    Card border radius for internal pieces.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-link-margin-left</code></td>
+                <td>string</td>
+                <td><code>1.25rem</code></td>
+                <td>
+                    Horizontal spacing between card link items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-title-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Horizontal spacing for a card title.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-subtitle-margin-top</code></td>
+                <td>string</td>
+                <td><code>-.5rem</code></td>
+                <td>
+                    Horizontal spacing for a card subtitle.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-card-padding-y</code></td>
+                <td>string</td>
+                <td><code>.75rem</code></td>
+                <td>
+                    Vertical padding for card header and footer.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-card-padding-x</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Horizontal padding for card header and footer.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-cap-bg</code></td>
+                <td>string</td>
+                <td><code>$component-section-bg</code></td>
+                <td>
+                    Background color for card header and footer.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-cap-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-section-border-color</code></td>
+                <td>
+                    Border color for card header and footer.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-cap-border-width</code></td>
+                <td>string</td>
+                <td><code>$card-border-width</code></td>
+                <td>
+                    Border width for card header and footer.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-img-overlay-padding</code></td>
+                <td>string</td>
+                <td><code>$card-padding-y $card-padding-x</code></td>
+                <td>
+                    Vertical and horizontal padding for image overlay content.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-deck-gutter-widths</code></td>
+                <td>string</td>
+                <td><code>$grid-gutter-widths</code></td>
+                <td>
+                    Horizontal spacing between cards in a card deck.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-columns-count</code></td>
+                <td>integer</td>
+                <td><code>3</code></td>
+                <td>
+                    Number of columns for card columns.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-columns-column-gap</code></td>
+                <td>string</td>
+                <td><code>1.25rem</code></td>
+                <td>
+                    Horizontal spacing between cards for card columns.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-horizontal-breakpoints</code></td>
+                <td>list</td>
+                <td><code>map-keys($grid-breakpoints)</code></td>
+                <td>
+                    Breakpoint list for responsive horizontal cards.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-deck-breakpoints</code></td>
+                <td>list</td>
+                <td><code>map-keys($grid-breakpoints)</code></td>
+                <td>
+                    Breakpoint list for responsive card decks.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-group-breakpoints</code></td>
+                <td>list</td>
+                <td><code>map-keys($grid-breakpoints)</code></td>
+                <td>
+                    Breakpoint list for responsive card groups.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$card-columns-breakpoints</code></td>
+                <td>list</td>
+                <td><code>map-keys($grid-breakpoints)</code></td>
+                <td>
+                    Breakpoint list for responsive card columns.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/cards.md
+++ b/docs/components/cards.md
@@ -1126,14 +1126,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-card-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of the base card class.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-card-body</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>
@@ -1254,14 +1246,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-card-deck-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of the non-repsonsive card deck rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-card-deck-responsive</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>
@@ -1278,14 +1262,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-card-group-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of the non-repsonsive card group rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-card-group-responsive</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>
@@ -1299,14 +1275,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td><code>true</code></td>
                 <td>
                     Enable the generation of the card columns rules.
-                </td>
-            </tr>
-            <tr>
-                <td><code>$enable-card-columns-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of the non-repsonsive card columns rules.
                 </td>
             </tr>
             <tr>

--- a/docs/components/input-group.md
+++ b/docs/components/input-group.md
@@ -419,3 +419,85 @@ Screen readers will have trouble with your forms if you don't include a label fo
 The exact technique to be used (`<label>` elements hidden using the `.sr-only` class, or use of the `aria-label` and `aria-labelledby` attributes, possibly in combination with `aria-describedby`) and what additional information will need to be conveyed will vary depending on the exact type of interface widget you're implementing. The examples in this section provide a few suggested, case-specific approaches.
 
 There is also an issue when placing buttons before inputs, as this can cause a confusing ordering issue for those using screen readers, where the general expectation is that the buttons are at the end of a form, or at least, after the inputs.  This fix is not as simple as controlling the focus order since screen readers read in order of the DOM elements.  There might be ways to mitigate this using a description of some kind, but it might be better to ensure proper ordering of the elements, and putting the buttons after any input elements.
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for input groups.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-input-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the input group classes.
+                    Smaller segements of the input group classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-input-group-addon</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of input group addon classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-input-group-text</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of input group text classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-input-group-sizing</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of input group sizing classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$input-group-addon-color</code></td>
+                <td>string</td>
+                <td><code>$input-color</code></td>
+                <td>
+                    Input group addon text color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$input-group-addon-bg</code></td>
+                <td>string</td>
+                <td><code>$uibase-50</code></td>
+                <td>
+                    Input group addon background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$input-group-addon-border-color</code></td>
+                <td>string</td>
+                <td><code>$input-border-color</code></td>
+                <td>
+                    Input group addon border color.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -53,8 +53,8 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the input group classes.
-                    Smaller segements of the input group classes can be disabled with the following <code>$enable-*</code> variables.
+                    Enable the generation of the jumbotron classes.
+                    Smaller segements of the jumbotron classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/jumbotron.md
+++ b/docs/components/jumbotron.md
@@ -30,3 +30,101 @@ To make the jumbotron full width, and without rounded corners, add the `.jumbotr
   </div>
 </div>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for jumbotrons.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-jumbotron</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the input group classes.
+                    Smaller segements of the input group classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-jumbotron-fluid</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of fluid width jumbotron class.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-padding-y</code></td>
+                <td>string</td>
+                <td><code>3rem</code></td>
+                <td>
+                    Vertical padding for jumbotron.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-padding-x</code></td>
+                <td>string</td>
+                <td><code>1.5rem</code></td>
+                <td>
+                    Horizontal padding for jumbotron.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-breakpoint</code></td>
+                <td>breakpoint</td>
+                <td><code>sm</code></td>
+                <td>
+                    At which breakpoint to alter the jumbotron padding.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-padding-xs-y</code></td>
+                <td>string</td>
+                <td><code>1.5rem</code></td>
+                <td>
+                    Vertical padding for jumbotron below the specified breakpoint.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-padding-xs-x</code></td>
+                <td>string</td>
+                <td><code>.75rem</code></td>
+                <td>
+                    Horizontal padding for jumbotron below the specified breakpoint.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-bg</code></td>
+                <td>string</td>
+                <td><code>$uibase-50</code></td>
+                <td>
+                    Background color for jumbotron.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$jumbotron-border-radius</code></td>
+                <td>string</td>
+                <td><code>.3125rem</code></td>
+                <td>
+                    Border radius for jumbotron.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/lists.md
+++ b/docs/components/lists.md
@@ -550,3 +550,390 @@ Contextual classes also work with `.list-item-action`. Note the addition of the 
     <li class="list-item list-item-dark active">Dark list item</li>
 </ul>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for list component.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-list</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the list component classes.
+                    Smaller segements of the list component classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-bulleted</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of styled bulleted lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-ordered</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of styled ordered lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-divided</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of styled divided lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-ruled</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of styled ruled lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of list groups.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-spaced</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of spaced lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-spaced-y</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of vertically spaced lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-spaced-x</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of horizontally spaced lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-horizontal</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of styled horizontal lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-item-action</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of list item actions.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-list-item-colors</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of list item color variants.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-margin-left</code></td>
+                <td>string</td>
+                <td><code>1.25rem</code></td>
+                <td>
+                    Width of margin to indent lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Spacing below lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-bg</code></td>
+                <td>string</td>
+                <td><code>transparent</code></td>
+                <td>
+                    Background color for list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-disabled-bg</code></td>
+                <td>string</td>
+                <td><code>$list-item-bg</code></td>
+                <td>
+                    Background color for disabled list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-disabled-color</code></td>
+                <td>string</td>
+                <td><code>$component-disabled-color</code></td>
+                <td>
+                    Text color for disabled list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-active-bg</code></td>
+                <td>string</td>
+                <td><code>$component-active-bg</code></td>
+                <td>
+                    Background color for active list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-active-color</code></td>
+                <td>string</td>
+                <td><code>$component-active-color</code></td>
+                <td>
+                    Text color for active list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-active-border</code></td>
+                <td>string</td>
+                <td><code>$component-active-border-color</code></td>
+                <td>
+                    Border color for active list items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-action-color</code></td>
+                <td>string</td>
+                <td><code>$component-action-color</code></td>
+                <td>
+                    Text color for list item actions.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-hover-color</code></td>
+                <td>string</td>
+                <td><code>$list-item-hover-color</code></td>
+                <td>
+                    Text color for list item actions when hovered or focused.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-item-hover-bg</code></td>
+                <td>string</td>
+                <td><code>$component-hover-bg</code></td>
+                <td>
+                    Background color for list item actions when hovered or focused.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Border width for list items with borders.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-border-color</code></td>
+                <td>
+                    Border color for list items with borders.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-group-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Border radisu for list groups.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-bulleted-content</code></td>
+                <td>string</td>
+                <td><code>"\25cf\00a0"</code></td>
+                <td>
+                    Visual content to use for bullets.  Default content is a black circle and a space.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-ordered-delimeter</code></td>
+                <td>string</td>
+                <td><code>"\25cf\00a0"</code></td>
+                <td>
+                    Visual content to use as a delimeter after the order value.  Default content is a space.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-horizontal-padding</code></td>
+                <td>string</td>
+                <td><code>.5em</code></td>
+                <td>
+                    Horizontal padding to use between list items in a horizontal list.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-spaced-item-padding-y</code></td>
+                <td>string</td>
+                <td><code>.75em</code></td>
+                <td>
+                    Vertical padding for list items in a spaced list.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-spaced-item-padding-x</code></td>
+                <td>string</td>
+                <td><code>1em</code></td>
+                <td>
+                    Horizontal padding for list items in a spaced list.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-themes</code></td>
+                <td>map</td>
+                <td><code>()</code></td>
+                <td>
+                    Map of color schemes for lists.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-colors</code></td>
+                <td>list</td>
+                <td><code>$base-colors</code></td>
+                <td>
+                    Colors to mix and merge into <code>$list-themes</code>
+                </td>
+            </tr>
+            <tr>
+                <td><code>$list-levels</code></td>
+                <td>map</td>
+                <td><code>$level-context</code></td>
+                <td>
+                    Levels to mix list colors with.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+Here are the mixins related to lists that we use to help generate our CSS.  You can also uses these mixins to generate your own custom components or utilities.
+
+#### list-unstyled
+{:.no_toc}
+
+List with no left padding or list item markers.
+
+{% highlight sass %}
+@include list-unstyled();
+{% endhighlight %}
+
+#### list-item-variant
+{:.no_toc}
+
+Create a contextual color variant for a list item.
+
+{% highlight sass %}
+@include list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border);
+{% endhighlight %}
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Argument</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$state</code></td>
+                <td>string</td>
+                <td><code>''</code></td>
+                <td>
+                    The value appended to generate the class <code>.list-item-#{$state}</code>.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$bg</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Background color for a list item.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$color</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Text color for a list item.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$border</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Border color for a list item.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-bg</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Background color for a list item in active, hover, and focus states.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-color</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Text color for a list item in active, hover, and focus states..
+                </td>
+            </tr>
+            <tr>
+                <td><code>$hover-border</code></td>
+                <td>string</td>
+                <td>none</td>
+                <td>
+                    Border color for a list item in active, hover, and focus states..
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/components/media-object.md
+++ b/docs/components/media-object.md
@@ -218,3 +218,44 @@ Even create your own social media layout.
   </div>
 </div>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the media object component.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-media</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the media object classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$media-margin-y</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Vertical spacing under a media object.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -836,7 +836,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td><code>true</code></td>
                 <td>
                     Enable the generation of the navbar classes.
-                    Smaller segements of the input group classes can be disabled with the following <code>$enable-*</code> variables.
+                    Smaller segements of the navbar classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/components/navbar.md
+++ b/docs/components/navbar.md
@@ -812,3 +812,333 @@ Use our [position utilities]({{ site.baseurl }}/utilities/position/) to place na
   <a href="#" class="navbar-brand">Sticky top</a>
 </nav>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for navbar components.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-navbar</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the navbar classes.
+                    Smaller segements of the input group classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-brand</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar brand classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-nav</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar nav classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-text</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar text classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-divider</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar divider classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-collapse</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar collapse classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-toggle</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of navbar toggle classes.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-light</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of color overrides for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-navbar-dark</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of color overrides for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-padding-y</code></td>
+                <td>string</td>
+                <td><code>($spacer / 2)</code></td>
+                <td>
+                    Vertical padding for navbar.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-padding-x</code></td>
+                <td>string</td>
+                <td><code>$spacer</code></td>
+                <td>
+                    Horizontal padding for navbar.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-item-padding-y</code></td>
+                <td>string</td>
+                <td><code>.3125rem</code></td>
+                <td>
+                    Vertical padding for <code>.nav-link</code> items within navbar.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-item-padding-x</code></td>
+                <td>string</td>
+                <td><code>.5rem</code></td>
+                <td>
+                    Horizontal padding for <code>.nav-link</code> items within navbar.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-brand-padding-y</code></td>
+                <td>string</td>
+                <td><code>.125rem</code></td>
+                <td>
+                    Vertical padding for navbar brand.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-brand-padding-x</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Horizontal padding for navbar brand.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-brand-font-size</code></td>
+                <td>string</td>
+                <td><code>($font-size-base * 1.25)</code></td>
+                <td>
+                    Font size for navbar brand.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-brand-font-weight</code></td>
+                <td>string</td>
+                <td><code>$font-weight-bold</code></td>
+                <td>
+                    Font weight for navbar brand.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-divider-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Border width for navbar divider.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-divider-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .65)</code></td>
+                <td>
+                    Border color for navbar divider.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-divider-margin-y</code></td>
+                <td>string</td>
+                <td><code>$navbar-item-padding-y</code></td>
+                <td>
+                    Vertical spacing for navbar divider.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-divider-margin-x</code></td>
+                <td>string</td>
+                <td><code>$navbar-item-padding-x</code></td>
+                <td>
+                    Horizontal spacing for navbar divider.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-toggle-font-size</code></td>
+                <td>string</td>
+                <td><code>($font-size-base * 1.25)</code></td>
+                <td>
+                    Font size for navbar toggle.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-toggle-padding-y</code></td>
+                <td>string</td>
+                <td><code>$btn-padding-y</code></td>
+                <td>
+                    Vertical spacing for navbar toggle.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-toggle-padding-x</code></td>
+                <td>string</td>
+                <td><code>$btn-padding-x</code></td>
+                <td>
+                    Horizontal spacing for navbar toggle.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-toggle-border-radius</code></td>
+                <td>string</td>
+                <td><code>$btn-border-radius</code></td>
+                <td>
+                    Border radius for navbar toggle.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-expand-breakpoints</code></td>
+                <td>list</td>
+                <td><code>map-keys($grid-breakpoints)</code></td>
+                <td>
+                    Breakpoints to generate the rules for expanding navbars.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .6)</code></td>
+                <td>
+                    Text color override for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-hover-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .85)</code></td>
+                <td>
+                    Text color override in hover or focus state for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-active-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .95)</code></td>
+                <td>
+                    Text color override in active state for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-disabled-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .5)</code></td>
+                <td>
+                    Text color override in disabled state for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-divider-color</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .65)</code></td>
+                <td>
+                    Divider border color override for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-light-toggle-border</code></td>
+                <td>string</td>
+                <td><code>rgba($black, .35)</code></td>
+                <td>
+                    Toggle border color override for use on a navbar with a light background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-color</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .65)</code></td>
+                <td>
+                    Text color override for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-hover-color</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .9)</code></td>
+                <td>
+                    Text color override in hover or focus state for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-active-color</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .95)</code></td>
+                <td>
+                    Text color override in active state for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-disabled-color</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .5)</code></td>
+                <td>
+                    Text color override in disabled state for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-divider-color</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .7)</code></td>
+                <td>
+                    Divider border color override for use on a navbar with a dark background color.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$navbar-dark-toggle-border</code></td>
+                <td>string</td>
+                <td><code>rgba($white, .35)</code></td>
+                <td>
+                    Toggle border color override for use on a navbar with a dark background color.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/navs.md
+++ b/docs/components/navs.md
@@ -323,3 +323,205 @@ For accessibility reasons, do not mix use of the [Tab widget]({{ site.baseurl }}
   </li>
 </ul>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for nav components.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-nav</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the nav classes.
+                    Smaller segements of the nav classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-nav-tabs</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of tab nav styles.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-nav-pills</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of pill nav styles.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-nav-vertical</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of vertical nav style.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-nav-fill</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of fill alignment nav style.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-nav-justify</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of justify alignment nav style.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-tab-content</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of tab content pane visibility styles.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-link-padding-y</code></td>
+                <td>string</td>
+                <td><code>.3125rem</code></td>
+                <td>
+                    Vertical padding for nav links.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-link-padding-x</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Horizontal padding for nav links.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-link-disabled-opacity</code></td>
+                <td>string</td>
+                <td><code>.6</code></td>
+                <td>
+                    Opacity for disabled nav links.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-link-disabled-color</code></td>
+                <td>string</td>
+                <td><code>.6</code></td>
+                <td>
+                    Text color for disabled nav links.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-border-color</code></td>
+                <td>
+                    Border color for tab navs.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Border width for tab navs.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-hover-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-hover-bg</code></td>
+                <td>
+                    Border color for tab navs in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-hover-bg</code></td>
+                <td>string</td>
+                <td><code>$component-hover-bg</code></td>
+                <td>
+                    Background color for tab navs in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-active-color</code></td>
+                <td>string</td>
+                <td><code>$component-action-color</code></td>
+                <td>
+                    Text color for tab navs in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-active-bg</code></td>
+                <td>string</td>
+                <td><code>$body-bg</code></td>
+                <td>
+                    Background color for tab navs in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-tabs-active-border-color</code></td>
+                <td>string</td>
+                <td><code>$component-border-color</code></td>
+                <td>
+                    Border color for tab navs in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-pills-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Border radius for pill navs.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$nav-pills-hover-bg</code></td>
+                <td>string</td>
+                <td><code>$component-hover-bg</code></td>
+                <td>
+                    Background color for pill navs in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$component-active-color</code></td>
+                <td>string</td>
+                <td><code>$component-active-color</code></td>
+                <td>
+                    Text color for pill navs in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$component-active-bg</code></td>
+                <td>string</td>
+                <td><code>$component-active-bg</code></td>
+                <td>
+                    Background color for pill navs in active state.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -86,6 +86,42 @@ Want to use an icon or symbol in place of text for some pagination links? Be sur
         </li>
     </ul>
 </nav>
+
+<nav aria-label="Page navigation">
+    <ul class="pagination pagination-spaced">
+        <li class="page-item">
+            <a href="#" class="page-link" aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+        <li class="page-item"><a href="#" class="page-link">1</a></li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><a href="#" class="page-link">3</a></li>
+        <li class="page-item">
+            <a href="#" class="page-link" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+
+<nav aria-label="Page navigation">
+    <ul class="pagination pagination-group">
+        <li class="page-item">
+            <a href="#" class="page-link" aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+        <li class="page-item"><a href="#" class="page-link">1</a></li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><a href="#" class="page-link">3</a></li>
+        <li class="page-item">
+            <a href="#" class="page-link" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+    </ul>
+</nav>
 {% endexample %}
 
 ## Disabled and Active States
@@ -102,6 +138,34 @@ Please refer to the [Accessiblity notes about disabled anchors]({{ site.baseurl 
 {% example html %}
 <nav aria-label="...">
     <ul class="pagination">
+        <li class="page-item">
+            <a href="#" class="page-link disabled" tabindex="-1" aria-disabled="true">Previous</a>
+        </li>
+        <li class="page-item">
+            <a href="#" class="page-link active" aria-current="page">1</a>
+        </li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><a href="#" class="page-link">3</a></li>
+        <li class="page-item"><a href="#" class="page-link">Next</a></li>
+    </ul>
+</nav>
+
+<nav aria-label="...">
+    <ul class="pagination pagination-spaced">
+        <li class="page-item">
+            <a href="#" class="page-link disabled" tabindex="-1" aria-disabled="true">Previous</a>
+        </li>
+        <li class="page-item">
+            <a href="#" class="page-link active" aria-current="page">1</a>
+        </li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><a href="#" class="page-link">3</a></li>
+        <li class="page-item"><a href="#" class="page-link">Next</a></li>
+    </ul>
+</nav>
+
+<nav aria-label="...">
+    <ul class="pagination pagination-group">
         <li class="page-item">
             <a href="#" class="page-link disabled" tabindex="-1" aria-disabled="true">Previous</a>
         </li>
@@ -143,6 +207,30 @@ Add normal text to your pagination navigation by using `.page-text`.  This class
 {% example html %}
 <nav aria-label="...">
     <ul class="pagination">
+        <li class="page-item"><span class="page-link disabled">Previous</span></li>
+        <li class="page-item"><a href="#" class="page-link">1</a></li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><span class="page-text">&hellip;</span></li>
+        <li class="page-item"><a href="#" class="page-link">98</a></li>
+        <li class="page-item"><a href="#" class="page-link">99</a></li>
+        <li class="page-item"><a href="#" class="page-link">Next</a></li>
+    </ul>
+</nav>
+
+<nav aria-label="...">
+    <ul class="pagination pagination-spaced">
+        <li class="page-item"><span class="page-link disabled">Previous</span></li>
+        <li class="page-item"><a href="#" class="page-link">1</a></li>
+        <li class="page-item"><a href="#" class="page-link">2</a></li>
+        <li class="page-item"><span class="page-text">&hellip;</span></li>
+        <li class="page-item"><a href="#" class="page-link">98</a></li>
+        <li class="page-item"><a href="#" class="page-link">99</a></li>
+        <li class="page-item"><a href="#" class="page-link">Next</a></li>
+    </ul>
+</nav>
+
+<nav aria-label="...">
+    <ul class="pagination pagination-group">
         <li class="page-item"><span class="page-link disabled">Previous</span></li>
         <li class="page-item"><a href="#" class="page-link">1</a></li>
         <li class="page-item"><a href="#" class="page-link">2</a></li>
@@ -299,3 +387,270 @@ Change the alignment of pagination components using the [flexbox utilities]({{ s
     </ul>
 </nav>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for pagination component.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-pagination</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the pagination classes.
+                    Smaller segements of the pagination classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-pagination-spaced</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the spaced pagination variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-pagination-group</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the pagination group variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-pagination-sizing</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the pagination sizing variants.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-margin-bottom</code></td>
+                <td>string</td>
+                <td><code>.5em</code></td>
+                <td>
+                    Vertical spacing below a pagination container.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-line-height</code></td>
+                <td>string</td>
+                <td><code>$btn-line-height</code></td>
+                <td>
+                    Line height for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-padding-y</code></td>
+                <td>string</td>
+                <td><code>$btn-padding-y</code></td>
+                <td>
+                    Vertical padding for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-padding-x</code></td>
+                <td>string</td>
+                <td><code>.5em</code></td>
+                <td>
+                    Horizontal padding for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-border-width</code></td>
+                <td>string</td>
+                <td><code>$border-width</code></td>
+                <td>
+                    Border width for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-border-color</code></td>
+                <td>string</td>
+                <td><code>$btn-default-border-color</code></td>
+                <td>
+                    Border color for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Border radius for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-bg</code></td>
+                <td>string</td>
+                <td><code>$btn-default-bg</code></td>
+                <td>
+                    Background color for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-color</code></td>
+                <td>string</td>
+                <td><code>$btn-default-color</code></td>
+                <td>
+                    Text color for pagination items.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-hover-bg</code></td>
+                <td>string</td>
+                <td><code>$btn-default-hover-bg</code></td>
+                <td>
+                    Background color for pagination items in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-hover-color</code></td>
+                <td>string</td>
+                <td><code>$btn-default-hover-color</code></td>
+                <td>
+                    Text color for pagination items in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-hover-border-color</code></td>
+                <td>string</td>
+                <td><code>$pagination-border-color</code></td>
+                <td>
+                    Border color for pagination items in hover or focus state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-active-color</code></td>
+                <td>string</td>
+                <td><code>$component-active-color</code></td>
+                <td>
+                    Text color for pagination items in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-active-bg</code></td>
+                <td>string</td>
+                <td><code>$component-active-bg</code></td>
+                <td>
+                    Background color for pagination items in active state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-disabled-color</code></td>
+                <td>string</td>
+                <td><code>$component-disabled-color</code></td>
+                <td>
+                    Text color for pagination items in disabled state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-disabled-bg</code></td>
+                <td>string</td>
+                <td><code>$component-disabled-bg</code></td>
+                <td>
+                    Background color for pagination items in disabled state.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-spaced-margin-end</code></td>
+                <td>string</td>
+                <td><code>.25em</code></td>
+                <td>
+                    Vertical spacing between items in spaced pagination.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$pagination-sizes</code></td>
+                <td>map</td>
+                <td><code>$component-sizes</code></td>
+                <td>
+                    Values for pagination sizing variants.
+                </td>
+            </tr>
+
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+Here are the mixins related to pagination that we use to help generate our CSS.  You can also uses these mixins to generate your own custom components or utilities.
+
+#### pagination-size
+{:.no_toc}
+
+Build a size variant for pagination.
+
+{% highlight sass %}
+@include pagination-size($padding-y, $padding-x, $font-size, $line-height, $border-radius);
+{% endhighlight %}
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Argument</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$padding-y</code></td>
+                <td>string</td>
+                <td><code>''</code></td>
+                <td>
+                    Vertical padding for pagination size variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$padding-x</code></td>
+                <td>string</td>
+                <td><code>none</code></td>
+                <td>
+                    Horizontal padding for pagination size variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$font-size</code></td>
+                <td>string</td>
+                <td><code>none</code></td>
+                <td>
+                    Font size for pagination size variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$line-height</code></td>
+                <td>string</td>
+                <td><code>none</code></td>
+                <td>
+                   Line height for pagination size variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$border-radius</code></td>
+                <td>string</td>
+                <td><code>none</code></td>
+                <td>
+                   Border radius for pagination size variant.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -168,3 +168,141 @@ Include multiple progress bars in a progress component if you need.
     <div class="progress-bar bg-info" role="progressbar" style="width: 20%" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100"></div>
 </div>
 {% endexample %}
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for progress component.
+
+<div class="table-scroll">
+    <table class="table table-bordered table-striped">
+        <thead>
+            <tr>
+                <th style="width: 100px;">Name</th>
+                <th style="width: 50px;">Type</th>
+                <th style="width: 50px;">Default</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>$enable-progress</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the progress classes.
+                    Smaller segements of the progress classes can be disabled with the following <code>$enable-*</code> variables.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-progress-striped</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the striped progress bar rule.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-progress-animated</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the animated progress bar rule.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-height</code></td>
+                <td>string</td>
+                <td><code>1rem</code></td>
+                <td>
+                    Height of progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-font-size</code></td>
+                <td>string</td>
+                <td><code>($font-size-base * .75)</code></td>
+                <td>
+                    Font size for progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bg</code></td>
+                <td>string</td>
+                <td><code>$uibase-100</code></td>
+                <td>
+                    Background color for progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bg</code></td>
+                <td>string</td>
+                <td><code>$uibase-100</code></td>
+                <td>
+                    Background color for progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-border-radius</code></td>
+                <td>string</td>
+                <td><code>$border-radius</code></td>
+                <td>
+                    Border radius for progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-box-shadow</code></td>
+                <td>string</td>
+                <td><code>map-get($shadows, "i1")</code></td>
+                <td>
+                    Box shadow for progress component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bar-color</code></td>
+                <td>string</td>
+                <td><code>$white</code></td>
+                <td>
+                    Text color for progress bar component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bar-color</code></td>
+                <td>string</td>
+                <td><code>$uibase-300</code></td>
+                <td>
+                    Background color for progress bar component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-box-shadow</code></td>
+                <td>string</td>
+                <td><code>inset 0 .125rem .25rem rgba($white, .25)</code></td>
+                <td>
+                    Box shadow for progress bar component.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bar-animation-timing</code></td>
+                <td>string</td>
+                <td><code>1s linear infinite</code></td>
+                <td>
+                    Timing for animated progress bar.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$progress-bar-transition</code></td>
+                <td>string</td>
+                <td><code>width .3s ease</code></td>
+                <td>
+                    Transition rule for animated progress bar.
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/docs/content/buttons.md
+++ b/docs/content/buttons.md
@@ -318,7 +318,7 @@ You can also use `.btn-check`s inside a `.btn-group` for grouping controls toget
 
 ### Variables
 
-The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for tables.
+The available [Customization options]({{ site.baseurl }}/get-started/options/), or Sass variables, that can be customized for the button component.
 
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
@@ -336,8 +336,8 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the button classes.
-                    Smaller segements of the button classes can be disabled with the following <code>$enable-*</code> variables.
+                    Enable the generation of the button component classes.
+                    Smaller segements of the button component classes can be disabled with the following <code>$enable-*</code> variables.
                 </td>
             </tr>
             <tr>

--- a/docs/content/buttons.md
+++ b/docs/content/buttons.md
@@ -345,7 +345,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the common button, <code>.btn</code> rules.
+                    Enable the generation of the common button, <code>.btn</code>, rules.
                 </td>
             </tr>
             <tr>

--- a/docs/content/buttons.md
+++ b/docs/content/buttons.md
@@ -341,14 +341,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-btn-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of the common button, <code>.btn</code>, rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-btn-default</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>

--- a/docs/content/tables.md
+++ b/docs/content/tables.md
@@ -1563,14 +1563,6 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
                 </td>
             </tr>
             <tr>
-                <td><code>$enable-table-common</code></td>
-                <td>boolean</td>
-                <td><code>true</code></td>
-                <td>
-                    Enable the generation of common <code>.table</code> CSS rules.
-                </td>
-            </tr>
-            <tr>
                 <td><code>$enable-table-borders</code></td>
                 <td>boolean</td>
                 <td><code>true</code></td>

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -114,6 +114,33 @@ $enable-btn-group-vertical:                 true !default; // true
 $enable-btn-group-sizing:                   true !default; // true
 $enable-btn-toolbar:                        true !default; // true
 
+// Cards
+$enable-card:                               true !default;
+$enable-card-common:                        true !default;
+$enable-card-body:                          true !default;
+$enable-card-title:                         true !default;
+$enable-card-subtitle:                      true !default;
+$enable-card-text:                          true !default;
+$enable-card-link:                          true !default;
+$enable-card-list:                          true !default;
+$enable-card-table:                         true !default;
+$enable-card-header:                        true !default;
+$enable-card-footer:                        true !default;
+$enable-card-header-tabs:                   true !default;
+$enable-card-header-pills:                  true !default;
+$enable-card-img:                           true !default;
+$enable-card-img-overlay:                   true !default;
+$enable-card-horizontal:                    true !default;
+$enable-card-deck:                          true !default;
+$enable-card-deck-common:                   true !default;
+$enable-card-deck-responsive:               true !default;
+$enable-card-group:                         true !default;
+$enable-card-group-common:                  true !default;
+$enable-card-group-responsive:              true !default;
+$enable-card-columns:                       true !default;
+$enable-card-columns-common:                true !default;
+$enable-card-columns-responsive:            true !default;
+
 // Input Group
 $enable-input-group:                        true !default; // true
 

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -49,9 +49,9 @@ $enable-btn-colors:                         true !default; // true
 $enable-btn-outline:                        true !default; // true
 $enable-btn-outline-colors:                 true !default; // true
 $enable-btn-link:                           true !default; // true
-$enable-btn-sizes:                          true !default; // true
+$enable-btn-sizing:                         true !default; // true
 $enable-btn-icon:                           true !default; // true
-$enable-btn-icon-sizes:                     true !default; // true
+$enable-btn-icon-sizing:                    true !default; // true
 $enable-btn-block:                          true !default; // true
 $enable-btn-check:                          true !default; // true
 
@@ -59,9 +59,9 @@ $enable-btn-check:                          true !default; // true
 $enable-form:                               true !default; // true
 $enable-form-control:                       true !default; // true
 $enable-form-control-special:               true !default; // true
-$enable-form-control-sizes:                 true !default; // true
+$enable-form-control-sizing:                true !default; // true
 $enable-form-control-label:                 true !default; // true
-$enable-form-control-label-sizes:           true !default; // true
+$enable-form-control-label-sizing:          true !default; // true
 $enable-form-control-static:                true !default; // true
 $enable-form-group:                         true !default; // true
 $enable-form-text:                          true !default; // true
@@ -79,7 +79,7 @@ $enable-custom-checkbox:                    true !default; // true
 $enable-custom-radio:                       true !default; // true
 $enable-custom-switch:                      true !default; // true
 $enable-custom-select:                      true !default; // true
-$enable-custom-select-sizes:                true !default; // true
+$enable-custom-select-sizing:               true !default; // true
 $enable-custom-file:                        true !default; // true
 $enable-custom-color:                       true !default; // true
 $enable-custom-range:                       true !default; // true

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -104,6 +104,9 @@ $enable-badge-colors:                       true !default; // true
 $enable-badge-outline:                      true !default; // true
 $enable-badge-outline-colors:               true !default; // true
 
+// Breadcrumb
+$enable-breadcrumb:                         true !default; // true
+
 // Input Group
 $enable-input-group:                        true !default; // true
 

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -31,7 +31,6 @@ $enable-figure:                             true !default;
 
 // Table
 $enable-table:                              true !default;
-$enable-table-common:                       true !default;
 $enable-table-borders:                      true !default;
 $enable-table-striped:                      true !default;
 $enable-table-hover:                        true !default;
@@ -43,7 +42,6 @@ $enable-table-scroll-responsive:            true !default;
 
 // Button
 $enable-btn:                                true !default;
-$enable-btn-common:                         true !default;
 $enable-btn-default:                        true !default;
 $enable-btn-colors:                         true !default;
 $enable-btn-outline:                        true !default;
@@ -86,7 +84,6 @@ $enable-custom-range:                       true !default;
 
 // Alert
 $enable-alert:                              true !default;
-$enable-alert-common:                       true !default;
 $enable-alert-close:                        true !default;
 $enable-alert-heading:                      true !default;
 $enable-alert-link:                         true !default;
@@ -95,7 +92,6 @@ $enable-alert-colors:                       true !default;
 
 // Badge
 $enable-badge:                              true !default;
-$enable-badge-common:                       true !default;
 $enable-badge-close:                        true !default;
 $enable-badge-pill:                         true !default;
 $enable-badge-group:                        true !default;
@@ -116,7 +112,6 @@ $enable-btn-toolbar:                        true !default;
 
 // Cards
 $enable-card:                               true !default;
-$enable-card-common:                        true !default;
 $enable-card-body:                          true !default;
 $enable-card-title:                         true !default;
 $enable-card-subtitle:                      true !default;
@@ -132,17 +127,21 @@ $enable-card-img:                           true !default;
 $enable-card-img-overlay:                   true !default;
 $enable-card-horizontal:                    true !default;
 $enable-card-deck:                          true !default;
-$enable-card-deck-common:                   true !default;
 $enable-card-deck-responsive:               true !default;
 $enable-card-group:                         true !default;
-$enable-card-group-common:                  true !default;
 $enable-card-group-responsive:              true !default;
 $enable-card-columns:                       true !default;
-$enable-card-columns-common:                true !default;
 $enable-card-columns-responsive:            true !default;
 
 // Input Group
 $enable-input-group:                        true !default;
+$enable-input-group-addon:                  true !default;
+$enable-input-group-text:                   true !default;
+$enable-input-group-sizing:                 true !default;
+
+// Jumbotron
+$enable-jumbotron:                          true !default;
+$enable-jumbotron-fluid:                    true !default;
 
 // Utility Options
 $enable-utility-bg:                         true !default;

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -171,6 +171,29 @@ $enable-navbar-toggle:                      true !default;
 $enable-navbar-light:                       true !default;
 $enable-navbar-dark:                        true !default;
 
+// Nav
+$enable-nav:                                true !default;
+$enable-nav-tabs:                           true !default;
+$enable-nav-pills:                          true !default;
+$enable-nav-vertical:                       true !default;
+$enable-nav-fill:                           true !default;
+$enable-nav-justify:                        true !default;
+$enable-tab-content:                        true !default;
+
+// Pagination
+$enable-pagination:                         true !default;
+$enable-pagination-spaced:                  true !default;
+$enable-pagination-group:                   true !default;
+$enable-pagination-sizing:                  true !default;
+
+// Progress
+$enable-progress:                           true !default;
+$enable-progress-striped:                   true !default;
+$enable-progress-animated:                  true !default;
+
+//Dropdown
+$enable-dropdown:                           true !default;
+
 // Utility Options
 $enable-utility-bg:                         true !default;
 $enable-utility-bg-colors:                  true !default;

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -84,6 +84,26 @@ $enable-custom-file:                        true !default; // true
 $enable-custom-color:                       true !default; // true
 $enable-custom-range:                       true !default; // true
 
+// Alert
+$enable-alert:                              true !default; // true
+$enable-alert-common:                       true !default; // true
+$enable-alert-close:                        true !default; // true
+$enable-alert-heading:                      true !default; // true
+$enable-alert-link:                         true !default; // true
+$enable-alert-hr:                           true !default; // true
+$enable-alert-colors:                       true !default; // true
+
+// Badge
+$enable-badge:                              true !default; // true
+$enable-badge-common:                       true !default; // true
+$enable-badge-close:                        true !default; // true
+$enable-badge-pill:                         true !default; // true
+$enable-badge-group:                        true !default; // true
+$enable-badge-default:                      true !default; // true
+$enable-badge-colors:                       true !default; // true
+$enable-badge-outline:                      true !default; // true
+$enable-badge-outline-colors:               true !default; // true
+
 // Input Group
 $enable-input-group:                        true !default; // true
 

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -143,6 +143,34 @@ $enable-input-group-sizing:                 true !default;
 $enable-jumbotron:                          true !default;
 $enable-jumbotron-fluid:                    true !default;
 
+// List
+$enable-list:                               true !default;
+$enable-list-bulleted:                      true !default;
+$enable-list-ordered:                       true !default;
+$enable-list-divided:                       true !default;
+$enable-list-ruled:                         true !default;
+$enable-list-group:                         true !default;
+$enable-list-spaced:                        true !default;
+$enable-list-spaced-y:                      true !default;
+$enable-list-spaced-x:                      true !default;
+$enable-list-horizontal:                    true !default;
+$enable-list-item-action:                   true !default;
+$enable-list-item-colors:                   true !default;
+
+// Media Object
+$enable-media:                              true !default;
+
+// Navbar
+$enable-navbar:                             true !default;
+$enable-navbar-brand:                       true !default;
+$enable-navbar-nav:                         true !default;
+$enable-navbar-text:                        true !default;
+$enable-navbar-divider:                     true !default;
+$enable-navbar-collapse:                    true !default;
+$enable-navbar-toggle:                      true !default;
+$enable-navbar-light:                       true !default;
+$enable-navbar-dark:                        true !default;
+
 // Utility Options
 $enable-utility-bg:                         true !default;
 $enable-utility-bg-colors:                  true !default;

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -1,118 +1,118 @@
 // Root CSS variables
-$enable-root:                               true !default; // true
-$enable-root-colors:                        true !default; // true
-$enable-root-breakpoints:                   true !default; // true
-$enable-root-fonts:                         true !default; // true
+$enable-root:                               true !default;
+$enable-root-colors:                        true !default;
+$enable-root-breakpoints:                   true !default;
+$enable-root-fonts:                         true !default;
 
 // Base Typography
-$enable-typography:                         true !default; // true
-$enable-typography-headings:                true !default; // true
-$enable-typography-lead:                    true !default; // true
-$enable-typography-hr:                      true !default; // true
-$enable-typography-small:                   true !default; // true
-$enable-typography-mark:                    true !default; // true
-$enable-typography-list-unstyled:           true !default; // true
-$enable-typography-initialism:              true !default; // true
-$enable-typography-blockquote:              true !default; // true
+$enable-typography:                         true !default;
+$enable-typography-headings:                true !default;
+$enable-typography-lead:                    true !default;
+$enable-typography-hr:                      true !default;
+$enable-typography-small:                   true !default;
+$enable-typography-mark:                    true !default;
+$enable-typography-list-unstyled:           true !default;
+$enable-typography-initialism:              true !default;
+$enable-typography-blockquote:              true !default;
 
 // Code snippets
-$enable-code:                               true !default; // true
-$enable-code-code:                          true !default; // true
-$enable-code-kbd:                           true !default; // true
-$enable-code-pre:                           true !default; // true
+$enable-code:                               true !default;
+$enable-code-code:                          true !default;
+$enable-code-kbd:                           true !default;
+$enable-code-pre:                           true !default;
 
 // Images
-$enable-img:                                true !default; // true
-$enable-img-fluid:                          true !default; // true
-$enable-img-thumbnail:                      true !default; // true
+$enable-img:                                true !default;
+$enable-img-fluid:                          true !default;
+$enable-img-thumbnail:                      true !default;
 
 // Figure
-$enable-figure:                             true !default; // true
+$enable-figure:                             true !default;
 
 // Table
-$enable-table:                              true !default; // true
-$enable-table-common:                       true !default; // true
-$enable-table-borders:                      true !default; // true
-$enable-table-striped:                      true !default; // true
-$enable-table-hover:                        true !default; // true
-$enable-table-condensed:                    true !default; // true
-$enable-table-active:                       true !default; // true
-$enable-table-colors:                       true !default; // true
-$enable-table-scroll:                       true !default; // true
-$enable-table-scroll-responsive:            true !default; // true
+$enable-table:                              true !default;
+$enable-table-common:                       true !default;
+$enable-table-borders:                      true !default;
+$enable-table-striped:                      true !default;
+$enable-table-hover:                        true !default;
+$enable-table-condensed:                    true !default;
+$enable-table-active:                       true !default;
+$enable-table-colors:                       true !default;
+$enable-table-scroll:                       true !default;
+$enable-table-scroll-responsive:            true !default;
 
 // Button
-$enable-btn:                                true !default; // true
-$enable-btn-common:                         true !default; // true
-$enable-btn-default:                        true !default; // true
-$enable-btn-colors:                         true !default; // true
-$enable-btn-outline:                        true !default; // true
-$enable-btn-outline-colors:                 true !default; // true
-$enable-btn-link:                           true !default; // true
-$enable-btn-sizing:                         true !default; // true
-$enable-btn-icon:                           true !default; // true
-$enable-btn-icon-sizing:                    true !default; // true
-$enable-btn-block:                          true !default; // true
-$enable-btn-check:                          true !default; // true
+$enable-btn:                                true !default;
+$enable-btn-common:                         true !default;
+$enable-btn-default:                        true !default;
+$enable-btn-colors:                         true !default;
+$enable-btn-outline:                        true !default;
+$enable-btn-outline-colors:                 true !default;
+$enable-btn-link:                           true !default;
+$enable-btn-sizing:                         true !default;
+$enable-btn-icon:                           true !default;
+$enable-btn-icon-sizing:                    true !default;
+$enable-btn-block:                          true !default;
+$enable-btn-check:                          true !default;
 
 // Form
-$enable-form:                               true !default; // true
-$enable-form-control:                       true !default; // true
-$enable-form-control-special:               true !default; // true
-$enable-form-control-sizing:                true !default; // true
-$enable-form-control-label:                 true !default; // true
-$enable-form-control-label-sizing:          true !default; // true
-$enable-form-control-static:                true !default; // true
-$enable-form-group:                         true !default; // true
-$enable-form-text:                          true !default; // true
-$enable-form-row:                           true !default; // true
-$enable-form-check:                         true !default; // true
-$enable-form-check-inline:                  true !default; // true
-$enable-form-validation:                    true !default; // true
-$enable-form-validation-feedback:           true !default; // true
-$enable-form-validation-tooltip:            true !default; // true
-$enable-form-inline:                        true !default; // true
+$enable-form:                               true !default;
+$enable-form-control:                       true !default;
+$enable-form-control-special:               true !default;
+$enable-form-control-sizing:                true !default;
+$enable-form-control-label:                 true !default;
+$enable-form-control-label-sizing:          true !default;
+$enable-form-control-static:                true !default;
+$enable-form-group:                         true !default;
+$enable-form-text:                          true !default;
+$enable-form-row:                           true !default;
+$enable-form-check:                         true !default;
+$enable-form-check-inline:                  true !default;
+$enable-form-validation:                    true !default;
+$enable-form-validation-feedback:           true !default;
+$enable-form-validation-tooltip:            true !default;
+$enable-form-inline:                        true !default;
 
 // Custom Form
-$enable-custom-control:                     true !default; // true
-$enable-custom-checkbox:                    true !default; // true
-$enable-custom-radio:                       true !default; // true
-$enable-custom-switch:                      true !default; // true
-$enable-custom-select:                      true !default; // true
-$enable-custom-select-sizing:               true !default; // true
-$enable-custom-file:                        true !default; // true
-$enable-custom-color:                       true !default; // true
-$enable-custom-range:                       true !default; // true
+$enable-custom-control:                     true !default;
+$enable-custom-checkbox:                    true !default;
+$enable-custom-radio:                       true !default;
+$enable-custom-switch:                      true !default;
+$enable-custom-select:                      true !default;
+$enable-custom-select-sizing:               true !default;
+$enable-custom-file:                        true !default;
+$enable-custom-color:                       true !default;
+$enable-custom-range:                       true !default;
 
 // Alert
-$enable-alert:                              true !default; // true
-$enable-alert-common:                       true !default; // true
-$enable-alert-close:                        true !default; // true
-$enable-alert-heading:                      true !default; // true
-$enable-alert-link:                         true !default; // true
-$enable-alert-hr:                           true !default; // true
-$enable-alert-colors:                       true !default; // true
+$enable-alert:                              true !default;
+$enable-alert-common:                       true !default;
+$enable-alert-close:                        true !default;
+$enable-alert-heading:                      true !default;
+$enable-alert-link:                         true !default;
+$enable-alert-hr:                           true !default;
+$enable-alert-colors:                       true !default;
 
 // Badge
-$enable-badge:                              true !default; // true
-$enable-badge-common:                       true !default; // true
-$enable-badge-close:                        true !default; // true
-$enable-badge-pill:                         true !default; // true
-$enable-badge-group:                        true !default; // true
-$enable-badge-default:                      true !default; // true
-$enable-badge-colors:                       true !default; // true
-$enable-badge-outline:                      true !default; // true
-$enable-badge-outline-colors:               true !default; // true
+$enable-badge:                              true !default;
+$enable-badge-common:                       true !default;
+$enable-badge-close:                        true !default;
+$enable-badge-pill:                         true !default;
+$enable-badge-group:                        true !default;
+$enable-badge-default:                      true !default;
+$enable-badge-colors:                       true !default;
+$enable-badge-outline:                      true !default;
+$enable-badge-outline-colors:               true !default;
 
 // Breadcrumb
-$enable-breadcrumb:                         true !default; // true
+$enable-breadcrumb:                         true !default;
 
 // Button Group
-$enable-btn-group:                          true !default; // true
-$enable-btn-group-horizontal:               true !default; // true
-$enable-btn-group-vertical:                 true !default; // true
-$enable-btn-group-sizing:                   true !default; // true
-$enable-btn-toolbar:                        true !default; // true
+$enable-btn-group:                          true !default;
+$enable-btn-group-horizontal:               true !default;
+$enable-btn-group-vertical:                 true !default;
+$enable-btn-group-sizing:                   true !default;
+$enable-btn-toolbar:                        true !default;
 
 // Cards
 $enable-card:                               true !default;
@@ -142,88 +142,88 @@ $enable-card-columns-common:                true !default;
 $enable-card-columns-responsive:            true !default;
 
 // Input Group
-$enable-input-group:                        true !default; // true
+$enable-input-group:                        true !default;
 
 // Utility Options
-$enable-utility-bg:                         true !default;  // true
-$enable-utility-bg-colors:                  true !default;  // true
-$enable-utility-bg-palette:                 true !default;  // true
-$enable-utility-bg-special:                 true !default;  // true
+$enable-utility-bg:                         true !default;
+$enable-utility-bg-colors:                  true !default;
+$enable-utility-bg-palette:                 true !default;
+$enable-utility-bg-special:                 true !default;
 
-$enable-utility-border:                     true !default;  // true
-$enable-utility-border-addition:            true !default;  // true
-$enable-utility-border-removal:             true !default;  // true
-$enable-utility-border-colors:              true !default;  // true
-$enable-utility-border-palette:             true !default;  // true
-$enable-utility-border-special:             true !default;  // true
-$enable-utility-border-radius-circle:       true !default;  // true
-$enable-utility-border-radius-addition:     true !default;  // true
-$enable-utility-border-radius-component:    true !default;  // true
-$enable-utility-border-radius-removal:      true !default;  // true
+$enable-utility-border:                     true !default;
+$enable-utility-border-addition:            true !default;
+$enable-utility-border-removal:             true !default;
+$enable-utility-border-colors:              true !default;
+$enable-utility-border-palette:             true !default;
+$enable-utility-border-special:             true !default;
+$enable-utility-border-radius-circle:       true !default;
+$enable-utility-border-radius-addition:     true !default;
+$enable-utility-border-radius-component:    true !default;
+$enable-utility-border-radius-removal:      true !default;
 
-$enable-utility-clearfix:                   true !default;  // true
+$enable-utility-clearfix:                   true !default;
 
-$enable-utility-display:                    true !default;  // true
-$enable-utility-display-common:             true !default;  // true
-$enable-utility-display-table:              true !default;  // true
-$enable-utility-display-down:               true !default;  // true
-$enable-utility-display-print:              true !default;  // true
+$enable-utility-display:                    true !default;
+$enable-utility-display-common:             true !default;
+$enable-utility-display-table:              true !default;
+$enable-utility-display-down:               true !default;
+$enable-utility-display-print:              true !default;
 
-$enable-utility-embed:                      true !default;  // true
-$enable-utility-embed-fluid:                true !default;  // true
-$enable-utility-embed-fullscreen:           true !default;  // true
+$enable-utility-embed:                      true !default;
+$enable-utility-embed-fluid:                true !default;
+$enable-utility-embed-fullscreen:           true !default;
 
-$enable-utility-flex:                       true !default;  // true
-$enable-utility-flex-order:                 true !default;  // true
-$enable-utility-flex-direction:             true !default;  // true
-$enable-utility-flex-wrap:                  true !default;  // true
-$enable-utility-flex-justify:               true !default;  // true
-$enable-utility-flex-items:                 true !default;  // true
-$enable-utility-flex-content:               true !default;  // true
-$enable-utility-flex-self:                  true !default;  // true
-$enable-utility-flex-sizing:                true !default;  // true
+$enable-utility-flex:                       true !default;
+$enable-utility-flex-order:                 true !default;
+$enable-utility-flex-direction:             true !default;
+$enable-utility-flex-wrap:                  true !default;
+$enable-utility-flex-justify:               true !default;
+$enable-utility-flex-items:                 true !default;
+$enable-utility-flex-content:               true !default;
+$enable-utility-flex-self:                  true !default;
+$enable-utility-flex-sizing:                true !default;
 
-$enable-utility-float:                      true !default;  // true
+$enable-utility-float:                      true !default;
 
-$enable-utility-position:                   true !default;  // true
-$enable-utility-position-common:            true !default;  // true
-$enable-utility-position-fixed:             true !default;  // true
-$enable-utility-position-fixed-top:         true !default;  // true
-$enable-utility-position-fixed-bottom:      true !default;  // true
-$enable-utility-position-sticky:            true !default;  // true
-$enable-utility-position-sticky-top:        true !default;  // true
+$enable-utility-position:                   true !default;
+$enable-utility-position-common:            true !default;
+$enable-utility-position-fixed:             true !default;
+$enable-utility-position-fixed-top:         true !default;
+$enable-utility-position-fixed-bottom:      true !default;
+$enable-utility-position-sticky:            true !default;
+$enable-utility-position-sticky-top:        true !default;
 
-$enable-utility-sronly:                     true !default;  // true
-$enable-utility-sronly-common:              true !default;  // true
-$enable-utility-sronly-focusable:           true !default;  // true
-$enable-utility-sronly-responsive:          true !default;  // true
-$enable-utility-sronly-responsive-down:     true !default;  // true
+$enable-utility-sronly:                     true !default;
+$enable-utility-sronly-common:              true !default;
+$enable-utility-sronly-focusable:           true !default;
+$enable-utility-sronly-responsive:          true !default;
+$enable-utility-sronly-responsive-down:     true !default;
 
-$enable-utility-shadow:                     true !default;  // true
+$enable-utility-shadow:                     true !default;
 
-$enable-utility-sizing:                     true !default;  // true
-$enable-utility-sizing-width:               true !default;  // true
-$enable-utility-sizing-height:              true !default;  // true
+$enable-utility-sizing:                     true !default;
+$enable-utility-sizing-width:               true !default;
+$enable-utility-sizing-height:              true !default;
 
-$enable-utility-spacing:                    true !default;  // true
-$enable-utility-spacing-padding:            true !default;  // true
-$enable-utility-spacing-margin:             true !default;  // true
-$enable-utility-spacing-margin-auto:        true !default;  // true
-$enable-utility-spacing-margin-negative:    true !default;  // true
+$enable-utility-spacing:                    true !default;
+$enable-utility-spacing-padding:            true !default;
+$enable-utility-spacing-margin:             true !default;
+$enable-utility-spacing-margin-auto:        true !default;
+$enable-utility-spacing-margin-negative:    true !default;
 
-$enable-utility-text:                       true !default;  // true
-$enable-utility-text-justify:               true !default;  // true
-$enable-utility-text-nowrap:                true !default;  // true
-$enable-utility-text-align:                 true !default;  // true
-$enable-utility-text-transform:             true !default;  // true
-$enable-utility-text-weight:                true !default;  // true
-$enable-utility-text-style:                 true !default;  // true
-$enable-utility-text-family:                true !default;  // true
-$enable-utility-text-truncate:              true !default;  // true
-$enable-utility-text-colors:                true !default;  // true
-$enable-utility-text-palette:               true !default;  // true
-$enable-utility-text-special:               true !default;  // true
+$enable-utility-text:                       true !default;
+$enable-utility-text-justify:               true !default;
+$enable-utility-text-nowrap:                true !default;
+$enable-utility-text-align:                 true !default;
+$enable-utility-text-transform:             true !default;
+$enable-utility-text-weight:                true !default;
+$enable-utility-text-style:                 true !default;
+$enable-utility-text-family:                true !default;
+$enable-utility-text-truncate:              true !default;
+$enable-utility-text-colors:                true !default;
+$enable-utility-text-palette:               true !default;
+$enable-utility-text-special:               true !default;
 
-$enable-utility-valign:                     true !default;  // true
+$enable-utility-valign:                     true !default;
 
-$enable-utility-visibility:                 true !default;  // true
+$enable-utility-visibility:                 true !default;

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -107,6 +107,13 @@ $enable-badge-outline-colors:               true !default; // true
 // Breadcrumb
 $enable-breadcrumb:                         true !default; // true
 
+// Button Group
+$enable-btn-group:                          true !default; // true
+$enable-btn-group-horizontal:               true !default; // true
+$enable-btn-group-vertical:                 true !default; // true
+$enable-btn-group-sizing:                   true !default; // true
+$enable-btn-toolbar:                        true !default; // true
+
 // Input Group
 $enable-input-group:                        true !default; // true
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -963,7 +963,7 @@ $jumbotron-padding-x:       1.5rem !default;
 $jumbotron-padding-xs-y:    1.5rem !default;
 $jumbotron-padding-xs-x:    .75rem !default;
 $jumbotron-bg:              $uibase-50 !default;
-$jumbotron-border-radius:   .3rem !default;
+$jumbotron-border-radius:   .3125rem !default;
 $jumbotron-breakpoint:      sm !default;
 
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1035,13 +1035,7 @@ $card-cap-border-width:     $card-border-width !default;
 
 $card-img-overlay-padding:  $card-padding-y $card-padding-x !default;
 
-$card-deck-gutter-widths: (
-    xs: map-get($grid-gutter-widths, xs),
-    sm: map-get($grid-gutter-widths, sm),
-    md: map-get($grid-gutter-widths, md),
-    lg: map-get($grid-gutter-widths, lg),
-    xl: map-get($grid-gutter-widths, xl)
-) !default;
+$card-deck-gutter-widths:   $grid-gutter-widths !default;
 
 $card-columns-count:            3 !default;
 $card-columns-column-gap:       1.25rem !default;

--- a/scss/component/_alert.scss
+++ b/scss/component/_alert.scss
@@ -1,23 +1,21 @@
 @if $enable-alert {
 
     // Base styles
-    @if $enable-alert-common {
-        .alert {
-            position: relative;
-            padding: $alert-padding-y $alert-padding-x;
-            padding-right: ($alert-padding-x + ($alert-close-padding-x * 2));
-            margin-bottom: $alert-margin-bottom;
-            border: $alert-border-width solid transparent;
-            @include border-radius($alert-border-radius);
+    .alert {
+        position: relative;
+        padding: $alert-padding-y $alert-padding-x;
+        padding-right: ($alert-padding-x + ($alert-close-padding-x * 2));
+        margin-bottom: $alert-margin-bottom;
+        border: $alert-border-width solid transparent;
+        @include border-radius($alert-border-radius);
 
-            // Adjust close link position and color
-            @if $enable-alert-close {
-                .close {
-                    position: absolute;
-                    top: 0;
-                    right: 0;
-                    padding: $alert-close-padding-y $alert-close-padding-x;
-                }
+        // Adjust close link position and color
+        @if $enable-alert-close {
+            .close {
+                position: absolute;
+                top: 0;
+                right: 0;
+                padding: $alert-close-padding-y $alert-close-padding-x;
             }
         }
     }

--- a/scss/component/_alert.scss
+++ b/scss/component/_alert.scss
@@ -1,51 +1,64 @@
-// Base styles
-.alert {
-    position: relative;
-    padding: $alert-padding-y $alert-padding-x;
-    padding-right: ($alert-padding-x + ($alert-close-padding-x * 2));
-    margin-bottom: $alert-margin-bottom;
-    border: $alert-border-width solid transparent;
-    @include border-radius($alert-border-radius);
+@if $enable-alert {
 
-    // Adjust close link position and color
-    .close {
-        position: absolute;
-        top: 0;
-        right: 0;
-        padding: $alert-close-padding-y $alert-close-padding-x;
+    // Base styles
+    @if $enable-alert-common {
+        .alert {
+            position: relative;
+            padding: $alert-padding-y $alert-padding-x;
+            padding-right: ($alert-padding-x + ($alert-close-padding-x * 2));
+            margin-bottom: $alert-margin-bottom;
+            border: $alert-border-width solid transparent;
+            @include border-radius($alert-border-radius);
+
+            // Adjust close link position and color
+            @if $enable-alert-close {
+                .close {
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    padding: $alert-close-padding-y $alert-close-padding-x;
+                }
+            }
+        }
     }
-}
 
-// Headings for larger alerts
-.alert-heading {
-    // Specified to prevent conflicts of changing $headings-color
-    color: inherit;
-}
+    // Headings for larger alerts
+    @if $enable-alert-heading {
+        .alert-heading {
+            // Specified to prevent conflicts of changing $headings-color
+            color: inherit;
+        }
+    }
 
-// Provide class for links that match alerts
-.alert-link {
-    font-weight: $alert-link-font-weight;
-}
+    // Provide class for links that match alerts
+    @if $enable-alert-link {
+        .alert-link {
+            font-weight: $alert-link-font-weight;
+        }
+    }
 
-// Theme generation
-@if (type-of($alert-colors) == "map" and length($alert-colors) != 0) {
-    $mixed-alert-themes: _mix-context-colors($alert-colors, $alert-levels);
-    $alert-themes: map-merge($mixed-alert-themes, $alert-themes);
-}
+    // Theme generation
+    @if $enable-alert-colors {
+        @if (type-of($alert-colors) == "map" and length($alert-colors) != 0) {
+            $mixed-alert-themes: _mix-context-colors($alert-colors, $alert-levels);
+            $alert-themes: map-merge($mixed-alert-themes, $alert-themes);
+        }
 
-// Contextual modifiers
-@if (type-of($alert-themes) == "map" and length($alert-themes) != 0) {
-    @each $theme, $colors in $alert-themes {
-        $bg:          map-get($colors, "bg");
-        $color:       map-get($colors, "color");
-        $border:      map-get($colors, "border-color");
-        $hover-color: map-get($colors, "hover-color");
+        // Contextual modifiers
+        @if (type-of($alert-themes) == "map" and length($alert-themes) != 0) {
+            @each $theme, $colors in $alert-themes {
+                $bg:          map-get($colors, "bg");
+                $color:       map-get($colors, "color");
+                $border:      map-get($colors, "border-color");
+                $hover-color: map-get($colors, "hover-color");
 
-        $color:       color-if-contrast($color, $bg);
-        $hover-color: color-if-contrast($hover-color, $bg);
+                $color:       color-if-contrast($color, $bg);
+                $hover-color: color-if-contrast($hover-color, $bg);
 
-        .alert-#{$theme} {
-            @include alert-variant($color, $bg, $border, $hover-color);
+                .alert-#{$theme} {
+                    @include alert-variant($color, $bg, $border, $hover-color);
+                }
+            }
         }
     }
 }

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -1,47 +1,47 @@
 @if $enable-badge {
     // Base class
-    @if $enable-badge-common {
-        .badge {
-            display: inline-block;
-            padding: $badge-padding-y $badge-padding-x;
-            @include font-size($badge-font-size);
-            font-weight: $badge-font-weight;
-            line-height: $badge-line-height;
-            text-align: center;
-            text-decoration: none;
-            white-space: nowrap;
-            vertical-align: baseline;
-            border: $badge-border-width solid transparent;
-            @include border-radius($badge-border-radius);
+    .badge {
+        display: inline-block;
+        padding: $badge-padding-y $badge-padding-x;
+        @include font-size($badge-font-size);
+        font-weight: $badge-font-weight;
+        line-height: $badge-line-height;
+        text-align: center;
+        text-decoration: none;
+        white-space: nowrap;
+        vertical-align: baseline;
+        border: $badge-border-width solid transparent;
+        @include border-radius($badge-border-radius);
 
-            // Empty badges collapse automatically
-            &:empty {
-                display: none;
-            }
+        // Empty badges collapse automatically
+        &:empty {
+            display: none;
+        }
 
-            // Add hover effects, but only for links
-            &[href] {
-                @include hover-focus {
-                    text-decoration: none;
-                }
-            }
-
-            @if $enable-badge-close {
-                .close {
-                    padding-right: $badge-close-padding-x;
-                    padding-left: $badge-close-padding-x;
-                    margin-right: -$badge-close-padding-x;
-                    font-size: $badge-close-font-size;
-                }
-            }
-
-            // Default color (linked badges get darker on :hover)
-            @if $enable-badge-default {
-                @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
+        // Add hover effects, but only for links
+        &[href] {
+            @include hover-focus {
+                text-decoration: none;
             }
         }
 
-        // Quick fix for badges in buttons
+        @if $enable-badge-close {
+            .close {
+                padding-right: $badge-close-padding-x;
+                padding-left: $badge-close-padding-x;
+                margin-right: -$badge-close-padding-x;
+                font-size: $badge-close-font-size;
+            }
+        }
+
+        // Default color (linked badges get darker on :hover)
+        @if $enable-badge-default {
+            @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
+        }
+    }
+
+    // Quick fix for badges in buttons
+    @if $enable-btn {
         .btn .badge {
             position: relative;
             top: -1px;

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -19,7 +19,7 @@
         }
 
         // Add hover effects, but only for links
-        &[href] {
+        @at-root a#{&} {
             @include hover-focus {
                 text-decoration: none;
             }

--- a/scss/component/_badge.scss
+++ b/scss/component/_badge.scss
@@ -1,108 +1,127 @@
-// Base class
-.badge {
-    display: inline-block;
-    padding: $badge-padding-y $badge-padding-x;
-    @include font-size($badge-font-size);
-    font-weight: $badge-font-weight;
-    line-height: $badge-line-height;
-    text-align: center;
-    text-decoration: none;
-    white-space: nowrap;
-    vertical-align: baseline;
-    border: $badge-border-width solid transparent;
-    @include border-radius($badge-border-radius);
-
-    // Empty badges collapse automatically
-    &:empty {
-        display: none;
-    }
-
-    // Add hover effects, but only for links
-    &[href] {
-        @include hover-focus {
+@if $enable-badge {
+    // Base class
+    @if $enable-badge-common {
+        .badge {
+            display: inline-block;
+            padding: $badge-padding-y $badge-padding-x;
+            @include font-size($badge-font-size);
+            font-weight: $badge-font-weight;
+            line-height: $badge-line-height;
+            text-align: center;
             text-decoration: none;
+            white-space: nowrap;
+            vertical-align: baseline;
+            border: $badge-border-width solid transparent;
+            @include border-radius($badge-border-radius);
+
+            // Empty badges collapse automatically
+            &:empty {
+                display: none;
+            }
+
+            // Add hover effects, but only for links
+            &[href] {
+                @include hover-focus {
+                    text-decoration: none;
+                }
+            }
+
+            @if $enable-badge-close {
+                .close {
+                    padding-right: $badge-close-padding-x;
+                    padding-left: $badge-close-padding-x;
+                    margin-right: -$badge-close-padding-x;
+                    font-size: $badge-close-font-size;
+                }
+            }
+
+            // Default color (linked badges get darker on :hover)
+            @if $enable-badge-default {
+                @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
+            }
+        }
+
+        // Quick fix for badges in buttons
+        .btn .badge {
+            position: relative;
+            top: -1px;
         }
     }
 
-    .close {
-        padding-right: $badge-close-padding-x;
-        padding-left: $badge-close-padding-x;
-        margin-right: -$badge-close-padding-x;
-        font-size: $badge-close-font-size;
-    }
-
-    // Default color (linked badges get darker on :hover)
-    @include badge-variant($badge-default-color, $badge-default-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
-}
-
-// Quick fix for badges in buttons
-.btn .badge {
-    position: relative;
-    top: -1px;
-}
-
-// Pill
-.badge-pill {
-    padding-right: $badge-pill-padding-x;
-    padding-left: $badge-pill-padding-x;
-    @include border-radius($badge-pill-border-radius);
-}
-
-// Badge group
-.badge-group {
-    display: inline-flex;
-    vertical-align: baseline;
-
-    > .badge {
-        &:not(:first-child) {
-            margin-left: -$badge-border-width;
-            @include border-start-radius(0);
-        }
-
-        &:not(:last-child) {
-            @include border-end-radius(0);
+    // Pill
+    @if $enable-badge-pill {
+        .badge-pill {
+            padding-right: $badge-pill-padding-x;
+            padding-left: $badge-pill-padding-x;
+            @include border-radius($badge-pill-border-radius);
         }
     }
-}
 
-// Theme generation
-@if (type-of($badge-colors) == "map" and length($badge-colors) != 0) {
-    $mixed-badge-themes: _mix-context-colors($badge-colors, $badge-levels);
-    $badge-themes: map-merge($mixed-badge-themes, $badge-themes);
-}
+    // Badge group
+    @if $enable-badge-group {
+        .badge-group {
+            display: inline-flex;
+            vertical-align: baseline;
 
-@if (type-of($badge-outline-colors) == "map" and length($badge-outline-colors) != 0) {
-    $mixed-badge-outline-themes: _mix-context-colors($badge-outline-colors, $badge-outline-levels);
-    $badge-outline-themes: map-merge($mixed-badge-outline-themes, $badge-outline-themes);
-}
+            > .badge {
+                &:not(:first-child) {
+                    margin-left: -$badge-border-width;
+                    @include border-start-radius(0);
+                }
 
-// Colors (linked badges get darker on :hover)
-@if (type-of($badge-themes) == "map" and length($badge-themes) != 0) {
-    @each $theme, $colors in $badge-themes {
-        $bg:            map-get($colors, "bg");
-        $color:         map-get($colors, "color");
-        $hover-bg:      map-get($colors, "hover-bg");
-        $hover-color:   map-get($colors, "hover-color");
-
-        .badge-#{$theme} {
-            @include badge-variant($color, $bg, $bg, $hover-color, $hover-bg, $hover-bg);
+                &:not(:last-child) {
+                    @include border-end-radius(0);
+                }
+            }
         }
     }
-}
 
-// Outline (linked badges get color fill on :hover)
-.badge-outline {
-    @include badge-variant($badge-default-color, $badge-outline-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
-}
-@if (type-of($badge-outline-themes) == "map" and length($badge-outline-themes) != 0) {
-    @each $theme, $colors in $badge-outline-themes {
-        $bg:            $badge-outline-bg;
-        $color:         map-get($colors, "base");
-        $hover-bg:      map-get($colors, "bg");
-        $hover-color:   map-get($colors, "hover-color");
+    // Theme generation
+    @if $enable-badge-colors {
+        @if (type-of($badge-colors) == "map" and length($badge-colors) != 0) {
+            $mixed-badge-themes: _mix-context-colors($badge-colors, $badge-levels);
+            $badge-themes: map-merge($mixed-badge-themes, $badge-themes);
+        }
 
-        .badge-outline-#{$theme} {
-            @include badge-variant($color, $bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
+        // Colors (linked badges get darker on :hover)
+        @if (type-of($badge-themes) == "map" and length($badge-themes) != 0) {
+            @each $theme, $colors in $badge-themes {
+                $bg:            map-get($colors, "bg");
+                $color:         map-get($colors, "color");
+                $hover-bg:      map-get($colors, "hover-bg");
+                $hover-color:   map-get($colors, "hover-color");
+
+                .badge-#{$theme} {
+                    @include badge-variant($color, $bg, $bg, $hover-color, $hover-bg, $hover-bg);
+                }
+            }
+        }
+    }
+
+    // Outline (linked badges get color fill on :hover)
+    @if $enable-badge-outline {
+        .badge-outline {
+            @include badge-variant($badge-default-color, $badge-outline-bg, $badge-default-border, $badge-default-hover-color, $badge-default-hover-bg, $badge-default-hover-border);
+        }
+    }
+
+    @if $enable-badge-outline-colors {
+        @if (type-of($badge-outline-colors) == "map" and length($badge-outline-colors) != 0) {
+            $mixed-badge-outline-themes: _mix-context-colors($badge-outline-colors, $badge-outline-levels);
+            $badge-outline-themes: map-merge($mixed-badge-outline-themes, $badge-outline-themes);
+        }
+
+        @if (type-of($badge-outline-themes) == "map" and length($badge-outline-themes) != 0) {
+            @each $theme, $colors in $badge-outline-themes {
+                $bg:            $badge-outline-bg;
+                $color:         map-get($colors, "base");
+                $hover-bg:      map-get($colors, "bg");
+                $hover-color:   map-get($colors, "hover-color");
+
+                .badge-outline-#{$theme} {
+                    @include badge-variant($color, $bg, $hover-bg, $hover-color, $hover-bg, $hover-bg);
+                }
+            }
         }
     }
 }

--- a/scss/component/_breadcrumb.scss
+++ b/scss/component/_breadcrumb.scss
@@ -1,39 +1,41 @@
-.breadcrumb {
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: $breadcrumb-margin-bottom;
-    @include list-unstyled();
-}
+@if $enable-breadcrumb {
+    .breadcrumb {
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: $breadcrumb-margin-bottom;
+        @include list-unstyled();
+    }
 
-.breadcrumb-item {
-    // The separator between breadcrumbs (by default, a forward-slash: "/")
-    + .breadcrumb-item {
-        padding-left: $breadcrumb-item-padding-x;
+    .breadcrumb-item {
+        // The separator between breadcrumbs (by default, a forward-slash: "/")
+        + .breadcrumb-item {
+            padding-left: $breadcrumb-item-padding-x;
 
-        &::before {
-            display: inline-block; // Suppress underlining of the separator in modern browsers
-            padding-right: $breadcrumb-item-padding-x;
-            color: $breadcrumb-divider-color;
-            content: $breadcrumb-divider;
+            &::before {
+                display: inline-block; // Suppress underlining of the separator in modern browsers
+                padding-right: $breadcrumb-item-padding-x;
+                color: $breadcrumb-divider-color;
+                content: $breadcrumb-divider;
+            }
         }
-    }
 
-    // IE10-11 hack to properly handle hyperlink underlines for breadcrumbs built
-    // without `<ul>`s. The `::before` pseudo-element generates an element
-    // *within* the .breadcrumb-item and thereby inherits the `text-decoration`.
-    //
-    // To trick IE into suppressing the underline, we give the pseudo-element an
-    // underline and then immediately remove it.
-    // stylelint-disable no-duplicate-selectors
-    + .breadcrumb-item:hover::before {
-        text-decoration: underline;
-    }
-    + .breadcrumb-item:hover::before {
-        text-decoration: none;
-    }
-    // stylelint-enable no-duplicate-selectors
+        // IE10-11 hack to properly handle hyperlink underlines for breadcrumbs built
+        // without `<ul>`s. The `::before` pseudo-element generates an element
+        // *within* the .breadcrumb-item and thereby inherits the `text-decoration`.
+        //
+        // To trick IE into suppressing the underline, we give the pseudo-element an
+        // underline and then immediately remove it.
+        // stylelint-disable no-duplicate-selectors
+        + .breadcrumb-item:hover::before {
+            text-decoration: underline;
+        }
+        + .breadcrumb-item:hover::before {
+            text-decoration: none;
+        }
+        // stylelint-enable no-duplicate-selectors
 
-    &.active {
-        color: $breadcrumb-active-color;
+        &.active {
+            color: $breadcrumb-active-color;
+        }
     }
 }

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -1,113 +1,201 @@
-// Make the div behave like a button
-.btn-group,
-.btn-group-vertical {
-    position: relative;
-    display: inline-flex;
-    vertical-align: middle; // match .btn alignment given font-size hack above
-
-    > .btn,
-    > .btn-check > .btn {
+@if $enable-btn-group {
+    // Placeholder for buttons inside a button group
+    %btn-group-btn-base {
         position: relative;
         flex: 0 1 auto;
         margin-bottom: 0; // Override default `<label>` value
+    }
 
-        // Bring the "active" button to the front
-        &:active,
-        &.active {
-            z-index: 1;
+    // Placeholder for base button group
+    // Make the div behave like a button
+    %btn-group-base {
+        position: relative;
+        display: inline-flex;
+        vertical-align: middle; // match .btn alignment
+
+        > .btn {
+            @extend %btn-group-btn-base;
+
+            // Bring checked and focus buttons up to overlay
+            // Focus comes up higher for box-shadow focus ring
+            &:hover,
+            &:active,
+            &.active {
+                z-index: 1;
+            }
+            &:focus {
+                z-index: 2;
+            }
         }
-        &:hover,
-        &:focus,
-        &.focus {
-            z-index: 2;
+
+        @if $enable-btn-check {
+            > .btn-check {
+                > .btn {
+                    @extend %btn-group-btn-base;
+                }
+
+                // Bring checked and focus buttons up to overlay
+                // Focus comes up higher for box-shadow focus ring
+                > .btn:hover,
+                > .btn-check-input:checked ~ .btn {
+                    z-index: 1;
+                }
+                > .btn-check-input:focus ~ .btn {
+                    z-index: 2;
+                }
+            }
         }
     }
 
-    > .btn-check > .btn-check-input:focus ~ .btn {
-        z-index: 2;
-    }
-}
+    @if $enable-btn-group-horizontal {
+        .btn-group {
+            @extend %btn-group-base;
 
-// Group multiple button groups together for a toolbar
-.btn-toolbar {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+            // Prevent double borders when buttons are next to each other
+            %btn-group-btn-not-first-align {
+                margin-left: -$btn-border-width;
+            }
+            > .btn:not(:first-child),
+            > .btn-group:not(:first-child) {
+                @extend %btn-group-btn-not-first-align;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:first-child) {
+                    @extend %btn-group-btn-not-first-align;
+                }
+            }
 
-    .input-group {
-        width: auto;
-    }
-}
+            // Reset rounded corners
+            %btn-group-btn-not-last-radius {
+                @include border-end-radius(0);
+            }
+            > .btn:not(:last-child):not(.btn-group-end),
+            > .btn-group:not(:last-child) > .btn {
+                @extend %btn-group-btn-not-last-radius;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:last-child) > .btn {
+                    @extend %btn-group-btn-not-last-radius;
+                }
+            }
 
-.btn-group {
-    // Prevent double borders when buttons are next to each other
-    > .btn:not(:first-child),
-    > .btn-group:not(:first-child),
-    > .btn-check:not(:first-child) {
-        margin-left: -$btn-border-width;
-    }
-
-    // Reset rounded corners
-    > .btn:not(:last-child):not(.btn-group-end),
-    > .btn-group:not(:last-child) > .btn,
-    > .btn-check:not(:last-child) > .btn {
-        @include border-end-radius(0);
-    }
-
-    > .btn:not(:first-child),
-    > .btn-group:not(:first-child) > .btn,
-    > .btn-check:not(:first-child) > .btn {
-        @include border-start-radius(0);
-    }
-}
-
-// Sizing
-// Remix the button sizing classes into new ones for easier manipulation
-@if $enable-sizing {
-    @each $size, $dims in $btn-sizes {
-        .btn-group-#{$size} > .btn,
-        .btn-group-#{$size} > .btn-check > .btn {
-            @extend %btn-#{$size};
+            %btn-group-btn-not-first-radius {
+                @include border-start-radius(0);
+            }
+            > .btn:not(:first-child),
+            > .btn-group:not(:first-child) > .btn {
+                @extend %btn-group-btn-not-first-radius;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:first-child) > .btn {
+                    @extend %btn-group-btn-not-first-radius;
+                }
+            }
         }
-        @if $enable-btn-icon {
-            .btn-group-#{$size} > .btn-icon {
-                @extend %btn-icon-#{$size};
+    }
+
+    // Sizing
+    // Remix the button sizing classes into new ones for easier manipulation
+    @if $enable-sizing {
+        @each $size, $dims in $btn-sizes {
+            @if $enable-btn-group-sizing {
+                .btn-group-#{$size} > .btn {
+                    @extend %btn-#{$size};
+                }
+                @if $enable-btn-check {
+                    .btn-group-#{$size} > .btn-check > .btn {
+                        @extend %btn-#{$size};
+                    }
+                }
+                @if $enable-btn-icon {
+                    .btn-group-#{$size} > .btn-icon {
+                        @extend %btn-icon-#{$size};
+                    }
+                }
+            }
+        }
+    }
+
+    @if $enable-btn-group-vertical {
+        // Vertical button groups
+        .btn-group-vertical {
+            @extend %btn-group-base;
+
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: center;
+
+            %btn-group-vertical-btn-base {
+                width: 100%;
+                max-width: 100%;
+            }
+            > .btn,
+            > .btn-group,
+            > .btn-group > .btn {
+                @extend %btn-group-vertical-btn-base;
+            }
+            @if $enable-btn-check {
+                > .btn-check,
+                > .btn-check > .btn {
+                    @extend %btn-group-vertical-btn-base;
+                }
+            }
+
+            %btn-group-vertical-btn-not-first-align {
+                margin-top: -$btn-border-width;
+            }
+            > .btn:not(:first-child),
+            > .btn-group:not(:first-child) {
+                @extend %btn-group-vertical-btn-not-first-align;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:first-child) {
+                    @extend %btn-group-vertical-btn-not-first-align;
+                }
+            }
+
+            // Reset rounded corners
+            %btn-group-vertical-btn-not-last-radius {
+                @include border-bottom-radius(0);
+            }
+            > .btn:not(:last-child):not(.btn-group-end),
+            > .btn-group:not(:last-child) > .btn {
+                @extend %btn-group-vertical-btn-not-last-radius;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:last-child) > .btn {
+                    @extend %btn-group-vertical-btn-not-last-radius;
+                }
+            }
+
+            %btn-group-vertical-btn-not-first-radius {
+                @include border-top-radius(0);
+            }
+            > .btn:not(:first-child),
+            > .btn-group:not(:first-child) > .btn {
+                @extend %btn-group-vertical-btn-not-first-radius;
+            }
+            @if $enable-btn-check {
+                > .btn-check:not(:first-child) > .btn {
+                    @extend %btn-group-vertical-btn-not-first-radius;
+                }
+            }
+        }
+    }
+
+    // Group multiple button groups together for a toolbar
+    @if $enable-btn-toolbar {
+        .btn-toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+
+            @if $enable-input-group {
+                .input-group {
+                    width: auto;
+                }
             }
         }
     }
 }
 
-// Vertical button groups
-.btn-group-vertical {
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-
-    > .btn,
-    > .btn-group,
-    > .btn-group > .btn,
-    > .btn-check,
-    > .btn-check > .btn {
-        width: 100%;
-        max-width: 100%;
-    }
-
-    > .btn:not(:first-child),
-    > .btn-group:not(:first-child),
-    > .btn-check:not(:first-child) {
-        margin-top: -$btn-border-width;
-    }
-
-    // Reset rounded corners
-    > .btn:not(:last-child):not(.btn-group-end),
-    > .btn-group:not(:last-child) > .btn,
-    > .btn-check:not(:last-child) > .btn {
-        @include border-bottom-radius(0);
-    }
-
-    > .btn:not(:first-child),
-    > .btn-group:not(:first-child) > .btn,
-    > .btn-check:not(:first-child) > .btn {
-        @include border-top-radius(0);
-    }
-}

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -16,7 +16,7 @@
         > .btn {
             @extend %btn-group-btn-base;
 
-            // Bring checked and focus buttons up to overlay
+            // Bring active, hovered, and focused buttons up to overlay
             // Focus comes up higher for box-shadow focus ring
             &:hover,
             &:active,
@@ -34,7 +34,7 @@
                     @extend %btn-group-btn-base;
                 }
 
-                // Bring checked and focus buttons up to overlay
+                // Bring checked, hovered, and focused input buttons up to overlay
                 // Focus comes up higher for box-shadow focus ring
                 > .btn:hover,
                 > .btn-check-input:checked ~ .btn {

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -1,24 +1,22 @@
 @if $enable-card {
-    @if $enable-card-common {
-        .card {
-            position: relative;
-            display: flex;
-            flex-direction: column;
-            min-width: 0;
-            margin-bottom: $card-margin-bottom;
-            word-wrap: break-word;
-            background-color: $card-bg;
-            border: $card-border-width solid $card-border-color;
-            @include border-radius($card-border-radius);
+    .card {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        margin-bottom: $card-margin-bottom;
+        word-wrap: break-word;
+        background-color: $card-bg;
+        border: $card-border-width solid $card-border-color;
+        @include border-radius($card-border-radius);
 
-            > hr {
-                margin-right: 0;
-                margin-left: 0;
-            }
+        > hr {
+            margin-right: 0;
+            margin-left: 0;
         }
     }
 
-    @if $enable-card-common {
+    @if $enable-card-body {
         .card-body {
             // Enable `flex-grow: 1` for decks and groups so that card blocks take up
             // as much space as possible, ensuring footers are aligned to the bottom.
@@ -365,7 +363,7 @@
         @each $breakpoint in $card-deck-breakpoints {
             $bprule: breakpoint-designator($breakpoint);
 
-            @if ($enable-card-deck-common and $bprule == "") or ($enable-card-deck-responsive and $bprule != "") {
+            @if $bprule == "" or ($enable-card-deck-responsive and $bprule != "") {
                 .card-deck#{$bprule} {
                     @extend %card-deck-base;
 
@@ -400,7 +398,7 @@
 
                 @each $bp-inner in map-keys($grid-breakpoints) {
                     $bprule-inner: breakpoint-designator($bp-inner);
-                    @if ($enable-card-deck-common and $bprule-inner == "") or ($enable-card-deck-responsive and $bprule-inner != "") {
+                    @if $bprule-inner == "" or ($enable-card-deck-responsive and $bprule-inner != "") {
                         .card-deck#{$bprule-inner} {
                             @extend %card-deck-gutter;
                         }
@@ -423,7 +421,7 @@
         @each $breakpoint in $card-group-breakpoints {
             $bprule: breakpoint-designator($breakpoint);
 
-            @if ($enable-card-group-common and $bprule == "") or ($enable-card-group-responsive and $bprule != "") {
+            @if $bprule == "" or ($enable-card-group-responsive and $bprule != "") {
                 .card-group#{$bprule} {
                     @extend %card-group-base;
 
@@ -541,7 +539,7 @@
         @each $breakpoint in $card-columns-breakpoints {
             $bprule: breakpoint-designator($breakpoint);
 
-            @if ($enable-card-columns-common and $bprule == "") or ($enable-card-columns-responsive and $bprule != "") {
+            @if $bprule == "" or ($enable-card-columns-responsive and $bprule != "") {
                 @include media-breakpoint-up(#{$breakpoint}) {
                     .card-columns#{$bprule} {
                         margin-bottom: $card-margin-bottom;

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -1,378 +1,566 @@
-.card {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    margin-bottom: $card-margin-bottom;
-    word-wrap: break-word;
-    background-color: $card-bg;
-    border: $card-border-width solid $card-border-color;
-    @include border-radius($card-border-radius);
+@if $enable-card {
+    @if $enable-card-common {
+        .card {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+            margin-bottom: $card-margin-bottom;
+            word-wrap: break-word;
+            background-color: $card-bg;
+            border: $card-border-width solid $card-border-color;
+            @include border-radius($card-border-radius);
 
-    > hr {
-        margin-right: 0;
-        margin-left: 0;
+            > hr {
+                margin-right: 0;
+                margin-left: 0;
+            }
+        }
     }
-}
 
-.card-body {
-    // Enable `flex-grow: 1` for decks and groups so that card blocks take up
-    // as much space as possible, ensuring footers are aligned to the bottom.
-    flex: 1 1 auto;
-    // Set a min-height to keep IE in check with image stretching
-    min-height: 1px;
-    padding: $card-padding-y $card-padding-x;
-}
+    @if $enable-card-common {
+        .card-body {
+            // Enable `flex-grow: 1` for decks and groups so that card blocks take up
+            // as much space as possible, ensuring footers are aligned to the bottom.
+            flex: 1 1 auto;
+            // Set a min-height to keep IE in check with image stretching
+            min-height: 1px;
+            padding: $card-padding-y $card-padding-x;
+        }
+    }
 
-.card-title {
-    margin-bottom: $card-title-margin-bottom;
-}
+    @if $enable-card-title {
+        .card-title {
+            margin-bottom: $card-title-margin-bottom;
+        }
+    }
 
-.card-subtitle {
-    margin-top: $card-subtitle-margin-top;
-    margin-bottom: 0;
-}
+    @if $enable-card-subtitle {
+        .card-subtitle {
+            margin-top: $card-subtitle-margin-top;
+            margin-bottom: 0;
+        }
+    }
 
-.card-text:last-child {
-    margin-bottom: 0;
-}
+    @if $enable-card-text {
+        .card-text:last-child {
+            margin-bottom: 0;
+        }
+    }
 
-.card-link + .card-link {
-    margin-left: $card-link-margin-left;
-}
+    @if $enable-card-link {
+        .card-link + .card-link {
+            margin-left: $card-link-margin-left;
+        }
+    }
 
-.card-list {
-    &:first-child {
-        @include border-top-radius($card-inner-border-radius);
-
-        > .list-item:first-child {
-            @if $enable-rounded {
+    @if $enable-card-list {
+        .card-list {
+            &:first-child {
                 @include border-top-radius($card-inner-border-radius);
+
+                > .list-item:first-child {
+                    @if $enable-rounded {
+                        @include border-top-radius($card-inner-border-radius);
+                    }
+                }
             }
-        }
-    }
 
-    &:last-child {
-        margin-bottom: 0;
-        @include border-bottom-radius($card-inner-border-radius);
-
-        > .list-item:last-child {
-            @if $enable-rounded {
+            &:last-child {
+                margin-bottom: 0;
                 @include border-bottom-radius($card-inner-border-radius);
+
+                > .list-item:last-child {
+                    @if $enable-rounded {
+                        @include border-bottom-radius($card-inner-border-radius);
+                    }
+                }
             }
         }
     }
-}
 
-.card-table {
-    &:last-child {
-        margin-bottom: 0;
-    }
-}
-
-// Optional caps
-.card-header {
-    padding: $card-cap-padding-y $card-cap-padding-x;
-    margin-bottom: 0; // Removes the default margin-bottom of <hN>
-    background-color: $card-cap-bg;
-    border-bottom: $card-cap-border-width solid $card-cap-border-color;
-
-    &:first-child {
-        @include border-radius($card-inner-border-radius $card-inner-border-radius 0 0);
-    }
-}
-
-.card-footer {
-    padding: $card-cap-padding-y $card-cap-padding-x;
-    background-color: $card-cap-bg;
-    border-top: $card-cap-border-width solid $card-cap-border-color;
-
-    &:last-child {
-        @include border-radius(0 0 $card-inner-border-radius $card-inner-border-radius);
-    }
-}
-
-// Header navs
-.card-header-tabs {
-    margin-right: -($card-cap-padding-x / 2);
-    margin-bottom: -$card-cap-padding-y;
-    margin-left: -($card-cap-padding-x / 2);
-    border-bottom: 0;
-}
-.card-header-pills {
-    margin-right: -($card-cap-padding-x / 2);
-    margin-left: -($card-cap-padding-x / 2);
-}
-
-// Card image overlay
-.card-img-overlay {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    padding: $card-img-overlay-padding;
-}
-
-// Card images
-.card-img {
-    min-height: 1px;  // Stop stretch/white-space due to flexbox
-}
-.card-img-top {
-    @include border-top-radius($card-inner-border-radius);
-}
-.card-img-bottom {
-    @include border-bottom-radius($card-inner-border-radius);
-}
-
-// Horizontal Cards
-@each $breakpoint in $card-horizontal-breakpoints {
-    $bprule: breakpoint-designator($breakpoint);
-
-    @include media-breakpoint-up($breakpoint) {
-        .card-horizontal#{$bprule},
-        .card-horizontal#{$bprule}-reverse {
-            flex-flow: row wrap;
-
-            > .card-col {
-                display: flex;
-                flex-direction: column;
+    @if $enable-card-table {
+        .card-table {
+            &:last-child {
+                margin-bottom: 0;
             }
         }
+    }
 
-        .card-horizontal#{$bprule}-reverse {
-            flex-direction: row-reverse;
+    // Optional caps
+    @if $enable-card-header {
+        .card-header {
+            padding: $card-cap-padding-y $card-cap-padding-x;
+            margin-bottom: 0; // Removes the default margin-bottom of <hN>
+            background-color: $card-cap-bg;
+            border-bottom: $card-cap-border-width solid $card-cap-border-color;
+
+            &:first-child {
+                @include border-radius($card-inner-border-radius $card-inner-border-radius 0 0);
+            }
         }
     }
-}
 
+    @if $enable-card-footer {
+        .card-footer {
+            padding: $card-cap-padding-y $card-cap-padding-x;
+            background-color: $card-cap-bg;
+            border-top: $card-cap-border-width solid $card-cap-border-color;
 
-.card-col {
-    min-height: 1px; // Stop stretch/white-space due to flexbox w/ images in IE
-    padding-right: 0;
-    padding-left: 0;
-}
+            &:last-child {
+                @include border-radius(0 0 $card-inner-border-radius $card-inner-border-radius);
+            }
+        }
+    }
 
-@if $enable-rounded {
-    @each $breakpoint in $card-horizontal-breakpoints {
-        $bprule: breakpoint-designator($breakpoint);
-        $prev: breakpoint-prev($breakpoint, $grid-breakpoints);
+    // Header navs
+    @if $enable-card-header-tabs {
+        .card-header-tabs {
+            margin-right: -($card-cap-padding-x / 2);
+            margin-bottom: -$card-cap-padding-y;
+            margin-left: -($card-cap-padding-x / 2);
+            border-bottom: 0;
+        }
+    }
+    @if $enable-card-header-pills {
+        .card-header-pills {
+            margin-right: -($card-cap-padding-x / 2);
+            margin-left: -($card-cap-padding-x / 2);
+        }
+    }
 
-        // Skip smallest breakpoint
-        @if breakpoint-min($breakpoint, $grid-breakpoints) != null {
-            @include media-breakpoint-down($prev) {
+    // Card image overlay
+    @if $enable-card-img-overlay {
+        .card-img-overlay {
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            padding: $card-img-overlay-padding;
+        }
+    }
+
+    // Card images
+    @if $enable-card-img {
+        .card-img {
+            min-height: 1px;  // Stop stretch/white-space due to flexbox
+        }
+        .card-img-top {
+            @include border-top-radius($card-inner-border-radius);
+        }
+        .card-img-bottom {
+            @include border-bottom-radius($card-inner-border-radius);
+        }
+    }
+
+    // Horizontal Cards
+    @if $enable-card-horizontal {
+        @each $breakpoint in $card-horizontal-breakpoints {
+            $bprule: breakpoint-designator($breakpoint);
+
+            @include media-breakpoint-up($breakpoint) {
                 .card-horizontal#{$bprule},
                 .card-horizontal#{$bprule}-reverse {
-                    > .card-col:not(:first-child) {
-                        > .card-header,
-                        > .card-img > .card-img-top {
-                            @include border-top-radius(0);
-                        }
+                    flex-flow: row wrap;
+
+                    > .card-col {
+                        display: flex;
+                        flex-direction: column;
                     }
-                    > .card-col:not(:last-child) {
-                        > .card-footer,
-                        > .card-img > .card-img-bottom {
-                            @include border-bottom-radius(0);
-                        }
-                    }
+                }
+
+                .card-horizontal#{$bprule}-reverse {
+                    flex-direction: row-reverse;
                 }
             }
         }
 
-        @include media-breakpoint-up($breakpoint) {
-            .card-horizontal#{$bprule} {
-                > .card-col:not(:first-child) {
-                    > .card-header,
-                    > .card-img > .card-img-top {
-                        @include border-top-start-radius(0);
-                    }
-                    > .card-footer,
-                    > .card-img > .card-img-bottom {
-                        @include border-bottom-start-radius(0);
-                    }
-                }
-                > .card-col:not(:last-child) {
-                    > .card-header,
-                    > .card-img > .card-img-top {
-                        @include border-top-end-radius(0);
-                    }
-                    > .card-footer,
-                    > .card-img > .card-img-bottom {
-                        @include border-bottom-end-radius(0);
-                    }
-                }
-            }
+        .card-col {
+            min-height: 1px; // Stop stretch/white-space due to flexbox w/ images in IE
+            padding-right: 0;
+            padding-left: 0;
+        }
 
-            .card-horizontal#{$bprule}-reverse {
-                > .card-col:not(:first-child) {
-                    > .card-header,
-                    > .card-img > .card-img-top {
-                        @include border-top-end-radius(0);
-                    }
-                    > .card-footer,
-                    > .card-img > .card-img-bottom {
-                        @include border-bottom-end-radius(0);
+        @if $enable-rounded {
+            @each $breakpoint in $card-horizontal-breakpoints {
+                $bprule: breakpoint-designator($breakpoint);
+                $prev: breakpoint-prev($breakpoint, $grid-breakpoints);
+
+                // Skip smallest breakpoint
+                @if breakpoint-min($breakpoint, $grid-breakpoints) != null {
+                    @include media-breakpoint-down($prev) {
+                        .card-horizontal#{$bprule},
+                        .card-horizontal#{$bprule}-reverse {
+                            > .card-col:not(:first-child) {
+                                %card-hz-col-not-first-down#{$bprule} {
+                                    @include border-top-radius(0);
+                                }
+                                @if $enable-card-header {
+                                    > .card-header {
+                                        @extend %card-hz-col-not-first-down#{$bprule};
+                                    }
+                                }
+                                @if $enable-card-img {
+                                    > .card-img > .card-img-top {
+                                        @extend %card-hz-col-not-first-down#{$bprule};
+                                    }
+                                }
+                            }
+                            > .card-col:not(:last-child) {
+                                %card-hz-col-not-last-down#{$bprule} {
+                                    @include border-bottom-radius(0);
+                                }
+                                @if $enable-card-footer {
+                                    > .card-footer {
+                                        @extend %card-hz-col-not-last-down#{$bprule};
+                                    }
+                                }
+                                @if $enable-card-img {
+                                    > .card-img > .card-img-bottom {
+                                        @extend %card-hz-col-not-last-down#{$bprule};
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
-                > .card-col:not(:last-child) {
-                    > .card-header,
-                    > .card-img > .card-img-top {
-                        @include border-top-start-radius(0);
+
+                @include media-breakpoint-up($breakpoint) {
+                    .card-horizontal#{$bprule} {
+                        > .card-col:not(:first-child) {
+                            %card-hz-col-not-first-top-start-up#{$bprule} {
+                                @include border-top-start-radius(0);
+                            }
+                            @if $enable-card-header {
+                                > .card-header {
+                                    @extend %card-hz-col-not-first-top-start-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-top {
+                                    @extend %card-hz-col-not-first-top-start-up#{$bprule};
+                                }
+                            }
+
+                            %card-hz-col-not-first-bottom-start-up#{$bprule} {
+                                @include border-bottom-start-radius(0);
+                            }
+                            @if $enable-card-footer {
+                                > .card-footer {
+                                    @extend %card-hz-col-not-first-bottom-start-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-bottom {
+                                    @extend %card-hz-col-not-first-bottom-start-up#{$bprule};
+                                }
+                            }
+                        }
+                        > .card-col:not(:last-child) {
+                            %card-hz-col-not-last-top-end-up#{$bprule} {
+                                @include border-top-end-radius(0);
+                            }
+                            @if $enable-card-header {
+                                > .card-header {
+                                    @extend %card-hz-col-not-last-top-end-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-top {
+                                    @extend %card-hz-col-not-last-top-end-up#{$bprule};
+                                }
+                            }
+
+                            %card-hz-col-not-last-bottom-end-up#{$bprule} {
+                                @include border-bottom-end-radius(0);
+                            }
+                            @if $enable-card-footer {
+                                > .card-footer {
+                                    @extend %card-hz-col-not-last-bottom-end-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-bottom {
+                                    @extend %card-hz-col-not-last-bottom-end-up#{$bprule};
+                                }
+                            }
+                        }
                     }
-                    > .card-footer,
-                    > .card-img > .card-img-bottom {
-                        @include border-bottom-start-radius(0);
+
+                    .card-horizontal#{$bprule}-reverse {
+                        > .card-col:not(:first-child) {
+                            %card-hzrev-col-not-first-top-end-up#{$bprule} {
+                                @include border-top-end-radius(0);
+                            }
+                            @if $enable-card-header {
+                                > .card-header{
+                                    @extend %card-hzrev-col-not-first-top-end-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-top {
+                                    @extend %card-hzrev-col-not-first-top-end-up#{$bprule};
+                                }
+                            }
+
+                            %card-hzrev-col-not-first-bottom-end-up#{$bprule} {
+                                @include border-bottom-end-radius(0);
+                            }
+                            @if $enable-card-footer {
+                                > .card-footer {
+                                    @extend %card-hzrev-col-not-first-bottom-end-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-bottom {
+                                    @extend %card-hzrev-col-not-first-bottom-end-up#{$bprule};
+                                }
+                            }
+                        }
+                        > .card-col:not(:last-child) {
+                            %card-hzrev-col-not-last-top-start-up#{$bprule} {
+                                @include border-top-start-radius(0);
+                            }
+                            @if $enable-card-header {
+                                > .card-header {
+                                    @extend %card-hzrev-col-not-last-top-start-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-top {
+                                    @extend %card-hzrev-col-not-last-top-start-up#{$bprule};
+                                }
+                            }
+
+                            %card-hzrev-col-not-last-bottom-start-up#{$bprule} {
+                                @include border-bottom-start-radius(0);
+                            }
+                            @if $enable-card-footer {
+                                > .card-footer {
+                                    @extend %card-hzrev-col-not-last-bottom-start-up#{$bprule};
+                                }
+                            }
+                            @if $enable-card-img {
+                                > .card-img > .card-img-bottom {
+                                    @extend %card-hzrev-col-not-last-bottom-start-up#{$bprule};
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
     }
-}
 
-// Card deck
-// 1. Individual cards have margin-bottom by default.
-//    Replace with single margin on the deck.
-%card-deck-base {
-    display: flex;
-    flex-direction: column;
-}
-
-@each $breakpoint in $card-deck-breakpoints {
-    $bprule: breakpoint-designator($breakpoint);
-
-    .card-deck#{$bprule} {
-        @extend %card-deck-base;
-
-        @include media-breakpoint-up(#{$breakpoint}) {
-            flex-flow: row wrap;
-            margin-bottom: $card-margin-bottom; // 1
-
-            > .card {
-                // Flexbugs #4: https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
-                flex: 1 0 0%;
-                margin-bottom: 0; // 1
-            }
+    // Card deck
+    // 1. Individual cards have margin-bottom by default.
+    //    Replace with single margin on the deck.
+    @if $enable-card-deck {
+        %card-deck-base {
+            display: flex;
+            flex-direction: column;
         }
-    }
-}
 
-// Card deck gutters
-@each $breakpoint, $gutter in $card-deck-gutter-widths {
-    @include check-gutter-change($breakpoint, $card-deck-gutter-widths) {
-        @include media-breakpoint-up($breakpoint) {
-            %card-deck-gutter {
-                margin-right: -($gutter / 2);
-                margin-left: -($gutter / 2);
+        @each $breakpoint in $card-deck-breakpoints {
+            $bprule: breakpoint-designator($breakpoint);
 
-                > .card {
-                    margin-right: ($gutter / 2);
-                    margin-left: ($gutter / 2);
+            @if ($enable-card-deck-common and $bprule == "") or ($enable-card-deck-responsive and $bprule != "") {
+                .card-deck#{$bprule} {
+                    @extend %card-deck-base;
+
+                    @include media-breakpoint-up(#{$breakpoint}) {
+                        flex-flow: row wrap;
+                        margin-bottom: $card-margin-bottom; // 1
+
+                        > .card {
+                            // Flexbugs #4: https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
+                            flex: 1 0 0%;
+                            margin-bottom: 0; // 1
+                        }
+                    }
                 }
             }
         }
 
-        @each $bp-inner in map-keys($grid-breakpoints) {
-            $bprule-inner: breakpoint-designator($bp-inner);
-            .card-deck#{$bprule-inner} {
-                @extend %card-deck-gutter;
-            }
-        }
-    }
-}
+        // Card deck gutters
+        @each $breakpoint, $gutter in $card-deck-gutter-widths {
+            @include check-gutter-change($breakpoint, $card-deck-gutter-widths) {
+                @include media-breakpoint-up($breakpoint) {
+                    %card-deck-gutter {
+                        margin-right: -($gutter / 2);
+                        margin-left: -($gutter / 2);
 
-
-// Card group
-// 1. Individual cards have margin-bottom by default,
-//    Replace with single margin on the group.
-%card-group-base {
-    display: flex;
-    flex-direction: column;
-}
-
-@each $breakpoint in $card-group-breakpoints {
-    $bprule: breakpoint-designator($breakpoint);
-
-    .card-group#{$bprule} {
-        @extend %card-group-base;
-
-        @include media-breakpoint-up(#{$breakpoint}) {
-            flex-flow: row wrap;
-            margin-bottom: $card-margin-bottom; // 1
-
-            > .card {
-                // Flexbugs #4: https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
-                flex: 1 0 0%;
-                margin-bottom: 0; // 1
-
-                + .card {
-                    margin-left: 0;
-                    border-left: 0;
+                        > .card {
+                            margin-right: ($gutter / 2);
+                            margin-left: ($gutter / 2);
+                        }
+                    }
                 }
 
-                // Handle rounded corners
-                @if $enable-rounded {
-                    &:first-child:not(:only-child) {
-                        @include border-end-radius(0);
-
-                        .card-img-top,
-                        .card-header {
-                            @include border-top-end-radius(0);
-                        }
-                        .card-img-bottom,
-                        .card-footer {
-                            @include border-bottom-end-radius(0);
-                        }
-                    }
-                    &:last-child:not(:only-child) {
-                        @include border-start-radius(0);
-
-                        .card-img-top,
-                        .card-header {
-                            @include border-top-start-radius(0);
-                        }
-                        .card-img-bottom,
-                        .card-footer {
-                            @include border-bottom-start-radius(0);
-                        }
-                    }
-                    &:not(:first-child):not(:last-child):not(:only-child) {
-                        @include border-radius(0);
-
-                        .card-img-top,
-                        .card-img-bottom,
-                        .card-header,
-                        .card-footer {
-                            @include border-radius(0);
+                @each $bp-inner in map-keys($grid-breakpoints) {
+                    $bprule-inner: breakpoint-designator($bp-inner);
+                    @if ($enable-card-deck-common and $bprule-inner == "") or ($enable-card-deck-responsive and $bprule-inner != "") {
+                        .card-deck#{$bprule-inner} {
+                            @extend %card-deck-gutter;
                         }
                     }
                 }
             }
         }
     }
-}
 
 
-// Card columns
-@each $breakpoint in $card-columns-breakpoints {
-    $bprule: breakpoint-designator($breakpoint);
+    // Card group
+    // 1. Individual cards have margin-bottom by default,
+    //    Replace with single margin on the group.
+    @if $enable-card-group {
+        %card-group-base {
+            display: flex;
+            flex-direction: column;
+        }
 
-    @include media-breakpoint-up(#{$breakpoint}) {
-        .card-columns#{$bprule} {
-            margin-bottom: $card-margin-bottom;
-            column-count: $card-columns-count;
-            column-gap: $card-columns-column-gap;
-            orphans: 1;
-            widows: 1;
+        @each $breakpoint in $card-group-breakpoints {
+            $bprule: breakpoint-designator($breakpoint);
 
+            @if ($enable-card-group-common and $bprule == "") or ($enable-card-group-responsive and $bprule != "") {
+                .card-group#{$bprule} {
+                    @extend %card-group-base;
 
-            > .card {
-                margin-top: $card-margin-bottom;
-                margin-bottom: 0;
-                break-inside: avoid;
-                backface-visibility: hidden;
+                    @include media-breakpoint-up(#{$breakpoint}) {
+                        flex-flow: row wrap;
+                        margin-bottom: $card-margin-bottom; // 1
 
-                &:first-child {
-                    margin-top: 0;
+                        > .card {
+                            // Flexbugs #4: https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
+                            flex: 1 0 0%;
+                            margin-bottom: 0; // 1
+
+                            + .card {
+                                margin-left: 0;
+                                border-left: 0;
+                            }
+
+                            // Handle rounded corners
+                            @if $enable-rounded {
+                                &:first-child:not(:only-child) {
+                                    @include border-end-radius(0);
+
+                                    %card-group-first-top-end#{$bprule} {
+                                        @include border-top-end-radius(0);
+                                    }
+                                    @if $enable-card-header {
+                                        .card-header {
+                                            @extend %card-group-first-top-end#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-img {
+                                        .card-img-top {
+                                            @extend %card-group-first-top-end#{$bprule};
+                                        }
+                                    }
+
+                                    %card-group-first-bottom-end#{$bprule} {
+                                        @include border-bottom-end-radius(0);
+                                    }
+                                    @if $enable-card-footer {
+                                        .card-footer {
+                                            @extend %card-group-first-bottom-end#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-img {
+                                        .card-img-bottom {
+                                            @extend %card-group-first-bottom-end#{$bprule};
+                                        }
+                                    }
+                                }
+                                &:last-child:not(:only-child) {
+                                    @include border-start-radius(0);
+
+                                    %card-group-last-top-start#{$bprule} {
+                                        @include border-top-start-radius(0);
+                                    }
+                                    @if $enable-card-header {
+                                        .card-header {
+                                            @extend %card-group-last-top-start#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-img {
+                                        .card-img-top {
+                                            @extend %card-group-last-top-start#{$bprule};
+                                        }
+                                    }
+
+                                    %card-group-last-bottom-start#{$bprule} {
+                                        @include border-bottom-start-radius(0);
+                                    }
+                                    @if $enable-card-footer {
+                                        .card-footer {
+                                            @extend %card-group-last-bottom-start#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-img {
+                                        .card-img-bottom {
+                                            @extend %card-group-last-bottom-start#{$bprule};
+                                        }
+                                    }
+                                }
+                                &:not(:first-child):not(:last-child):not(:only-child) {
+                                    @include border-radius(0);
+
+                                    %card-group-middle#{$bprule} {
+                                        @include border-radius(0);
+                                    }
+                                    @if $enable-card-header {
+                                        .card-header {
+                                            @extend %card-group-middle#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-footer {
+                                        .card-footer {
+                                            @extend %card-group-middle#{$bprule};
+                                        }
+                                    }
+                                    @if $enable-card-img {
+                                        .card-img-top,
+                                        .card-img-bottom {
+                                            @extend %card-group-middle#{$bprule};
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Card columns
+    @if $enable-card-columns {
+        @each $breakpoint in $card-columns-breakpoints {
+            $bprule: breakpoint-designator($breakpoint);
+
+            @if ($enable-card-columns-common and $bprule == "") or ($enable-card-columns-responsive and $bprule != "") {
+                @include media-breakpoint-up(#{$breakpoint}) {
+                    .card-columns#{$bprule} {
+                        margin-bottom: $card-margin-bottom;
+                        column-count: $card-columns-count;
+                        column-gap: $card-columns-column-gap;
+                        orphans: 1;
+                        widows: 1;
+
+                        > .card {
+                            margin-top: $card-margin-bottom;
+                            margin-bottom: 0;
+                            break-inside: avoid;
+                            backface-visibility: hidden;
+
+                            &:first-child {
+                                margin-top: 0;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -1,162 +1,186 @@
 // stylelint-disable selector-no-qualifying-type
-
-// Base styles
-.input-group {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap; // For form validation feedback
-    align-items: stretch;
-    width: 100%;
-
-    > .form-control,
-    > .custom-select,
-    > .custom-file {
-        position: relative;  // Needed for z-index on focus/active state
-        flex: 1 1 auto;
-        // Add width 1% and flex-basis auto to ensure that button will not wrap out
-        // the column. Applies to IE Edge+ and Firefox. Chrome does not require this.
-        width: 1%;
-        margin-bottom: 0;
-        margin-left: -$input-border-width;
-
-        &:first-child {
-            margin-left: 0;
-        }
-
-        + .form-control,
-        + .custom-select,
-        + .custom-file {
-            margin-left: -$input-border-width;
-        }
-    }
-
-    // Bring the "active" form control to the top of surrounding elements
-    > .form-control:focus,
-    > .custom-select:focus,
-    > .custom-file .custom-file-input:focus ~ .custom-file-label {
-        z-index: 3;
-    }
-
-    > .form-control,
-    > .custom-select {
-        &:not(:first-child) { @include border-start-radius(0); }
-        &:not(:last-child):not(.input-group-end) { @include border-end-radius(0); }
-    }
-
-    // Custom file inputs have more complex markup,
-    // needing special overrides.
-    > .custom-file {
-        display: flex;
-        align-items: center;
-
-        &:not(:last-child) .custom-file-label,
-        &:not(:last-child) .custom-file-label::after { @include border-end-radius(0); }
-        &:not(:first-child) .custom-file-label { @include border-start-radius(0); }
-    }
-}
-
-// Addon
-// While it requires one extra layer of HTML for each, dedicated addon element allows for:
-// 1) be less clever
-// 2) simplify our selectors
-// 3) support HTML5 form validation
-.input-group-addon {
-    display: flex;
-    margin-left: -$input-border-width;
-
-    &:first-child {
-        margin-left: 0;
-    }
-
-    // Ensure buttons are always above inputs for more visually pleasing borders.
-    // This isn't needed for `.input-group-text` since it shares the same border-color
-    // as our inputs.
-    .btn {
+@if $enable-input-group {
+    // Base styles
+    .input-group {
         position: relative;
-        z-index: 2;
+        display: flex;
+        flex-wrap: wrap; // For form validation feedback
+        align-items: stretch;
+        width: 100%;
 
-        &:hover,
-        &:focus {
+        > .form-control,
+        > .custom-select,
+        > .custom-file {
+            position: relative;  // Needed for z-index on focus/active state
+            flex: 1 1 auto;
+            // Add width 1% and flex-basis auto to ensure that button will not wrap out
+            // the column. Applies to IE Edge+ and Firefox. Chrome does not require this.
+            width: 1%;
+            margin-bottom: 0;
+            margin-left: -$input-border-width;
+
+            &:first-child {
+                margin-left: 0;
+            }
+
+            + .form-control,
+            + .custom-select,
+            + .custom-file {
+                margin-left: -$input-border-width;
+            }
+        }
+
+        // Bring the "active" form control to the top of surrounding elements
+        > .form-control:focus,
+        > .custom-select:focus,
+        > .custom-file .custom-file-input:focus ~ .custom-file-label {
             z-index: 3;
         }
-    }
 
-    .btn + .btn,
-    .btn + .input-group-text,
-    .input-group-text + .input-group-text,
-    .input-group-text + .btn {
-        margin-left: -$input-border-width;
-    }
-}
-
-// Textual addon item
-// Catch-all element for any text or radio/checkbox input you wish
-// to addon to an input.
-.input-group-text {
-    display: flex;
-    align-items: center;
-    padding: $input-padding-y $input-padding-x;
-    margin-bottom: 0; // Allow use of <label> elements by overriding our default margin-bottom
-    @include font-size($font-size-base); // Match inputs
-    font-weight: $font-weight-normal;
-    line-height: $input-line-height;
-    color: $input-group-addon-color;
-    text-align: center;
-    white-space: nowrap;
-    background-color: $input-group-addon-bg;
-    border: $input-border-width solid $input-group-addon-border-color;
-    @include border-radius($input-border-radius);
-
-    // Nuke default margins from checkboxes and radios to vertically center within.
-    input[type="radio"],
-    input[type="checkbox"] {
-        margin-top: 0;
-    }
-}
-
-// Sizing options
-// Remix the default form control sizing classes into new ones for easier manipulation.
-@if $enable-sizing {
-    @each $size, $dims in $input-sizes {
-        $sz-padding-x:     map-get($dims, "padding-x");
-
-        .input-group-#{$size} > .form-control,
-        .input-group-#{$size} > .custom-select,
-        .input-group-#{$size} > .input-group-addon > .input-group-text {
-            @extend %form-control-#{$size};
+        > .form-control,
+        > .custom-select {
+            &:not(:first-child) { @include border-start-radius(0); }
+            &:not(:last-child):not(.input-group-end) { @include border-end-radius(0); }
         }
 
-        .input-group-#{$size} > .input-group-addon > .btn,
-        .input-group-#{$size} > .input-group-addon > .btn-check > .btn {
-            @extend %btn-#{$size};
-        }
+        // Custom file inputs have more complex markup,
+        // needing special overrides.
+        @if $enable-custom-file {
+            > .custom-file {
+                display: flex;
+                align-items: center;
 
-        @if $enable-btn-icon {
-            .input-group-#{$size} > .input-group-addon > .btn-icon {
-                @extend %btn-icon-#{$size};
+                &:not(:last-child) .custom-file-label,
+                &:not(:last-child) .custom-file-label::after { @include border-end-radius(0); }
+                &:not(:first-child) .custom-file-label { @include border-start-radius(0); }
             }
         }
     }
-}
+
+    // Addon
+    // While it requires one extra layer of HTML for each, dedicated addon element allows for:
+    // 1) be less clever
+    // 2) simplify our selectors
+    // 3) support HTML5 form validation
+    @if $enable-input-group-addon {
+        .input-group-addon {
+            display: flex;
+            margin-left: -$input-border-width;
+
+            &:first-child {
+                margin-left: 0;
+            }
+
+            // Ensure buttons are always above inputs for more visually pleasing borders.
+            // This isn't needed for `.input-group-text` since it shares the same border-color
+            // as our inputs.
+            @if $enable-btn {
+                .btn {
+                    position: relative;
+                    z-index: 2;
+
+                    &:hover,
+                    &:focus {
+                        z-index: 3;
+                    }
+                }
+                @if $enable-btn-check {
+                    .btn-check-input:focus ~ .btn {
+                        z-index: 3;
+                    }
+                }
+
+                .btn + .btn,
+                .btn + .input-group-text,
+                .input-group-text + .btn {
+                    margin-left: -$input-border-width;
+                }
+            }
+        }
+    }
+
+    // Textual addon item
+    // Catch-all element for any text or radio/checkbox input you wish
+    // to addon to an input.
+    @if $enable-input-group-text {
+        .input-group-text {
+            display: flex;
+            align-items: center;
+            padding: $input-padding-y $input-padding-x;
+            margin-bottom: 0; // Allow use of <label> elements by overriding our default margin-bottom
+            @include font-size($font-size-base); // Match inputs
+            font-weight: $font-weight-normal;
+            line-height: $input-line-height;
+            color: $input-group-addon-color;
+            text-align: center;
+            white-space: nowrap;
+            background-color: $input-group-addon-bg;
+            border: $input-border-width solid $input-group-addon-border-color;
+            @include border-radius($input-border-radius);
+
+            & + .input-group-text {
+                margin-left: -$input-border-width;
+            }
+
+            // Nuke default margins from checkboxes and radios to vertically center within.
+            input[type="radio"],
+            input[type="checkbox"] {
+                margin-top: 0;
+            }
+        }
+    }
+
+    // Sizing options
+    // Remix the default form control sizing classes into new ones for easier manipulation.
+    @if $enable-sizing  and $enable-input-group-sizing {
+        @each $size, $dims in $input-sizes {
+            $sz-padding-x:     map-get($dims, "padding-x");
+
+            .input-group-#{$size} > .form-control,
+            .input-group-#{$size} > .custom-select,
+            .input-group-#{$size} > .input-group-addon > .input-group-text {
+                @extend %form-control-#{$size};
+            }
+
+            @if $enable-btn {
+                .input-group-#{$size} > .input-group-addon > .btn {
+                    @extend %btn-#{$size};
+
+                    @if $enable-btn-check {
+                        .input-group-#{$size} > .input-group-addon > .btn-check > .btn {
+                            @extend %btn-#{$size};
+                        }
+                    }
+                    @if $enable-btn-icon {
+                        .input-group-#{$size} > .input-group-addon > .btn-icon {
+                            @extend %btn-icon-#{$size};
+                        }
+                    }
+                }
+            }
+        }
+    }
 
 
-// Reset rounded corners
-// These rulesets must come after the sizing ones to properly override sizing
-// border-radius values when extending. They're more specific than we'd like
-// with the `.input-group >` part, but without it, we cannot override the sizing.
+    // Reset rounded corners
+    // These rulesets must come after the sizing ones to properly override sizing
+    // border-radius values when extending. They're more specific than we'd like
+    // with the `.input-group >` part, but without it, we cannot override the sizing.
+    @if $enable-input-group-addon {
+        .input-group > .input-group-addon:not(:last-child) > .btn:not(.input-group-end),
+        .input-group > .input-group-addon:not(:last-child) > .input-group-text:not(.input-group-end),
+        .input-group > .input-group-addon:not(:last-child) > .btn-check:not(.input-group-end) > .btn,
+        .input-group > .input-group-addon:last-child > .btn:not(:last-child):not(.input-group-end),
+        .input-group > .input-group-addon:last-child > .input-group-text:not(:last-child) {
+            @include border-end-radius(0);
+        }
 
-.input-group > .input-group-addon:not(:last-child) > .btn:not(.input-group-end),
-.input-group > .input-group-addon:not(:last-child) > .input-group-text:not(.input-group-end),
-.input-group > .input-group-addon:not(:last-child) > .btn-check:not(.input-group-end) > .btn,
-.input-group > .input-group-addon:last-child > .btn:not(:last-child):not(.input-group-end),
-.input-group > .input-group-addon:last-child > .input-group-text:not(:last-child) {
-    @include border-end-radius(0);
-}
-
-.input-group > .input-group-addon:not(:first-child) > .btn,
-.input-group > .input-group-addon:not(:first-child) > .input-group-text,
-.input-group > .input-group-addon:not(:first-child) > .btn-check > .btn,
-.input-group > .input-group-addon:first-child > .btn:not(:first-child),
-.input-group > .input-group-addon:first-child > .input-group-text:not(:first-child) {
-    @include border-start-radius(0);
+        .input-group > .input-group-addon:not(:first-child) > .btn,
+        .input-group > .input-group-addon:not(:first-child) > .input-group-text,
+        .input-group > .input-group-addon:not(:first-child) > .btn-check > .btn,
+        .input-group > .input-group-addon:first-child > .btn:not(:first-child),
+        .input-group > .input-group-addon:first-child > .input-group-text:not(:first-child) {
+            @include border-start-radius(0);
+        }
+    }
 }

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -145,16 +145,16 @@
             @if $enable-btn {
                 .input-group-#{$size} > .input-group-addon > .btn {
                     @extend %btn-#{$size};
+                }
 
-                    @if $enable-btn-check {
-                        .input-group-#{$size} > .input-group-addon > .btn-check > .btn {
-                            @extend %btn-#{$size};
-                        }
+                @if $enable-btn-check {
+                    .input-group-#{$size} > .input-group-addon > .btn-check > .btn {
+                        @extend %btn-#{$size};
                     }
-                    @if $enable-btn-icon {
-                        .input-group-#{$size} > .input-group-addon > .btn-icon {
-                            @extend %btn-icon-#{$size};
-                        }
+                }
+                @if $enable-btn-icon {
+                    .input-group-#{$size} > .input-group-addon > .btn-icon {
+                        @extend %btn-icon-#{$size};
                     }
                 }
             }

--- a/scss/component/_jumbotron.scss
+++ b/scss/component/_jumbotron.scss
@@ -1,16 +1,20 @@
-.jumbotron {
-    padding: $jumbotron-padding-xs-y $jumbotron-padding-xs-x;
-    margin-bottom: $jumbotron-padding-y;
-    background-color: $jumbotron-bg;
-    @include border-radius($jumbotron-border-radius);
+@if $enable-jumbotron {
+    .jumbotron {
+        padding: $jumbotron-padding-xs-y $jumbotron-padding-xs-x;
+        margin-bottom: $jumbotron-padding-y;
+        background-color: $jumbotron-bg;
+        @include border-radius($jumbotron-border-radius);
 
-    @include media-breakpoint-up(#{$jumbotron-breakpoint}) {
-        padding: $jumbotron-padding-y $jumbotron-padding-x;
+        @include media-breakpoint-up(#{$jumbotron-breakpoint}) {
+            padding: $jumbotron-padding-y $jumbotron-padding-x;
+        }
     }
-}
 
-.jumbotron-full {
-    padding-right: 0;
-    padding-left: 0;
-    @include border-radius(0);
+    @if $enable-jumbotron-fluid {
+        .jumbotron-fluid {
+            padding-right: 0;
+            padding-left: 0;
+            @include border-radius(0);
+        }
+    }
 }

--- a/scss/component/_list.scss
+++ b/scss/component/_list.scss
@@ -1,316 +1,391 @@
 // List and list items
 // Use on <ul>, <ol>, or <div>.
 // Basic layout becomes an unstyled list.
-.list {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    margin-bottom: $list-margin-bottom;
-    @include list-unstyled;
-
+@if $enable-list {
     .list {
-        padding: 0;
-        margin-bottom: 0;
-        margin-left: $list-margin-left;
-    }
-}
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        margin-bottom: $list-margin-bottom;
+        @include list-unstyled;
 
-// Space out nested bullet and ordered lists
-.list:not(.list-bulleted):not(.list-ordered) {
-    > .list-item {
-        > .list-bulleted,
-        > .list-ordered {
-            margin-left: $list-margin-left * 2;
+        .list {
+            padding: 0;
+            margin-bottom: 0;
+            margin-left: $list-margin-left;
         }
     }
-}
 
-// Bulleted list
-.list-bulleted {
-    margin-left: $list-margin-left;
+    // Space out nested bullet and ordered lists
+    .list:not(.list-bulleted):not(.list-ordered) {
+        > .list-item {
+            %list-indent {
+                margin-left: $list-margin-left * 2;
+            }
+            @if $enable-list-bulleted {
+                > .list-bulleted {
+                    @extend %list-indent;
+                }
+            }
+            @if $enable-list-ordered {
+                > .list-ordered {
+                    @extend %list-indent;
+                }
+            }
+        }
+    }
 
-    > .list-item {
-        list-style: none;
+    // Bulleted list
+    @if $enable-list-bulleted {
+        .list-bulleted {
+            margin-left: $list-margin-left;
+
+            > .list-item {
+                list-style: none;
+
+                &::before {
+                    position: absolute;
+                    margin-left: -$list-margin-left;
+                    content: $list-bulleted-content;
+                }
+            }
+        }
+    }
+
+    // Ordered list
+    @if $enable-list-ordered {
+        .list-ordered {
+            margin-left: $list-margin-left;
+            counter-reset: ordered;
+
+            > .list-item {
+                &::before {
+                    position: absolute;
+                    margin-left: -$list-margin-left;
+                    //content: counters(ordered, ".") " ";
+                    content: counter(ordered) "#{$list-ordered-delimeter}";
+                    counter-increment: ordered;
+                }
+            }
+        }
+    }
+
+    // Lists with borders
+    %list-bordered {
+        border-color: $list-border-color;
+
+        > .list-item {
+            margin-top: -$list-border-width;
+            border-top-color: inherit;
+            border-top-width: $list-border-width;
+            border-bottom-color: inherit;
+            border-bottom-width: $list-border-width;
+
+            &:first-child {
+                margin-top: 0;
+            }
+        }
+    }
+    @if $enable-list-divided {
+        .list-divided {
+            @extend %list-bordered;
+        }
+    }
+    @if $enable-list-ruled {
+        .list-ruled {
+            @extend %list-bordered;
+        }
+    }
+    @if $enable-list-group {
+        .list-group {
+            @extend %list-bordered;
+        }
+    }
+
+    // Remove top and bottom borders for divided
+    @if $enable-list-divided {
+        .list-divided {
+            > .list-item {
+                &:first-child {
+                    border-top: 0;
+                }
+
+                &:last-child {
+                    border-bottom: 0;
+                }
+            }
+        }
+    }
+
+    // Group a list with borders all around, and a radius on the
+    // first and last children.
+    @if $enable-list-group {
+        .list-group {
+            > .list-item {
+                border-right-color: inherit;
+                border-right-width: $list-border-width;
+                border-left-color: inherit;
+                border-left-width: $list-border-width;
+
+                &:first-child {
+                    @include border-top-radius($list-group-border-radius);
+                }
+                &:last-child {
+                    @include border-bottom-radius($list-group-border-radius);
+                }
+            }
+        }
+    }
+
+    // Add some padding to lists.
+    @if $enable-list-spaced {
+        .list-spaced {
+            > .list-item {
+                padding: $list-spaced-item-padding-y $list-spaced-item-padding-x;
+            }
+        }
+    }
+
+    @if $enable-list-spaced-y {
+        .list-spaced-y {
+            > .list-item {
+                padding-top: $list-spaced-item-padding-y;
+                padding-bottom: $list-spaced-item-padding-y;
+            }
+        }
+    }
+
+    @if $enable-list-spaced-x {
+        .list-spaced-x {
+            > .list-item {
+                padding-right: $list-spaced-item-padding-x;
+                padding-left: $list-spaced-item-padding-x;
+            }
+        }
+    }
+
+    // Horizontal layout variants.
+    @if $enable-list-horizontal {
+        .list-horizontal {
+            flex-direction: row;
+            padding-left: 0;
+
+            > .list-item {
+                &:not(:last-child) {
+                    margin-right: $list-horizontal-padding;
+                }
+            }
+
+            &%list-hz-bull-and-ord {
+                margin-left: 0;
+
+                > .list-item {
+                    &::before {
+                        position: static;
+                        margin-left: 0;
+                    }
+                }
+            }
+
+            @if $enable-list-bulleted {
+                &.list-bulleted {
+                    @extend %list-hz-bull-and-ord;
+                }
+            }
+            @if $enable-list-ordered {
+                &.list-ordered {
+                    @extend %list-hz-bull-and-ord;
+                }
+            }
+
+            @if $enable-list-bulleted {
+                &.list-bulleted {
+                    > .list-item {
+                        &:first-child::before {
+                            content: none;
+                        }
+                    }
+                }
+            }
+
+            &%list-hz-div-and-rul {
+                > .list-item {
+                    padding-right: $list-horizontal-padding;
+                    padding-left: $list-horizontal-padding;
+                    margin: 0 0 0 -#{$list-border-width};
+                    border-top: 0;
+                    border-right-color: inherit;
+                    border-right-width: $list-border-width;
+                    border-bottom: 0;
+                    border-left-color: inherit;
+                    border-left-width: $list-border-width;
+
+                    &:first-child {
+                        margin-left: 0;
+                    }
+                }
+            }
+            @if $enable-list-divided {
+                &.list-divided {
+                    @extend %list-hz-div-and-rul;
+                }
+            }
+            @if $enable-list-ruled {
+                &.list-ruled {
+                    @extend %list-hz-div-and-rul;
+                }
+            }
+
+            @if $enable-list-divided {
+                &.list-divided {
+                    > .list-item {
+                        &:first-child {
+                            padding-left: 0;
+                            border-left: 0;
+                        }
+
+                        &:last-child {
+                            padding-right: 0;
+                            border-right: 0;
+                        }
+                    }
+                }
+            }
+
+            @if $enable-list-group {
+                &.list-group {
+                    > .list-item {
+                        padding-right: $list-horizontal-padding;
+                        padding-left: $list-horizontal-padding;
+                        margin: 0 0 0 -#{$list-border-width};
+
+                        &:first-child {
+                            margin-left: 0;
+                            @include border-top-end-radius(0);
+                            @include border-start-radius($list-group-border-radius);
+                        }
+
+                        &:last-child {
+                            @include border-bottom-start-radius(0);
+                            @include border-end-radius($list-group-border-radius);
+                        }
+                    }
+                }
+            }
+
+            // Spacing again due to specificity.
+            @if $enable-list-spaced {
+                &.list-spaced {
+                    > .list-item {
+                        padding: $list-spaced-item-padding-y $list-spaced-item-padding-x;
+                    }
+                }
+            }
+
+            @if $enable-list-spaced-y {
+                &.list-spaced-y {
+                    > .list-item {
+                        padding-top: $list-spaced-item-padding-y;
+                        padding-bottom: $list-spaced-item-padding-y;
+                    }
+                }
+            }
+
+            @if $enable-list-spaced-x {
+                &.list-spaced-x {
+                    > .list-item {
+                        padding-right: $list-spaced-item-padding-x;
+                        padding-left: $list-spaced-item-padding-x;
+                    }
+                }
+            }
+        }
+    }
+
+    // Interactive list items
+    // Use anchor or button elements instead of `<li>`s or `<div>`s to create
+    // interactive list items.
+    // stylelint-disable selector-no-qualifying-type
+    @if $enable-list-item-action {
+        button.list-item-action {
+            cursor: pointer;
+        }
+        // stylelint-enable selector-no-qualifying-type
+        .list-item-action {
+            width: 100%; // For `<button>`s (anchors become 100% by default though)
+            padding: 0; // Reset `<button>` padding
+            color: $list-item-action-color;
+            text-align: inherit; // For `<button>`s (anchors inherit)
+            text-decoration: none;
+
+            // Hover state
+            @include hover-focus {
+                z-index: 2;
+                color: $list-item-action-hover-color;
+                text-decoration: none;
+                background-color: $list-item-action-hover-bg;
+            }
+
+            &.disabled,
+            &:disabled {
+                cursor: default;
+            }
+        }
+    }
+
+    // Individual list items
+    // Use on `<li>`s or `<div>`s within the `.list` parent.
+    .list-item {
+        position: relative;
+        display: block;
+        // Override `<button>` background and border.
+        background-color: $list-item-bg;
+        border: 0 solid;
+        //border-color: inherit;
 
         &::before {
-            position: absolute;
-            margin-left: -$list-margin-left;
-            content: $list-bulleted-content;
-        }
-    }
-}
-
-// Ordered list
-.list-ordered {
-    margin-left: $list-margin-left;
-    counter-reset: ordered;
-
-    > .list-item {
-        &::before {
-            position: absolute;
-            margin-left: -$list-margin-left;
-            //content: counters(ordered, ".") " ";
-            content: counter(ordered) "#{$list-ordered-delimeter}";
-            counter-increment: ordered;
-        }
-    }
-}
-
-// Lists with borders
-.list-divided,
-.list-ruled,
-.list-group {
-    border-color: $list-border-color;
-
-    > .list-item {
-        margin-top: -$list-border-width;
-        border-top-color: inherit;
-        border-top-width: $list-border-width;
-        border-bottom-color: inherit;
-        border-bottom-width: $list-border-width;
-
-        &:first-child {
-            margin-top: 0;
-        }
-    }
-}
-
-// Remove top and bottom borders
-.list-divided {
-    > .list-item {
-        &:first-child {
-            border-top: 0;
+            content: none;
         }
 
-        &:last-child {
-            border-bottom: 0;
+        &.disabled,
+        &:disabled {
+            color: $list-item-disabled-color;
+            text-decoration: none;
+            background-color: $list-item-disabled-bg;
         }
-    }
-}
 
-// Group a list with borders all around, and a radius on the
-// first and last children.
-.list-group {
-    > .list-item {
-        border-right-color: inherit;
-        border-right-width: $list-border-width;
-        border-left-color: inherit;
-        border-left-width: $list-border-width;
-
-        &:first-child {
-            @include border-top-radius($list-group-border-radius);
-        }
-        &:last-child {
-            @include border-bottom-radius($list-group-border-radius);
-        }
-    }
-}
-
-// Add some padding to lists.
-.list-spaced {
-    > .list-item {
-        padding: $list-spaced-item-padding-y $list-spaced-item-padding-x;
-    }
-}
-
-.list-spaced-y {
-    > .list-item {
-        padding-top: $list-spaced-item-padding-y;
-        padding-bottom: $list-spaced-item-padding-y;
-    }
-}
-
-.list-spaced-x {
-    > .list-item {
-        padding-right: $list-spaced-item-padding-x;
-        padding-left: $list-spaced-item-padding-x;
-    }
-}
-
-// Horizontal layout variants.
-.list-horizontal {
-    flex-direction: row;
-    padding-left: 0;
-
-    > .list-item {
-        &:not(:last-child) {
-            margin-right: $list-horizontal-padding;
+        &.active {
+            z-index: 1;
+            color: $list-item-active-color;
+            background-color: $list-item-active-bg;
+            border-color: $list-item-active-border;
         }
     }
 
-    &.list-bulleted,
-    &.list-ordered {
-        margin-left: 0;
+    // Theme generation
+    @if $enable-list-item-colors {
+        @if (type-of($list-colors) == "map" and length($list-colors) != 0) {
+            $mixed-list-themes: _mix-context-colors($list-colors, $list-levels);
+            $list-themes: map-merge($mixed-list-themes, $list-themes);
+        }
 
-        > .list-item {
-            &::before {
-                position: static;
-                margin-left: 0;
+        // Contextual variants
+        // Add modifier classes to change text and background color on individual items.
+        // Organizationally, this must come after the `:hover` states.
+        @if (type-of($list-themes) == "map" and length($list-themes) != 0) {
+            @each $theme, $colors in $list-themes {
+                $bg:           map-get($colors, "bg");
+                $color:        map-get($colors, "color");
+                $border:       map-get($colors, "border-color");
+                $hover-bg:     map-get($colors, "hover-bg");
+                $hover-color:  map-get($colors, "hover-color");
+                $hover-border: map-get($colors, "hover-border-color");
+
+                $color:       color-if-contrast($color, $bg);
+                $hover-color: color-if-contrast($hover-color, $hover-bg);
+
+                @include list-item-variant(#{$theme}, $bg, $color, $border, $hover-bg, $hover-color, $hover-border);
             }
         }
-    }
-
-    &.list-bulleted {
-        > .list-item {
-            &:first-child::before {
-                content: none;
-            }
-        }
-    }
-
-    &.list-divided,
-    &.list-ruled {
-        > .list-item {
-            padding-right: $list-horizontal-padding;
-            padding-left: $list-horizontal-padding;
-            margin: 0 0 0 -#{$list-border-width};
-            border-top: 0;
-            border-right-color: inherit;
-            border-right-width: $list-border-width;
-            border-bottom: 0;
-            border-left-color: inherit;
-            border-left-width: $list-border-width;
-
-            &:first-child {
-                margin-left: 0;
-            }
-        }
-    }
-
-    &.list-divided {
-        > .list-item {
-            &:first-child {
-                padding-left: 0;
-                border-left: 0;
-            }
-
-            &:last-child {
-                padding-right: 0;
-                border-right: 0;
-            }
-        }
-    }
-
-    &.list-group {
-        > .list-item {
-            padding-right: $list-horizontal-padding;
-            padding-left: $list-horizontal-padding;
-            margin: 0 0 0 -#{$list-border-width};
-
-            &:first-child {
-                margin-left: 0;
-                @include border-top-end-radius(0);
-                @include border-start-radius($list-group-border-radius);
-            }
-
-            &:last-child {
-                @include border-bottom-start-radius(0);
-                @include border-end-radius($list-group-border-radius);
-            }
-        }
-    }
-
-    // Spacing again due to specificity.
-    &.list-spaced {
-        > .list-item {
-            padding: $list-spaced-item-padding-y $list-spaced-item-padding-x;
-        }
-    }
-
-    &.list-spaced-y {
-        > .list-item {
-            padding-top: $list-spaced-item-padding-y;
-            padding-bottom: $list-spaced-item-padding-y;
-        }
-    }
-
-    &.list-spaced-x {
-        > .list-item {
-            padding-right: $list-spaced-item-padding-x;
-            padding-left: $list-spaced-item-padding-x;
-        }
-    }
-}
-
-// Interactive list items
-// Use anchor or button elements instead of `<li>`s or `<div>`s to create
-// interactive list items.
-// stylelint-disable selector-no-qualifying-type
-button.list-item-action {
-    cursor: pointer;
-}
-// stylelint-enable selector-no-qualifying-type
-.list-item-action {
-    width: 100%; // For `<button>`s (anchors become 100% by default though)
-    padding: 0; // Reset `<button>` padding
-    color: $list-item-action-color;
-    text-align: inherit; // For `<button>`s (anchors inherit)
-    text-decoration: none;
-
-    // Hover state
-    @include hover-focus {
-        z-index: 2;
-        color: $list-item-action-hover-color;
-        text-decoration: none;
-        background-color: $list-item-action-hover-bg;
-    }
-
-    &.disabled,
-    &:disabled {
-        cursor: default;
-    }
-}
-
-// Individual list items
-// Use on `<li>`s or `<div>`s within the `.list` parent.
-.list-item {
-    position: relative;
-    display: block;
-    // Override `<button>` background and border.
-    background-color: $list-item-bg;
-    border: 0 solid;
-    //border-color: inherit;
-
-    &::before {
-        content: none;
-    }
-
-    &.disabled,
-    &:disabled {
-        color: $list-item-disabled-color;
-        text-decoration: none;
-        background-color: $list-item-disabled-bg;
-    }
-
-    &.active {
-        z-index: 1;
-        color: $list-item-active-color;
-        background-color: $list-item-active-bg;
-        border-color: $list-item-active-border;
-    }
-}
-
-// Theme generation
-@if (type-of($list-colors) == "map" and length($list-colors) != 0) {
-    $mixed-list-themes: _mix-context-colors($list-colors, $list-levels);
-    $list-themes: map-merge($mixed-list-themes, $list-themes);
-}
-
-// Contextual variants
-// Add modifier classes to change text and background color on individual items.
-// Organizationally, this must come after the `:hover` states.
-@if (type-of($list-themes) == "map" and length($list-themes) != 0) {
-    @each $theme, $colors in $list-themes {
-        $bg:           map-get($colors, "bg");
-        $color:        map-get($colors, "color");
-        $border:       map-get($colors, "border-color");
-        $hover-bg:     map-get($colors, "hover-bg");
-        $hover-color:  map-get($colors, "hover-color");
-        $hover-border: map-get($colors, "hover-border-color");
-
-        $color:       color-if-contrast($color, $bg);
-        $hover-color: color-if-contrast($hover-color, $hover-bg);
-
-        @include list-item-variant(#{$theme}, $bg, $color, $border, $hover-bg, $hover-color, $hover-border);
     }
 }

--- a/scss/component/_media.scss
+++ b/scss/component/_media.scss
@@ -1,18 +1,20 @@
-.media {
-    display: flex;
-    align-items: flex-start;
-    margin-bottom: $media-margin-y;
-
-    // Nested media
+@if $enable-media {
     .media {
-        margin-top: $media-margin-y;
+        display: flex;
+        align-items: flex-start;
+        margin-bottom: $media-margin-y;
 
-        &:last-child {
-            margin-bottom: 0;
+        // Nested media
+        .media {
+            margin-top: $media-margin-y;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
         }
     }
-}
 
-.media-body {
-    flex: 1;
+    .media-body {
+        flex: 1;
+    }
 }

--- a/scss/component/_nav.scss
+++ b/scss/component/_nav.scss
@@ -1,129 +1,144 @@
 // Base class
 // Kickstart any navigation component with a set of style resets. Works with
 // `<nav>`s or `<ul>`s.
-
-.nav {
-    display: flex;
-    flex-wrap: wrap;
-    padding-left: 0;
-    margin-bottom: 0;
-    list-style: none;
-}
-
-.nav-link {
-    display: block;
-    padding: $nav-link-padding-y $nav-link-padding-x;
-
-    // Disabled state lightens text and removes hover/focus effects
-    // By default it also influences `.nav-tab` and `.nav-pills`
-    &.disabled {
-        color: $nav-link-disabled-color;
-        opacity: $nav-link-disabled-opacity;
-    }
-}
-
-
-// Tabs
-.nav-tabs {
-    flex-flow: row wrap;
-    border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
-
-    .nav-item {
-        // Make the list-items overlay the bottom border
-        margin-bottom: -$nav-tabs-border-width;
+@if $enable-nav {
+    .nav {
+        display: flex;
+        flex-wrap: wrap;
+        padding-left: 0;
+        margin-bottom: 0;
+        list-style: none;
     }
 
     .nav-link {
-        text-decoration: none;
-        border: $nav-tabs-border-width solid transparent;
-        @include border-radius($border-radius $border-radius 0 0);
+        display: block;
+        padding: $nav-link-padding-y $nav-link-padding-x;
 
-        @include hover-focus {
-            text-decoration: none;
-            background-color: $nav-tabs-hover-bg;
-            border-color: $nav-tabs-hover-border-color $nav-tabs-hover-border-color $nav-tabs-border-color;
-        }
-
+        // Disabled state lightens text and removes hover/focus effects
+        // By default it also influences `.nav-tab` and `.nav-pills`
         &.disabled {
             color: $nav-link-disabled-color;
-            background-color: transparent;
-            border-color: transparent;
+            opacity: $nav-link-disabled-opacity;
         }
     }
 
-    .nav-link.active,
-    .nav-item.open .nav-link {
-        color: $nav-tabs-active-color;
-        background-color: $nav-tabs-active-bg;
-        border-color: $nav-tabs-active-border-color $nav-tabs-active-border-color $nav-tabs-active-bg;
-    }
 
-    .dropdown-menu {
-        // Make dropdown border overlap tab border
-        margin-top: -$nav-tabs-border-width;
-        // Remove the top rounded corners here since there is a hard edge above the menu
-        @include border-top-radius(0);
-    }
-}
+    // Tabs
+    @if $enable-nav-tabs {
+        .nav-tabs {
+            flex-flow: row wrap;
+            border-bottom: $nav-tabs-border-width solid $nav-tabs-border-color;
 
+            .nav-item {
+                // Make the list-items overlay the bottom border
+                margin-bottom: -$nav-tabs-border-width;
+            }
 
-// Pills
-.nav-pills {
-    flex-flow: row wrap;
+            .nav-link {
+                text-decoration: none;
+                border: $nav-tabs-border-width solid transparent;
+                @include border-radius($border-radius $border-radius 0 0);
 
-    .nav-link {
-        text-decoration: none;
-        @include border-radius($nav-pills-border-radius);
+                @include hover-focus {
+                    text-decoration: none;
+                    background-color: $nav-tabs-hover-bg;
+                    border-color: $nav-tabs-hover-border-color $nav-tabs-hover-border-color $nav-tabs-border-color;
+                }
 
-        @include hover-focus {
-            color: inherit;
-            text-decoration: none;
-            background-color: $nav-pills-hover-bg;
+                &.disabled {
+                    color: $nav-link-disabled-color;
+                    background-color: transparent;
+                    border-color: transparent;
+                }
+            }
+
+            .nav-link.active,
+            .nav-item.open .nav-link {
+                color: $nav-tabs-active-color;
+                background-color: $nav-tabs-active-bg;
+                border-color: $nav-tabs-active-border-color $nav-tabs-active-border-color $nav-tabs-active-bg;
+            }
+
+            @if $enable-dropdown {
+                .dropdown-menu {
+                    // Make dropdown border overlap tab border
+                    margin-top: -$nav-tabs-border-width;
+                    // Remove the top rounded corners here since there is a hard edge above the menu
+                    @include border-top-radius(0);
+                }
+            }
         }
+    }
 
-        &.disabled {
-            color: $nav-link-disabled-color;
-            background-color: transparent;
-            border-color: transparent;
+
+    // Pills
+    @if $enable-nav-pills {
+        .nav-pills {
+            flex-flow: row wrap;
+
+            .nav-link {
+                text-decoration: none;
+                @include border-radius($nav-pills-border-radius);
+
+                @include hover-focus {
+                    color: inherit;
+                    text-decoration: none;
+                    background-color: $nav-pills-hover-bg;
+                }
+
+                &.disabled {
+                    color: $nav-link-disabled-color;
+                    background-color: transparent;
+                    border-color: transparent;
+                }
+            }
+
+            .nav-link.active,
+            .nav-item.open .nav-link {
+                color: $nav-pills-active-color;
+                background-color: $nav-pills-active-bg;
+            }
         }
     }
 
-    .nav-link.active,
-    .nav-item.open .nav-link {
-        color: $nav-pills-active-color;
-        background-color: $nav-pills-active-bg;
+
+    // Vertical navigation
+    @if $enable-nav-vertical {
+        .nav-vertical {
+            flex-direction: column;
+        }
     }
-}
 
-
-// Vertical navigation
-.nav-vertical {
-    flex-direction: column;
-}
-
-// Justified variants
-.nav-fill {
-    .nav-item {
-        flex: 1 1 auto;
-        text-align: center;
+    // Justified variants
+    @if $enable-nav-fill {
+        .nav-fill {
+            .nav-item {
+                flex: 1 1 auto;
+                text-align: center;
+            }
+        }
     }
-}
 
-.nav-justify {
-    .nav-item {
-        flex-basis: 0;
-        flex-grow: 1;
-        text-align: center;
+    @if $enable-nav-justify {
+        .nav-justify {
+            .nav-item {
+                flex-basis: 0;
+                flex-grow: 1;
+                text-align: center;
+            }
+        }
     }
 }
 
 // Tab content panes
 // Hide tabbable panes to start, show them when `.active`
-.tab-content {
-    > .tab-pane {
-        display: none;
-    }
-    > .active {
-        display: block;
+@if $enable-tab-content {
+    .tab-content {
+        > .tab-pane {
+            display: none;
+        }
+        > .active {
+            display: block;
+        }
     }
 }

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -22,7 +22,7 @@
             }
         }
 
-        @if $enable-navbar-nav {
+        @if $enable-navbar-nav and $enable-dropdown {
             &:not([class*="navbar-expand"]) {
                 .navbar-nav {
                     .dropdown-menu {
@@ -147,7 +147,7 @@
                 // Skip smallest breakpoint
                 @if breakpoint-min($bp, $grid-breakpoints) != null {
                     @include media-breakpoint-down($prev) {
-                        @if $enable-navbar-nav {
+                        @if $enable-navbar-nav and $enable-dropdown {
                             .navbar-nav {
                                 .dropdown-menu {
                                     position: static;
@@ -183,8 +183,10 @@
                             flex-direction: row;
                             align-items: center;
 
-                            .dropdown-menu {
-                                position: absolute;
+                            @if $enable-dropdown {
+                                .dropdown-menu {
+                                    position: absolute;
+                                }
                             }
 
                             .nav-link {

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -12,7 +12,7 @@
 
         // Because flex properties aren't inherited, we need to redeclare these first
         // few properities so that content nested within behave properly.
-        if $enable-grid-classes {
+        @if $enable-grid-classes {
             > .container,
             > .container-fluid {
                 display: flex;
@@ -196,9 +196,10 @@
 
                     // For nesting containers, have to redeclare for alignment purposes
                     @if $enable-grid-classes {
-                    > .container,
-                    > .container-fluid {
-                        flex-wrap: nowrap;
+                        > .container,
+                        > .container-fluid {
+                            flex-wrap: nowrap;
+                        }
                     }
 
                     @if $enable-navbar-collapse {

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -1,313 +1,363 @@
 // Navbar
 // Provide a static navbar from which we expand to create full-width, fixed, and
 // other navbar variations.
-.navbar {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap; // allow us to do the line break for collapsing content
-    align-items: center;
-    // justify-content: space-between; // space out brand from logo
-    padding: $navbar-padding-y $navbar-padding-x;
-
-    // Because flex properties aren't inherited, we need to redeclare these first
-    // few properities so that content nested within behave properly.
-    > .container,
-    > .container-fluid {
+@if $enable-navbar {
+    .navbar {
+        position: relative;
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: wrap; // allow us to do the line break for collapsing content
         align-items: center;
-        justify-content: space-between;
-    }
+        // justify-content: space-between; // space out brand from logo
+        padding: $navbar-padding-y $navbar-padding-x;
 
-    &:not([class*="navbar-expand"]) {
-        .navbar-nav {
-            .dropdown-menu {
-                position: static;
-                float: none;
+        // Because flex properties aren't inherited, we need to redeclare these first
+        // few properities so that content nested within behave properly.
+        if $enable-grid-classes {
+            > .container,
+            > .container-fluid {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                justify-content: space-between;
+            }
+        }
+
+        @if $enable-navbar-nav {
+            &:not([class*="navbar-expand"]) {
+                .navbar-nav {
+                    .dropdown-menu {
+                        position: static;
+                        float: none;
+                    }
+                }
             }
         }
     }
-}
 
-// Navbar Brand
-// Used for brand, project, or site name.
-.navbar-brand {
-    display: inline-block;
-    padding-top: $navbar-brand-padding-y;
-    padding-bottom: $navbar-brand-padding-y;
-    margin-right: $navbar-brand-margin-x;
-    @include font-size($navbar-brand-font-size);
-    font-weight: $navbar-brand-font-weight;
-    line-height: inherit;
-    text-decoration: none;
-    white-space: nowrap;
-
-    @include hover-focus {
-        text-decoration: none;
-    }
-
-    > img {
-        display: block;
-    }
-}
-
-// Navbar Nav
-// Navbar navigation based the base `.nav` styles.
-.navbar-nav {
-    display: flex;
-    flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
-    padding-left: 0;
-    margin-bottom: 0;
-    list-style: none;
-
-    .nav-link {
-        padding-right: 0;
-        padding-left: 0;
-        text-decoration: none;
-
-        @include hover-focus() {
+    // Navbar Brand
+    // Used for brand, project, or site name.
+    @if $enable-navbar-brand {
+        .navbar-brand {
+            display: inline-block;
+            padding-top: $navbar-brand-padding-y;
+            padding-bottom: $navbar-brand-padding-y;
+            margin-right: $navbar-brand-margin-x;
+            @include font-size($navbar-brand-font-size);
+            font-weight: $navbar-brand-font-weight;
+            line-height: inherit;
             text-decoration: none;
+            white-space: nowrap;
+
+            @include hover-focus {
+                text-decoration: none;
+            }
+
+            > img {
+                display: block;
+            }
         }
     }
-}
 
-//Navbar Text
-.navbar-text {
-    display: inline-block;
-    padding-top: $navbar-item-padding-y;
-    padding-bottom: $navbar-item-padding-y;
-}
+    // Navbar Nav
+    // Navbar navigation based the base `.nav` styles.
+    @if $enable-navbar-nav {
+        .navbar-nav {
+            display: flex;
+            flex-direction: column; // cannot use `inherit` to get the `.navbar`s value
+            padding-left: 0;
+            margin-bottom: 0;
+            list-style: none;
 
-// Navbar Divider
-.navbar-divider {
-    align-self: stretch;
-    margin: 0 $navbar-divider-margin-y;
-    overflow: hidden;
-    border-left: $navbar-divider-width solid $navbar-divider-color;
-}
+            .nav-link {
+                padding-right: 0;
+                padding-left: 0;
+                text-decoration: none;
 
-// Responsive navbar
-//
-// Custom styles for responsive collapsing and toggling of navbar contents.
-// Powered by the collapse Bootstrap JavaScript plugin.
-
-// When collapsed, prevent the toggleable navbar contents from appearing in
-// the default flexbox row orienation. Requires the use of `flex-wrap: wrap`
-// on the `.navbar` parent.
-.navbar-collapse {
-    flex: 1 1 100%;
-    // Align content vertically in all instances.  Use flexbox utils to override.
-    align-items: center;
-}
-
-
-// Navbar Toggle
-// Custom button for toggling the `.navbar-collapse`, powered by the collapse plugin.
-.navbar-toggle {
-    padding: $navbar-toggle-padding-y $navbar-toggle-padding-x;
-    @include font-size($navbar-toggle-font-size);
-    line-height: 1;
-    background-color: transparent; // Remove default button style
-    border: $border-width solid transparent; // Remove default button style
-    @include border-radius($navbar-toggle-border-radius);
-
-    @include hover-focus {
-        text-decoration: none;
+                @include hover-focus() {
+                    text-decoration: none;
+                }
+            }
+        }
     }
 
-    &:not(:disabled):not(.disabled) {
-        cursor: pointer;
+    //Navbar Text
+    @if $enable-navbar-text {
+        .navbar-text {
+            display: inline-block;
+            padding-top: $navbar-item-padding-y;
+            padding-bottom: $navbar-item-padding-y;
+        }
     }
-}
 
-// Generate series of `.navbar-expand-*` responsive classes for configuring
-// where your navbar collapses.
-.navbar-expand {
-    @each $bp in $navbar-expand-breakpoints {
-        $bprule: breakpoint-designator($bp);
-        $prev: breakpoint-prev($bp, $grid-breakpoints);
+    // Navbar Divider
+    @if $enable-navbar-divider {
+        .navbar-divider {
+            align-self: stretch;
+            margin: 0 $navbar-divider-margin-y;
+            overflow: hidden;
+            border-left: $navbar-divider-width solid $navbar-divider-color;
+        }
+    }
 
-        &#{$bprule} {
-            // Skip smallest breakpoint
-            @if breakpoint-min($bp, $grid-breakpoints) != null {
-                @include media-breakpoint-down($prev) {
-                    .navbar-nav {
-                        .dropdown-menu {
-                            position: static;
-                            float: none;
+    // Responsive navbar
+    //
+    // Custom styles for responsive collapsing and toggling of navbar contents.
+    // Powered by the collapse Bootstrap JavaScript plugin.
+
+    // When collapsed, prevent the toggleable navbar contents from appearing in
+    // the default flexbox row orienation. Requires the use of `flex-wrap: wrap`
+    // on the `.navbar` parent.
+    @if $enable-navbar-collapse {
+        .navbar-collapse {
+            flex: 1 1 100%;
+            // Align content vertically in all instances.  Use flexbox utils to override.
+            align-items: center;
+        }
+    }
+
+    // Navbar Toggle
+    // Custom button for toggling the `.navbar-collapse`, powered by the collapse plugin.
+    @if $enable-navbar-toggle {
+        .navbar-toggle {
+            padding: $navbar-toggle-padding-y $navbar-toggle-padding-x;
+            @include font-size($navbar-toggle-font-size);
+            line-height: 1;
+            background-color: transparent; // Remove default button style
+            border: $border-width solid transparent; // Remove default button style
+            @include border-radius($navbar-toggle-border-radius);
+
+            @include hover-focus {
+                text-decoration: none;
+            }
+
+            &:not(:disabled):not(.disabled) {
+                cursor: pointer;
+            }
+        }
+    }
+
+    // Generate series of `.navbar-expand-*` responsive classes for configuring
+    // where your navbar collapses.
+    .navbar-expand {
+        @each $bp in $navbar-expand-breakpoints {
+            $bprule: breakpoint-designator($bp);
+            $prev: breakpoint-prev($bp, $grid-breakpoints);
+
+            &#{$bprule} {
+                // Skip smallest breakpoint
+                @if breakpoint-min($bp, $grid-breakpoints) != null {
+                    @include media-breakpoint-down($prev) {
+                        @if $enable-navbar-nav {
+                            .navbar-nav {
+                                .dropdown-menu {
+                                    position: static;
+                                    float: none;
+                                }
+                            }
+                        }
+
+                        @if $enable-grid-classes {
+                            > .container,
+                            > .container-fluid {
+                                padding-right: 0;
+                                padding-left: 0;
+                            }
+                        }
+
+                        @if $enable-navbar-divider {
+                            .navbar-divider {
+                                margin: $navbar-divider-margin-x 0;
+                                border-top: $navbar-divider-width solid $navbar-divider-color;
+                                border-left: 0;
+                            }
+                        }
+                    }
+                }
+
+                @include media-breakpoint-up($bp) {
+                    flex-flow: row nowrap;
+                    justify-content: flex-start;
+
+                    @if $enable-navbar-nav {
+                        .navbar-nav {
+                            flex-direction: row;
+                            align-items: center;
+
+                            .dropdown-menu {
+                                position: absolute;
+                            }
+
+                            .nav-link {
+                                padding-right: $navbar-item-padding-x;
+                                padding-left: $navbar-item-padding-x;
+                            }
                         }
                     }
 
+                    // For nesting containers, have to redeclare for alignment purposes
+                    @if $enable-grid-classes {
                     > .container,
                     > .container-fluid {
-                        padding-right: 0;
-                        padding-left: 0;
+                        flex-wrap: nowrap;
                     }
 
-                    .navbar-divider {
-                        margin: $navbar-divider-margin-x 0;
-                        border-top: $navbar-divider-width solid $navbar-divider-color;
-                        border-left: 0;
-                    }
-                }
-            }
-
-            @include media-breakpoint-up($bp) {
-                flex-flow: row nowrap;
-                justify-content: flex-start;
-
-                .navbar-nav {
-                    flex-direction: row;
-                    align-items: center;
-
-                    .dropdown-menu {
-                        position: absolute;
+                    @if $enable-navbar-collapse {
+                        .navbar-collapse {
+                            display: flex !important;   // stylelint-disable-line declaration-no-important
+                            flex-basis: auto;
+                        }
                     }
 
-                    .nav-link {
-                        padding-right: $navbar-item-padding-x;
-                        padding-left: $navbar-item-padding-x;
+                    @if $enable-navbar-toggle {
+                        .navbar-toggle {
+                            display: none;
+                        }
                     }
-                }
-
-                // For nesting containers, have to redeclare for alignment purposes
-                > .container,
-                > .container-fluid {
-                    flex-wrap: nowrap;
-                }
-
-                .navbar-collapse {
-                    display: flex !important;   // stylelint-disable-line declaration-no-important
-                    flex-basis: auto;
-                }
-
-                .navbar-toggle {
-                    display: none;
                 }
             }
         }
     }
-}
 
-// Navbar Themes
-// Dark links against a light background
-.navbar-light {
-    .navbar-brand {
-        color: $navbar-light-active-color;
-
-        @include hover-focus {
-            color: $navbar-light-active-color;
-        }
-    }
-
-    .navbar-nav {
-        .nav-link {
-            color: $navbar-light-color;
-
-            @include hover-focus {
-                color: $navbar-light-hover-color;
-            }
-
-            &.disabled {
-                color: $navbar-light-disabled-color;
-                background-color: transparent;
-                border-color: transparent;
-            }
-        }
-
-        .open > .nav-link,
-        .active > .nav-link,
-        .nav-link.open,
-        .nav-link.active {
-            color: $navbar-light-active-color;
-        }
-    }
-
-    .navbar-toggle {
-        color: $navbar-light-color;
-        border-color: $navbar-light-toggle-border;
-
-        @include hover-focus {
-            color: $navbar-light-active-color;
-        }
-    }
-
-    .navbar-text {
-        color: $navbar-light-color;
-
-        a {
-            color: $navbar-light-hover-color;
-            text-decoration: none;
-
-            @include hover-focus {
+    // Navbar Themes
+    // Dark links against a light background
+    @if $enable-navbar-light {
+        .navbar-light {
+            .navbar-brand {
                 color: $navbar-light-active-color;
-                text-decoration: none;
+
+                @include hover-focus {
+                    color: $navbar-light-active-color;
+                }
+            }
+
+            @if $enable-navbar-nav {
+                .navbar-nav {
+                    .nav-link {
+                        color: $navbar-light-color;
+
+                        @include hover-focus {
+                            color: $navbar-light-hover-color;
+                        }
+
+                        &.disabled {
+                            color: $navbar-light-disabled-color;
+                            background-color: transparent;
+                            border-color: transparent;
+                        }
+                    }
+
+                    .open > .nav-link,
+                    .active > .nav-link,
+                    .nav-link.open,
+                    .nav-link.active {
+                        color: $navbar-light-active-color;
+                    }
+                }
+            }
+
+            @if $enable-navbar-toggle {
+                .navbar-toggle {
+                    color: $navbar-light-color;
+                    border-color: $navbar-light-toggle-border;
+
+                    @include hover-focus {
+                        color: $navbar-light-active-color;
+                    }
+                }
+            }
+
+            @if $enable-navbar-text {
+                .navbar-text {
+                    color: $navbar-light-color;
+
+                    a {
+                        color: $navbar-light-hover-color;
+                        text-decoration: none;
+
+                        @include hover-focus {
+                            color: $navbar-light-active-color;
+                            text-decoration: none;
+                        }
+                    }
+                }
+            }
+
+            @if $enable-navbar-divider {
+                .navbar-divider {
+                    border-color: $navbar-light-divider-color;
+                }
             }
         }
     }
 
-    .navbar-divider {
-        border-color: $navbar-light-divider-color;
-    }
-}
-
-// White links against a dark background
-.navbar-dark {
-    .navbar-brand {
-        color: $navbar-dark-active-color;
-
-        @include hover-focus {
-            color: $navbar-dark-hover-color;
-        }
-    }
-
-    .navbar-nav {
-        .nav-link {
-            color: $navbar-dark-color;
-
-            @include hover-focus {
-                color: $navbar-dark-hover-color;
-            }
-
-            &.disabled {
-                color: $navbar-dark-disabled-color;
-                background-color: transparent;
-                border-color: transparent;
-            }
-        }
-
-        .open > .nav-link,
-        .active > .nav-link,
-        .nav-link.open,
-        .nav-link.active {
-            color: $navbar-dark-active-color;
-        }
-    }
-
-    .navbar-toggle {
-        color: $navbar-dark-color;
-        border-color: $navbar-dark-toggle-border;
-
-        @include hover-focus {
-            color: $navbar-dark-active-color;
-        }
-    }
-
-    .navbar-text {
-        color: $navbar-dark-color;
-
-        a {
-            color: $navbar-dark-hover-color;
-            text-decoration: none;
-
-            @include hover-focus {
+    // White links against a dark background
+    @if $enable-navbar-dark {
+        .navbar-dark {
+            .navbar-brand {
                 color: $navbar-dark-active-color;
-                text-decoration: none;
+
+                @include hover-focus {
+                    color: $navbar-dark-hover-color;
+                }
+            }
+
+            @if $enable-navbar-nav {
+                .navbar-nav {
+                    .nav-link {
+                        color: $navbar-dark-color;
+
+                        @include hover-focus {
+                            color: $navbar-dark-hover-color;
+                        }
+
+                        &.disabled {
+                            color: $navbar-dark-disabled-color;
+                            background-color: transparent;
+                            border-color: transparent;
+                        }
+                    }
+
+                    .open > .nav-link,
+                    .active > .nav-link,
+                    .nav-link.open,
+                    .nav-link.active {
+                        color: $navbar-dark-active-color;
+                    }
+                }
+            }
+
+            @if $enable-navbar-toggle {
+                .navbar-toggle {
+                    color: $navbar-dark-color;
+                    border-color: $navbar-dark-toggle-border;
+
+                    @include hover-focus {
+                        color: $navbar-dark-active-color;
+                    }
+                }
+            }
+
+            @if $enable-navbar-text {
+                .navbar-text {
+                    color: $navbar-dark-color;
+
+                    a {
+                        color: $navbar-dark-hover-color;
+                        text-decoration: none;
+
+                        @include hover-focus {
+                            color: $navbar-dark-active-color;
+                            text-decoration: none;
+                        }
+                    }
+                }
+            }
+
+            @if $enable-navbar-divider {
+                .navbar-divider {
+                    border-color: $navbar-dark-divider-color;
+                }
             }
         }
-    }
-
-    .navbar-divider {
-        border-color: $navbar-dark-divider-color;
     }
 }

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -1,98 +1,107 @@
-.pagination {
-    display: flex;
-    padding-left: 0;
-    margin-bottom: $pagination-margin-bottom;
-    list-style: none;
-}
-
-.page-text,
-.page-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 2.25em;
-    padding: $pagination-padding-y $pagination-padding-x;
-    line-height: $pagination-line-height;
-    border: 0 solid $pagination-border-color;
-    @include border-radius($pagination-border-radius);
-}
-
-.page-link {
-    position: relative;
-    color: $pagination-color;
-    text-decoration: none;
-    cursor: pointer;
-    background-color: $pagination-bg;
-
-    &:hover,
-    &:focus {
-        z-index: 2;
-        color: $pagination-hover-color;
-        text-decoration: none;
-        background-color: $pagination-hover-bg;
-        border-color: $pagination-hover-border-color;
+@if $enable-pagination {
+    .pagination {
+        display: flex;
+        padding-left: 0;
+        margin-bottom: $pagination-margin-bottom;
+        list-style: none;
     }
 
-    &.active {
-        z-index: 1;
-        color: $pagination-active-color;
-        background-color: $pagination-active-bg;
-    }
-
-    &.disabled {
-        color: $pagination-disabled-color;
-        pointer-events: none;
-        cursor: auto;
-        background-color: $pagination-disabled-bg;
-    }
-}
-
-// Sizing
-@if $enable-sizing {
-    @each $size, $dims in $pagination-sizes {
-        $sz-font-size:     map-get($dims, "font-size");
-        $sz-line-height:   map-get($dims, "line-height");
-        $sz-padding-y:     map-get($dims, "padding-y");
-        //$sz-padding-x:     map-get($dims, "padding-x");
-        $sz-padding-x:    $pagination-padding-x;
-        $sz-border-radius: map-get($dims, "border-radius");
-
-        .pagination-#{$size} {
-            @include pagination-size($sz-padding-y, $sz-padding-x, $sz-font-size, $sz-line-height, $sz-border-radius);
-        }
-    }
-}
-
-.pagination-spaced {
-    .page-link {
-        border-width: $pagination-border-width;
-    }
-
-    .page-item {
-        &:not(:last-child) {
-            margin-right: $pagination-spaced-margin-end;
-        }
-    }
-}
-
-.pagination-group {
     .page-text,
     .page-link {
-        border-width: $pagination-border-width;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2.25em;
+        padding: $pagination-padding-y $pagination-padding-x;
+        line-height: $pagination-line-height;
+        border: 0 solid $pagination-border-color;
+        @include border-radius($pagination-border-radius);
     }
 
-    .page-item {
-        &:not(:first-child) {
-            .page-text,
-            .page-link {
-                margin-left: -$pagination-border-width;
-                @include border-start-radius(0);
+    .page-link {
+        position: relative;
+        color: $pagination-color;
+        text-decoration: none;
+        background-color: $pagination-bg;
+
+        &:hover,
+        &:focus {
+            z-index: 2;
+            color: $pagination-hover-color;
+            text-decoration: none;
+            background-color: $pagination-hover-bg;
+            border-color: $pagination-hover-border-color;
+        }
+
+        &.active {
+            z-index: 1;
+            color: $pagination-active-color;
+            background-color: $pagination-active-bg;
+        }
+
+        &.disabled {
+            color: $pagination-disabled-color;
+            pointer-events: none;
+            cursor: auto;
+            background-color: $pagination-disabled-bg;
+        }
+
+        @at-root a#{&} {
+            cursor: pointer;
+        }
+    }
+
+    // Sizing
+    @if $enable-sizing and $enable-pagination-sizing {
+        @each $size, $dims in $pagination-sizes {
+            $sz-font-size:     map-get($dims, "font-size");
+            $sz-line-height:   map-get($dims, "line-height");
+            $sz-padding-y:     map-get($dims, "padding-y");
+            //$sz-padding-x:     map-get($dims, "padding-x");
+            $sz-padding-x:    $pagination-padding-x;
+            $sz-border-radius: map-get($dims, "border-radius");
+
+            .pagination-#{$size} {
+                @include pagination-size($sz-padding-y, $sz-padding-x, $sz-font-size, $sz-line-height, $sz-border-radius);
             }
         }
-        &:not(:last-child) {
+    }
+
+    @if $enable-pagination-spaced {
+        .pagination-spaced {
+            .page-link {
+                border-width: $pagination-border-width;
+            }
+
+            .page-item {
+                &:not(:last-child) {
+                    margin-right: $pagination-spaced-margin-end;
+                }
+            }
+        }
+    }
+
+    @if $enable-pagination-group {
+        .pagination-group {
             .page-text,
             .page-link {
-                @include border-end-radius(0);
+                border-width: $pagination-border-width;
+            }
+
+            .page-item {
+                &:not(:first-child) {
+                    .page-text,
+                    .page-link {
+                        margin-left: -$pagination-border-width;
+                        @include border-start-radius(0);
+                    }
+                }
+                &:not(:last-child) {
+                    .page-text,
+                    .page-link {
+                        @include border-end-radius(0);
+                    }
+                }
             }
         }
     }

--- a/scss/component/_progress.scss
+++ b/scss/component/_progress.scss
@@ -1,35 +1,44 @@
-@keyframes progress-bar-stripes {
-    from { background-position: $progress-height 0; }
-    to { background-position: 0 0; }
-}
+@if $enable-progress {
 
-.progress {
-    display: flex;
-    height: $progress-height;
-    overflow: hidden; // Force rounded corners by cropping
-    @include font-size($progress-font-size);
-    background-color: $progress-bg;
-    @include border-radius($progress-border-radius);
-    @include box-shadow($progress-box-shadow);
-}
+    @if $enable-progress-animated {
+        @keyframes progress-bar-stripes {
+            from { background-position: $progress-height 0; }
+            to { background-position: 0 0; }
+        }
+    }
 
-.progress-bar {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    color: $progress-bar-color;
-    text-align: center;
-    white-space: nowrap;
-    background-color: $progress-bar-bg;
-    @include box-shadow($progress-bar-box-shadow);
-    @include transition($progress-bar-transition);
-}
+    .progress {
+        display: flex;
+        height: $progress-height;
+        overflow: hidden; // Force rounded corners by cropping
+        @include font-size($progress-font-size);
+        background-color: $progress-bg;
+        @include border-radius($progress-border-radius);
+        @include box-shadow($progress-box-shadow);
+    }
 
-.progress-bar-striped {
-    @include gradient-striped();
-    background-size: $progress-height $progress-height;
-}
+    .progress-bar {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        color: $progress-bar-color;
+        text-align: center;
+        white-space: nowrap;
+        background-color: $progress-bar-bg;
+        @include box-shadow($progress-bar-box-shadow);
+        @include transition($progress-bar-transition);
+    }
 
-.progress-bar-animated {
-    animation: progress-bar-stripes $progress-bar-animation-timing;
+    @if $enable-progress-striped {
+        .progress-bar-striped {
+            @include gradient-striped();
+            background-size: $progress-height $progress-height;
+        }
+    }
+
+    @if $enable-progress-animated {
+        .progress-bar-animated {
+            animation: progress-bar-stripes $progress-bar-animation-timing;
+        }
+    }
 }

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -20,45 +20,87 @@
             text-decoration: none;
         }
 
-        .btn:focus,
-        .btn-check-input:focus ~ .btn {
+        %btn-common-focus {
             text-decoration: none;
             // Turn off outline due to focus box-shadow set by button-variant()
             outline: 0;
         }
+        .btn:focus {
+            @extend %btn-common-focus;
+        }
+        @if $enable-btn-check {
+            .btn-check-input:focus ~ .btn {
+                @extend %btn-common-focus;
+            }
+        }
 
         // Disabled comes first so active can restyle
-        .btn.disabled,
-        .btn:disabled,
-        .btn-check-input:disabled ~ .btn {
+        %btn-common-disabled {
             opacity: $btn-disabled-opacity;
             @include box-shadow(none);
+        }
+        .btn.disabled,
+        .btn:disabled {
+            @extend %btn-common-disabled;
+        }
+        @if $enable-btn-check {
+            .btn-check-input:disabled ~ .btn {
+                @extend %btn-common-disabled;
+            }
         }
 
         .btn:not(:disabled):not(.disabled) {
             cursor: pointer;
         }
 
-        .btn:not(:disabled):not(.disabled):active,
-        .btn:not(:disabled):not(.disabled).active,
-        .btn-check-input:not(:disabled):checked ~ .btn,
-        .open > .btn {
+        %btn-common-active {
             @include box-shadow($btn-active-box-shadow);
         }
-
-        .btn:not(:disabled):not(.disabled):active:focus,
-        .btn:not(:disabled):not(.disabled).active:focus,
-        .btn-check-input:not(:disabled):checked:focus ~ .btn,
-        .open > .btn:focus {
-            @include box-shadow($btn-active-box-shadow, $btn-focus-box-shadow);
+        .btn:not(:disabled):not(.disabled):active,
+        .btn:not(:disabled):not(.disabled).active,
+        .open > .btn {
+            @if $enable-shadows {
+                @extend %btn-common-active;
+            }
+        }
+        @if $enable-btn-check {
+            .btn-check-input:not(:disabled):checked ~ .btn {
+                @if $enable-shadows {
+                    @extend %btn-common-active;
+                }
+            }
         }
 
+        %btn-common-active-focus {
+            @include box-shadow($btn-active-box-shadow, $btn-focus-box-shadow);
+        }
+        .btn:not(:disabled):not(.disabled):active:focus,
+        .btn:not(:disabled):not(.disabled).active:focus,
+        .open > .btn:focus {
+            @if $enable-shadows {
+                @extend %btn-common-active-focus;
+            }
+        }
+        @if $enable-btn-check {
+            .btn-check-input:not(:disabled):checked:focus ~ .btn {
+                @if $enable-shadows {
+                    @extend %btn-common-active-focus;
+                }
+            }
+        }
 
         // Future-proof disabling of clicks on `<a>` elements
-        a.btn.disabled,
-        fieldset:disabled a.btn,
-        .btn-check-input:disabled ~ .btn {
+        %btn-common-disabled-pointer {
             pointer-events: none;
+        }
+        a.btn.disabled,
+        fieldset:disabled a.btn {
+            @extend %btn-common-disabled-pointer;
+        }
+        @if $enable-btn-check {
+            .btn-check-input:disabled ~ .btn {
+                @extend %btn-common-disabled-pointer;
+            }
         }
     }
 
@@ -177,12 +219,12 @@
             }
 
             .btn-#{$size} {
-                @if $enable-btn-sizes {
+                @if $enable-btn-sizing {
                     @extend %btn-#{$size};
                 }
 
                 &.btn-icon {
-                    @if $enable-btn-icon and $enable-btn-icon-sizes {
+                    @if $enable-btn-icon and $enable-btn-icon-sizing {
                         @extend %btn-icon-#{$size};
                     }
                 }
@@ -216,7 +258,7 @@
     @if $enable-btn-check {
         .btn-check {
             position: relative;
-            display: inline-block;
+            display: inline-flex;
             vertical-align: middle;
         }
 

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -1,106 +1,104 @@
 // stylelint-disable selector-no-qualifying-type
 @if $enable-btn {
     // Base button
-    @if $enable-btn-common {
-        .btn {
-            display: inline-block;
-            font-weight: $btn-font-weight;
-            line-height: $btn-line-height;
-            text-align: center;
-            text-decoration: none;
-            vertical-align: middle;
-            user-select: none;
-            border: $btn-border-width solid transparent;
-            @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-line-height, $btn-border-radius);
-            @include box-shadow($btn-box-shadow);
-            @include transition($btn-transition);
-        }
+    .btn {
+        display: inline-block;
+        font-weight: $btn-font-weight;
+        line-height: $btn-line-height;
+        text-align: center;
+        text-decoration: none;
+        vertical-align: middle;
+        user-select: none;
+        border: $btn-border-width solid transparent;
+        @include button-size($btn-padding-y, $btn-padding-x, $font-size-base, $btn-line-height, $btn-border-radius);
+        @include box-shadow($btn-box-shadow);
+        @include transition($btn-transition);
+    }
 
-        .btn:hover {
-            text-decoration: none;
-        }
+    .btn:hover {
+        text-decoration: none;
+    }
 
-        %btn-common-focus {
-            text-decoration: none;
-            // Turn off outline due to focus box-shadow set by button-variant()
-            outline: 0;
-        }
-        .btn:focus {
+    %btn-common-focus {
+        text-decoration: none;
+        // Turn off outline due to focus box-shadow set by button-variant()
+        outline: 0;
+    }
+    .btn:focus {
+        @extend %btn-common-focus;
+    }
+    @if $enable-btn-check {
+        .btn-check-input:focus ~ .btn {
             @extend %btn-common-focus;
         }
-        @if $enable-btn-check {
-            .btn-check-input:focus ~ .btn {
-                @extend %btn-common-focus;
-            }
-        }
+    }
 
-        // Disabled comes first so active can restyle
-        %btn-common-disabled {
-            opacity: $btn-disabled-opacity;
-            @include box-shadow(none);
-        }
-        .btn.disabled,
-        .btn:disabled {
+    // Disabled comes first so active can restyle
+    %btn-common-disabled {
+        opacity: $btn-disabled-opacity;
+        @include box-shadow(none);
+    }
+    .btn.disabled,
+    .btn:disabled {
+        @extend %btn-common-disabled;
+    }
+    @if $enable-btn-check {
+        .btn-check-input:disabled ~ .btn {
             @extend %btn-common-disabled;
         }
-        @if $enable-btn-check {
-            .btn-check-input:disabled ~ .btn {
-                @extend %btn-common-disabled;
-            }
-        }
+    }
 
-        .btn:not(:disabled):not(.disabled) {
-            cursor: pointer;
-        }
+    .btn:not(:disabled):not(.disabled) {
+        cursor: pointer;
+    }
 
-        %btn-common-active {
-            @include box-shadow($btn-active-box-shadow);
+    %btn-common-active {
+        @include box-shadow($btn-active-box-shadow);
+    }
+    .btn:not(:disabled):not(.disabled):active,
+    .btn:not(:disabled):not(.disabled).active,
+    .open > .btn {
+        @if $enable-shadows {
+            @extend %btn-common-active;
         }
-        .btn:not(:disabled):not(.disabled):active,
-        .btn:not(:disabled):not(.disabled).active,
-        .open > .btn {
+    }
+    @if $enable-btn-check {
+        .btn-check-input:not(:disabled):checked ~ .btn {
             @if $enable-shadows {
                 @extend %btn-common-active;
             }
         }
-        @if $enable-btn-check {
-            .btn-check-input:not(:disabled):checked ~ .btn {
-                @if $enable-shadows {
-                    @extend %btn-common-active;
-                }
-            }
-        }
+    }
 
-        %btn-common-active-focus {
-            @include box-shadow($btn-active-box-shadow, $btn-focus-box-shadow);
+    %btn-common-active-focus {
+        @include box-shadow($btn-active-box-shadow, $btn-focus-box-shadow);
+    }
+    .btn:not(:disabled):not(.disabled):active:focus,
+    .btn:not(:disabled):not(.disabled).active:focus,
+    .open > .btn:focus {
+        @if $enable-shadows {
+            @extend %btn-common-active-focus;
         }
-        .btn:not(:disabled):not(.disabled):active:focus,
-        .btn:not(:disabled):not(.disabled).active:focus,
-        .open > .btn:focus {
+    }
+    @if $enable-btn-check {
+        .btn-check-input:not(:disabled):checked:focus ~ .btn {
             @if $enable-shadows {
                 @extend %btn-common-active-focus;
             }
         }
-        @if $enable-btn-check {
-            .btn-check-input:not(:disabled):checked:focus ~ .btn {
-                @if $enable-shadows {
-                    @extend %btn-common-active-focus;
-                }
-            }
-        }
+    }
 
-        // Future-proof disabling of clicks on `<a>` elements
-        %btn-common-disabled-pointer {
-            pointer-events: none;
-        }
-        a.btn.disabled,
-        fieldset:disabled a.btn {
+    // Future-proof disabling of clicks on `<a>` elements
+    %btn-common-disabled-pointer {
+        pointer-events: none;
+    }
+    a.btn.disabled,
+    fieldset:disabled a.btn {
+        @extend %btn-common-disabled-pointer;
+    }
+    @if $enable-btn-check {
+        .btn-check-input:disabled ~ .btn {
             @extend %btn-common-disabled-pointer;
-        }
-        @if $enable-btn-check {
-            .btn-check-input:disabled ~ .btn {
-                @extend %btn-common-disabled-pointer;
-            }
         }
     }
 

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -297,7 +297,7 @@
             $sz-inner-height:  (($sz-font-size * $sz-line-height) + ($sz-padding-y * 2));
             $sz-outer-height:  calc(#{$sz-inner-height} + #{($border-width * 2)});
 
-            @if $enable-custom-select and $enable-custom-select-sizes {
+            @if $enable-custom-select and $enable-custom-select-sizing {
                 // stylelint-disable declaration-block-no-duplicate-properties
                 .custom-select-#{$size} {
                     height: $sz-outer-height;

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -150,7 +150,7 @@ $input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2
                 @include border-radius($sz-border-radius);
             }
 
-            @if $enable-form-control and $enable-form-control-sizes {
+            @if $enable-form-control and $enable-form-control-sizing {
                 .form-control-#{$size} {
                     @extend %form-control-#{$size};
                 }
@@ -163,7 +163,7 @@ $input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2
                 line-height: $sz-line-height;
             }
 
-            @if $enable-form-control-label and $enable-form-control-label-sizes {
+            @if $enable-form-control-label and $enable-form-control-label-sizing {
                 .form-control-label-#{$size} {
                     @extend %form-control-label-#{$size};
                 }

--- a/scss/core/_tables.scss
+++ b/scss/core/_tables.scss
@@ -1,35 +1,33 @@
 @if $enable-table {
     // Basic table
-    @if $enable-table-common {
-        .table {
-            width: 100%;
-            margin-bottom: $table-margin-bottom;
-            background-color: $table-bg; // Reset for nesting within parents with `background-color`.
+    .table {
+        width: 100%;
+        margin-bottom: $table-margin-bottom;
+        background-color: $table-bg; // Reset for nesting within parents with `background-color`.
+        border: 0 solid;
+        border-color: $table-border-color;
+
+        // Allow border color to inherit all the way down.
+        // Only use `border-*-width` later to turn border on/off.
+        thead,
+        tbody,
+        tfoot,
+        tr,
+        th,
+        td {
             border: 0 solid;
-            border-color: $table-border-color;
+            border-color: inherit;
+        }
 
-            // Allow border color to inherit all the way down.
-            // Only use `border-*-width` later to turn border on/off.
-            thead,
-            tbody,
-            tfoot,
-            tr,
-            th,
-            td {
-                border: 0 solid;
-                border-color: inherit;
-            }
+        th,
+        td {
+            padding: $table-cell-padding;
+            vertical-align: top;
+        }
 
-            th,
-            td {
-                padding: $table-cell-padding;
-                vertical-align: top;
-            }
-
-            thead {
-                th {
-                    vertical-align: bottom;
-                }
+        thead {
+            th {
+                vertical-align: bottom;
             }
         }
     }

--- a/scss/mixins/_alert.scss
+++ b/scss/mixins/_alert.scss
@@ -4,15 +4,19 @@
     background-color: $bg;
     border-color: $border;
 
-    hr {
-        border-top-color: $border;
+    @if $enable-alert-hr {
+        hr {
+            border-top-color: $border;
+        }
     }
 
-    .alert-link {
-        color: $color;
+    @if $enable-alert-link {
+        .alert-link {
+            color: $color;
 
-        @include hover-focus {
-            color: $hover-color;
+            @include hover-focus {
+                color: $hover-color;
+            }
         }
     }
 }

--- a/scss/mixins/_badge.scss
+++ b/scss/mixins/_badge.scss
@@ -4,7 +4,7 @@
     background-color: $bg;
     border-color: $border;
 
-    &[href] {
+    @at-root a#{&} {
         @include hover-focus {
             color: $hover-color;
             background-color: $hover-bg;

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -8,11 +8,13 @@
 
 // List context color
 @mixin list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border) {
-    .list-item-action.list-item-#{$state} {
-        @include hover-focus {
-            color: $hover-color;
-            background-color: $hover-bg;
-            border-color: $hover-border;
+    @if $enable-list-item-action {
+        .list-item-action.list-item-#{$state} {
+            @include hover-focus {
+                color: $hover-color;
+                background-color: $hover-bg;
+                border-color: $hover-border;
+            }
         }
     }
 

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -242,7 +242,7 @@ $(window).ready(function() {
                         </div>
                         <div class="btn-check">
                             <input id="checkbox6" type="checkbox" class="btn-check-input">
-                            <label for="checkbox6" class="btn btn-outline-info">Check 2</label>
+                            <label for="checkbox6" class="btn btn-outline-danger">Check 2</label>
                         </div>
                         <div class="btn-check">
                             <input id="checkbox7" type="checkbox" class="btn-check-input">
@@ -279,7 +279,7 @@ $(window).ready(function() {
                         </div>
                         <div class="btn-check">
                             <input id="radio1-1" type="radio" name="radio1" class="btn-check-input">
-                            <label for="radio1-1" class="btn btn-outline-info">Radio 2</label>
+                            <label for="radio1-1" class="btn btn-outline-danger">Radio 2</label>
                         </div>
                         <div class="btn-check">
                             <input id="radio1-2" type="radio" name="radio1" class="btn-check-input">


### PR DESCRIPTION
Adding `$enable-*` options for Component Sass generation, along with Sass reference docs:

- [x] Alerts
- [x] Badges
- [x] Breadcrumb
- [x] Button Group
- [x] Cards
- [x] Input Group
- [x] Jumbotron
- [x] Lists
- [x] Media Object
- [x] Navbar
- [x] Navs
- [x] Pagination
- [x] Progress