### PR TITLE
Enforce use of border-radius mixins

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -258,7 +258,14 @@
       "fill",
       "stroke"
     ],
-    "property-blacklist": ["transition"],
+    "property-blacklist": [
+      "border-radius",
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius",
+      "transition"
+    ],
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": null,
     "scss/at-function-parentheses-space-before": "never",

--- a/docs/assets/scss/_player.scss
+++ b/docs/assets/scss/_player.scss
@@ -129,7 +129,7 @@
     margin: 0;
     color: #222;
     background-color: #fff;
-    border-radius: .25rem;
+    @include border-radius(.25rem);
 
     .col-md-6 {
         padding-right: 0;
@@ -202,7 +202,7 @@
     margin-bottom: 20px;
     background-color: #f5f5f5;
     border: 1px solid #e3e3e3;
-    border-radius: 4px;
+    @include border-radius(.25rem);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
 }
 .player-transcript-active {
@@ -240,6 +240,7 @@
     pointer-events: none;
     content: "\f144";
     background-color: #000;
+    // stylelint-disable-next-line property-blacklist
     border-radius: 50%;
     opacity: .75;
     transform: translate3d(-50%, -50%, 0);
@@ -290,7 +291,7 @@
     color: #fff;
     text-align: center;
     background-color: rgba(0, 0, 0, .65);
-    border-radius: .25rem;
+    @include border-radius(.25rem);
     transform: translateX(-50%);
 }
 .player-fulldisplay .player-caption-display {

--- a/docs/assets/scss/_responsive-tests.scss
+++ b/docs/assets/scss/_responsive-tests.scss
@@ -44,7 +44,7 @@
     font-weight: $font-weight-bold;
     line-height: 1.1;
     text-align: center;
-    border-radius: .25rem;
+    @include border-radius(.25rem);
 }
 .visible-on,
 .hidden-on {

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -436,7 +436,7 @@ h4 {
     padding: 1rem;
     background-color: #fff;
     border: 1px solid #e1e1e8;
-    border-radius: .25rem .25rem 0 0;
+    @include border-radius($border-radius $border-radius 0 0);
 
     + .cf-clipboard + .highlight {
         border-top: 0;
@@ -461,7 +461,7 @@ h4 {
     color: #393939;
     background-color: #f8f8f8;
     border: 1px solid #e1e1e8;
-    border-radius: .25rem;
+    @include border-radius($border-radius);
 
     // Use SASS interpolation syntax, for passing comment as string
     pre {
@@ -532,7 +532,7 @@ h4 {
     margin: 1rem 0;
     border: $border-width solid $uibase-300;
     border-left-width: .5rem;
-    border-radius: $border-radius;
+    @include border-radius($border-radius);
 
     .h3,
     .h4,
@@ -610,7 +610,7 @@ $callout-themes: _mix-context-colors($callout-colors, $level-context);
         text-decoration: none;
         white-space: nowrap;
         background: #424242;
-        border-radius: .5rem .5rem 0 0;
+        @include border-radius(.5rem .5rem 0 0);
 
         @include hover-focus() {
             color: #fff;

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -68,29 +68,31 @@
             }
 
             // Reset rounded corners
-            %btn-group-btn-not-last-radius {
-                @include border-end-radius(0);
-            }
-            > .btn:not(:last-child):not(.btn-group-end),
-            > .btn-group:not(:last-child) > .btn {
-                @extend %btn-group-btn-not-last-radius;
-            }
-            @if $enable-btn-check {
-                > .btn-check:not(:last-child) > .btn {
+            @if $enable-rounded {
+                %btn-group-btn-not-last-radius {
+                    @include border-end-radius(0);
+                }
+                > .btn:not(:last-child):not(.btn-group-end),
+                > .btn-group:not(:last-child) > .btn {
                     @extend %btn-group-btn-not-last-radius;
                 }
-            }
+                @if $enable-btn-check {
+                    > .btn-check:not(:last-child) > .btn {
+                        @extend %btn-group-btn-not-last-radius;
+                    }
+                }
 
-            %btn-group-btn-not-first-radius {
-                @include border-start-radius(0);
-            }
-            > .btn:not(:first-child),
-            > .btn-group:not(:first-child) > .btn {
-                @extend %btn-group-btn-not-first-radius;
-            }
-            @if $enable-btn-check {
-                > .btn-check:not(:first-child) > .btn {
+                %btn-group-btn-not-first-radius {
+                    @include border-start-radius(0);
+                }
+                > .btn:not(:first-child),
+                > .btn-group:not(:first-child) > .btn {
                     @extend %btn-group-btn-not-first-radius;
+                }
+                @if $enable-btn-check {
+                    > .btn-check:not(:first-child) > .btn {
+                        @extend %btn-group-btn-not-first-radius;
+                    }
                 }
             }
         }
@@ -157,29 +159,31 @@
             }
 
             // Reset rounded corners
-            %btn-group-vertical-btn-not-last-radius {
-                @include border-bottom-radius(0);
-            }
-            > .btn:not(:last-child):not(.btn-group-end),
-            > .btn-group:not(:last-child) > .btn {
-                @extend %btn-group-vertical-btn-not-last-radius;
-            }
-            @if $enable-btn-check {
-                > .btn-check:not(:last-child) > .btn {
+            @if $enable-rounded {
+                %btn-group-vertical-btn-not-last-radius {
+                    @include border-bottom-radius(0);
+                }
+                > .btn:not(:last-child):not(.btn-group-end),
+                > .btn-group:not(:last-child) > .btn {
                     @extend %btn-group-vertical-btn-not-last-radius;
                 }
-            }
+                @if $enable-btn-check {
+                    > .btn-check:not(:last-child) > .btn {
+                        @extend %btn-group-vertical-btn-not-last-radius;
+                    }
+                }
 
-            %btn-group-vertical-btn-not-first-radius {
-                @include border-top-radius(0);
-            }
-            > .btn:not(:first-child),
-            > .btn-group:not(:first-child) > .btn {
-                @extend %btn-group-vertical-btn-not-first-radius;
-            }
-            @if $enable-btn-check {
-                > .btn-check:not(:first-child) > .btn {
+                %btn-group-vertical-btn-not-first-radius {
+                    @include border-top-radius(0);
+                }
+                > .btn:not(:first-child),
+                > .btn-group:not(:first-child) > .btn {
                     @extend %btn-group-vertical-btn-not-first-radius;
+                }
+                @if $enable-btn-check {
+                    > .btn-check:not(:first-child) > .btn {
+                        @extend %btn-group-vertical-btn-not-first-radius;
+                    }
                 }
             }
         }

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -58,9 +58,7 @@
                 @include border-top-radius($card-inner-border-radius);
 
                 > .list-item:first-child {
-                    @if $enable-rounded {
-                        @include border-top-radius($card-inner-border-radius);
-                    }
+                    @include border-top-radius($card-inner-border-radius);
                 }
             }
 
@@ -69,9 +67,7 @@
                 @include border-bottom-radius($card-inner-border-radius);
 
                 > .list-item:last-child {
-                    @if $enable-rounded {
-                        @include border-bottom-radius($card-inner-border-radius);
-                    }
+                    @include border-bottom-radius($card-inner-border-radius);
                 }
             }
         }

--- a/scss/core/_code.scss
+++ b/scss/core/_code.scss
@@ -42,7 +42,7 @@
                 font-size: inherit;
                 color: inherit;
                 background-color: transparent;
-                border-radius: 0;
+                @include border-radius(0);
             }
         }
     }

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -130,6 +130,7 @@
         @if $enable-custom-radio {
             .custom-radio {
                 .custom-control-indicator::before {
+                    // stylelint-disable-next-line property-blacklist
                     border-radius: $custom-radio-radius;
                 }
 
@@ -167,7 +168,8 @@
                         height: $custom-switch-thumb-height;
                         background-color: $custom-switch-thumb-bg;
                         border: $custom-switch-thumb-border-width solid $custom-switch-thumb-border-color;
-                        @include border-radius($custom-switch-thumb-radius);
+                        // stylelint-disable-next-line property-blacklist
+                        border-radius: $custom-switch-thumb-radius;
                         @include box-shadow($custom-switch-thumb-box-shadow);
                     }
 
@@ -178,7 +180,8 @@
                         height: $custom-switch-track-height;
                         background-color: $custom-switch-track-bg;
                         border: $custom-switch-track-border-width solid $custom-switch-track-border-color;
-                        @include border-radius($custom-switch-track-radius);
+                        // stylelint-disable-next-line property-blacklist
+                        border-radius: $custom-switch-track-radius;
                         @include box-shadow($custom-switch-track-box-shadow);
                     }
                 }
@@ -248,11 +251,8 @@
             background: $input-bg $custom-select-indicator-image no-repeat right $custom-select-indicator-offset center;
             background-size: $custom-select-indicator-width $custom-select-indicator-height;
             border: $input-border-width solid $input-border-color;
-            @if $enable-rounded {
-                border-radius: $input-border-radius;
-            } @else {
-                border-radius: 0;
-            }
+            // Provide a fallback to override to the browser default
+            @include border-radius($input-border-radius, 0);
             @include box-shadow($input-box-shadow);
             appearance: none;
             @include transition($input-transition);

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -22,13 +22,8 @@ $input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2
             border: $input-border-width solid $input-border-color;
 
             // Note: This has no effect on <select>s in some browsers, due to the limited stylability of `<select>`s in CSS.
-            @if $enable-rounded {
-                // Manually use the if/else instead of the mixin to account for iOS override
-                border-radius: $input-border-radius;
-            } @else {
-                // Otherwise undo the iOS default
-                border-radius: 0;
-            }
+            // Provide a fallback to override to the iOS default
+            @include border-radius($input-border-radius, 0);
 
             @include box-shadow($input-box-shadow);
             @include transition($input-transition);

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -299,6 +299,7 @@ label {
 // Remove the default `border-radius` that macOS Chrome adds.
 // Details at https://github.com/twbs/bootstrap/issues/24093
 button {
+    // stylelint-disable-next-line property-blacklist
     border-radius: 0;
 }
 

--- a/scss/mixins/_border.scss
+++ b/scss/mixins/_border.scss
@@ -1,7 +1,12 @@
+// stylelint-disable property-blacklist
+
 // All
-@mixin border-radius($radius: $border-radius) {
+@mixin border-radius($radius: $border-radius, $fallback-radius: false) {
     @if $enable-rounded {
         border-radius: $radius;
+    }
+    @else if $fallback-radius != false {
+        border-radius: $fallback-radius;
     }
 }
 
@@ -66,19 +71,23 @@
     $sizerule: if($size, -#{$size}, "");
 
     .radius#{$sizerule} {
-        @include border-radius($radius);
+        border-radius: $radius;
     }
     .radius-t#{$sizerule} {
-        @include border-top-radius($radius);
+        border-top-left-radius: $radius;
+        border-top-right-radius: $radius;
     }
     .radius-e#{$sizerule} {
-        @include border-end-radius($radius);
+        border-top-right-radius: $radius;
+        border-bottom-right-radius: $radius;
     }
     .radius-b#{$sizerule} {
-        @include border-bottom-radius($radius);
+        border-bottom-right-radius: $radius;
+        border-bottom-left-radius: $radius;
     }
     .radius-s#{$sizerule} {
-        @include border-start-radius($radius);
+        border-top-left-radius: $radius;
+        border-bottom-left-radius: $radius;
     }
 }
 
@@ -88,15 +97,15 @@
     $sizerule: if($size, -#{$size}, "");
 
     .radius-te#{$sizerule} {
-        @include border-top-end-radius($radius);
+        border-top-right-radius: $radius;
     }
     .radius-ts#{$sizerule} {
-        @include border-top-start-radius($radius);
+        border-top-left-radius: $radius;
     }
     .radius-be#{$sizerule} {
-        @include border-bottom-end-radius($radius);
+        border-bottom-right-radius: $radius;
     }
     .radius-bs#{$sizerule} {
-        @include border-bottom-start-radius($radius);
+        border-bottom-left-radius: $radius;
     }
 }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -121,10 +121,6 @@
     padding: $padding-y $padding-x;
     @include font-size($font-size);
     line-height: $line-height;
-    // Manually declare to provide an override to the browser default
-    @if $enable-rounded {
-        border-radius: $border-radius;
-    } @else {
-        border-radius: 0;
-    }
+    // Provide a fallback to override to the browser default
+    @include border-radius($border-radius, 0);
 }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -23,7 +23,7 @@
             @include font-size($tooltip-font-size);
             color: color-auto-contrast($color);
             background-color: rgba($color, $tooltip-opacity);
-            border-radius: $tooltip-border-radius;
+            @include border-radius($tooltip-border-radius);
         }
     }
 

--- a/scss/utilities/_border.scss
+++ b/scss/utilities/_border.scss
@@ -1,4 +1,4 @@
-// stylelint-disable declaration-no-important
+// stylelint-disable declaration-no-important, property-blacklist
 
 @if $enable-utility-border {
     // Perfect circle


### PR DESCRIPTION
- Enforce use of border-radius mixins.
- Fix some issues when `$enable-radius` is set to `false`:
  - Make sure radius utils are generated
  - Fix gen error with button group resets