### PR TITLE
Remove user-select from pseudo element

### DIFF
--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -77,7 +77,6 @@
                 height: $custom-control-indicator-size;
                 pointer-events: none;
                 content: "";
-                user-select: none;
                 background-color: $custom-control-indicator-bg;
                 border: $custom-control-indicator-border-width solid $custom-control-indicator-border-color;
                 @include box-shadow($custom-control-indicator-box-shadow);


### PR DESCRIPTION
Default value is `user-select: none;` when used on `::before` and `::after` pseudo elements.

Reference:
https://developer.mozilla.org/en-US/docs/Web/CSS/user-select