### PR TITLE
Dont' generate CSS when delta for hover state is 0

### DIFF
--- a/scss/mixins/_background.scss
+++ b/scss/mixins/_background.scss
@@ -5,9 +5,11 @@
     #{$parent} {
         background-color: $bg !important;
     }
-    a#{$parent} {
-        @include hover-focus() {
-            background-color: palette($bg, 500 + $level-delta) !important;
+    @if $level-delta != 0 {
+        a#{$parent} {
+            @include hover-focus() {
+                background-color: palette($bg, 500 + $level-delta) !important;
+            }
         }
     }
 }
@@ -17,9 +19,11 @@
     #{$parent} {
         background-color: palette($color, $level) !important;
     }
-    a#{$parent} {
-        @include hover-focus() {
-            background-color: palette($color, $level + $level-delta) !important;
+    @if $level-delta != 0 {
+        a#{$parent} {
+            @include hover-focus() {
+                background-color: palette($color, $level + $level-delta) !important;
+            }
         }
     }
 }

--- a/scss/mixins/_text-emphasis.scss
+++ b/scss/mixins/_text-emphasis.scss
@@ -5,9 +5,11 @@
     #{$parent} {
         color: $color !important;
     }
-    a#{$parent} {
-        @include hover-focus() {
-            color: palette($color, 500 + $level-delta) !important;
+    @if $level-delta != 0 {
+        a#{$parent} {
+            @include hover-focus() {
+                color: palette($color, 500 + $level-delta) !important;
+            }
         }
     }
 }
@@ -17,9 +19,11 @@
     #{$parent} {
         color: palette($color, $level) !important;
     }
-    a#{$parent} {
-        @include hover-focus() {
-            color: palette($color, $level + $level-delta) !important;
+    @if $level-delta != 0 {
+        a#{$parent} {
+            @include hover-focus() {
+                color: palette($color, $level + $level-delta) !important;
+            }
         }
     }
 }


### PR DESCRIPTION
Stops the generation of CSS that is not needed if there is no change in hover/focus color state for text and background utilities.