### PR TITLE
Dropdown: additional event properties

### DIFF
--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -673,6 +673,10 @@ Hides the root menu element and disconnect all the event listeners and data from
 
 Event callbacks for the root menu happen on the toggle element. Callbacks for the submenus occur on the submenu's sibling anchor (toggle).
 
+Show and hide, both before and after, events have an added `relatedTarget` property, whose value is the toggling anchor element.
+
+Before and after hide events have a `clickEvent` property (only when the original event type is `click`) that contains an event object for the click event.
+
 <div class="table-scroll">
     <table class="table table-bordered table-striped">
         <thead>

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -73,7 +73,7 @@
         $('[data-cfw="dropdown"]').each(function() {
             var $parent = getParent($(this));
             if (!$parent.hasClass('open')) { return; }
-            $(this).CFW_Dropdown('hideRev');
+            $(this).CFW_Dropdown('hideRev', e);
         });
     };
 
@@ -286,7 +286,11 @@
             var showing = $parent.hasClass('open');
             if (showing) { return; }
 
-            if (!$trigger.CFW_trigger('beforeShow.cfw.dropdown')) {
+            var eventProperties = {
+                relatedTarget: $trigger[0]
+            };
+
+            if (!$trigger.CFW_trigger('beforeShow.cfw.dropdown', eventProperties)) {
                 return;
             }
 
@@ -351,7 +355,7 @@
             //  .children('a').attr('tabIndex', 0);
             this.$target.find('li').redraw();
 
-            $trigger.CFW_trigger('afterShow.cfw.dropdown');
+            $trigger.CFW_trigger('afterShow.cfw.dropdown', eventProperties);
         },
 
         hideMenu : function(e, $trigger, $menu, triggerFocus) {
@@ -363,7 +367,14 @@
             var showing = $parent.hasClass('open');
             if (!showing) { return; }
 
-            if (!$trigger.CFW_trigger('beforeHide.cfw.dropdown')) {
+            var eventProperties = {
+                relatedTarget: $trigger[0]
+            };
+            if (e && e.type === 'click') {
+                eventProperties.clickEvent = e;
+            }
+
+            if (!$trigger.CFW_trigger('beforeHide.cfw.dropdown', eventProperties)) {
                 return;
             }
 
@@ -412,7 +423,7 @@
                 $trigger.trigger('focus');
             }
             $parent.removeClass(this.c.hover);
-            $trigger.CFW_trigger('afterHide.cfw.dropdown');
+            $trigger.CFW_trigger('afterHide.cfw.dropdown', eventProperties);
         },
 
         toggle : function() {
@@ -427,8 +438,8 @@
             this.hideMenu(null, this.$element, this.$target);
         },
 
-        hideRev : function() {
-            this.hideMenu(null, this.$element, this.$target, false);
+        hideRev : function(e) {
+            this.hideMenu(e, this.$element, this.$target, false);
         },
 
         closeUp : function($node) {

--- a/test/js/unit/dropdown.js
+++ b/test/js/unit/dropdown.js
@@ -552,4 +552,129 @@ $(function() {
             which: 27 // Esc
         }));
     });
+
+    QUnit.test('should fire afterShow and afterHidden events with a relatedTarget', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">' +
+            '<button type="button" class="btn" data-cfw="dropdown">Dropdown</button>' +
+            '<ul class="dropdown-menu">' +
+            '<li><a href="#" id="focusable">Menu link</a></li>' +
+            '</ul>' +
+            '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown.parent('.dropdown')
+            .on('afterShow.cfw.dropdown', function(e) {
+                assert.strictEqual(e.relatedTarget, $dropdown[0]);
+                $(document.body).trigger('click');
+            })
+            .on('afterHide.cfw.dropdown', function(e) {
+                assert.strictEqual(e.relatedTarget, $dropdown[0]);
+                done();
+            });
+
+        $dropdown.trigger('click');
+    });
+
+    QUnit.test('submenu toggles should also fire afterShow and afterHidden events with a relatedTarget independent of main toggle', function(assert) {
+        assert.expect(4);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">' +
+            '<button type="button" class="btn" data-cfw="dropdown">Dropdown</button>' +
+            '<ul class="dropdown-menu">' +
+            '<li>' +
+            '<a href="#" id="subtoggle">Menu link</a>' +
+            '<ul>' +
+            '<li><a href="#">Sub-menu link</a></li>' +
+            '</ul>' +
+            '</li>' +
+            '</ul>' +
+            '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+        var $subtoggle = $('#subtoggle');
+
+        $dropdown.parent('.dropdown')
+            .on('afterShow.cfw.dropdown', function(e) {
+                assert.strictEqual(e.relatedTarget, $dropdown[0]);
+                $subtoggle.parent('li')
+                    .on('afterShow.cfw.dropdown', function(e) {
+                        e.stopPropagation();
+                        assert.strictEqual(e.relatedTarget, $subtoggle[0]);
+                        $(document.body).trigger('click');
+                    })
+                    .on('afterHide.cfw.dropdown', function(e) {
+                        e.stopPropagation();
+                        assert.strictEqual(e.relatedTarget, $subtoggle[0]);
+                    });
+
+                $subtoggle.trigger('click');
+            })
+            .on('afterHide.cfw.dropdown', function(e) {
+                assert.strictEqual(e.relatedTarget, $dropdown[0]);
+                done();
+            });
+
+        $dropdown.trigger('click');
+    });
+
+    QUnit.test('should fire beforeHide and afterHide events with a clickEvent if event type is click', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">' +
+            '<button type="button" class="btn" data-cfw="dropdown">Dropdown</button>' +
+            '<ul class="dropdown-menu">' +
+            '<li><a href="#" id="focusable">Menu link</a></li>' +
+            '</ul>' +
+            '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown.parent('.dropdown')
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok(true, 'afterShow was fired');
+                $(document.body).trigger('click');
+            })
+            .on('beforeHide.cfw.dropdown', function(e) {
+                assert.ok(e.clickEvent);
+            })
+            .on('afterHide.cfw.dropdown', function(e) {
+                assert.ok(e.clickEvent);
+                done();
+            });
+
+        $dropdown.trigger('click');
+    });
+
+    QUnit.test('should fire beforeHide and afterHide event without a clickEvent if event type is not click', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var dropdownHTML = '<div class="dropdown">' +
+            '<button type="button" class="btn" data-cfw="dropdown">Dropdown</button>' +
+            '<ul class="dropdown-menu">' +
+            '<li><a href="#" id="focusable">Menu link</a></li>' +
+            '</ul>' +
+            '</div>';
+        var $dropdown = $(dropdownHTML).appendTo('#qunit-fixture').find('[data-cfw="dropdown"]');
+        $dropdown.CFW_Dropdown();
+
+        $dropdown.parent('.dropdown')
+            .on('afterShow.cfw.dropdown', function() {
+                assert.ok(true, 'shown was fired');
+                $dropdown.trigger($.Event('keydown', {
+                    which: 27 // Esc
+                }));
+            })
+            .on('beforeHide.cfw.dropdown', function(e) {
+                assert.notOk(e.clickEvent);
+            })
+            .on('afterHide.cfw.dropdown', function(e) {
+                assert.notOk(e.clickEvent);
+                done();
+            });
+
+        $dropdown.trigger('click');
+    });
 });


### PR DESCRIPTION
Add `relatedTarget` to all non-init event callbacks to track which toggle is being actuated.

Also added `clickEvent` to pass originating click event types through on the before and after hide callbacks.