### PR TITLE
Prevent skip ink for abbreviations

### DIFF
--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -121,18 +121,20 @@ p {
 
 // Abbreviations
 //
-// 1. Remove the bottom border in Firefox 39-.
+// 1. Duplicate behavior to the data-* attribute for our tooltip and popover widgets.
 // 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
 // 3. Add explicit cursor to indicate changed behavior.
-// 4. Duplicate behavior to the data-* attribute for our tooltip and popover widgets.
+// 4. Remove the bottom border in Firefox 39-.
+// 5. Prevent the text-decoration to be skipped.
 // stylelint-disable declaration-block-no-duplicate-properties
 abbr[title],
-abbr[data-cfw-tooltip-original-title],  //4
-abbr[data-cfw-popover-original-title] { //4
+abbr[data-cfw-tooltip-original-title],  // 1
+abbr[data-cfw-popover-original-title] { // 1
     text-decoration: underline; // 2
     text-decoration: underline dotted; // 2
     cursor: help; // 3
-    border-bottom: 0; // 1
+    border-bottom: 0; // 4
+    text-decoration-skip-ink: none; // 5
 }
 // stylelint-enable declaration-block-no-duplicate-properties
 

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -187,7 +187,8 @@ Holder.addTheme("gray", {
 <p><abbr title="abbreviation">abbr</abbr></p>
 <p><abbr title="HyperText Markup Language" class="initialism">HTML</abbr></p>
 <p><abbr title="abbreviation" data-cfw="tooltip">abbr</abbr></p>
-
+<p><abbr title="uppercase">ABCDEFGHIJKLMNOPQRSTUVWXYZ</abbr></p>
+<p><abbr title="lowercase">abcdefghijklmnopqrstuvwxyz</abbr></p>
 <h3>Text - context</h3>
 <p>
     <span class="text-primary">Primary sample text</span><br />


### PR DESCRIPTION
Depending on OS/Browser, some fonts get strange dotted underline behavior. This  makes is more consistent.