### PR TITLE
Ascending sort for `$grid-breakpoints` and `$container-max-widths` maps

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -217,6 +217,10 @@ $grid-breakpoints: map-merge(
     ),
     $grid-breakpoints
 );
+
+// stylelint-disable-next-line scss/dollar-variable-default
+$grid-breakpoints: map-sort-by-values($grid-breakpoints);
+
 @include _assert-ascending($grid-breakpoints, "$grid-breakpoints");
 @include _assert-starts-at-zero($grid-breakpoints, "$grid-breakpoints");
 
@@ -256,6 +260,10 @@ $container-max-widths: map-merge(
     ),
     $container-max-widths
 );
+
+// stylelint-disable-next-line scss/dollar-variable-default
+$container-max-widths: map-sort-by-values($container-max-widths);
+
 @include _assert-ascending($container-max-widths, "$container-max-widths");
 
 

--- a/scss/functions/_map-util.scss
+++ b/scss/functions/_map-util.scss
@@ -12,3 +12,55 @@
     }
     @return $map;
 }
+
+// Sorts a map ascending by values
+// @author https://github.com/iamandrewluca
+// From: https://gist.github.com/Jakobud/a0ac11e80a1de453cd86f0d3fc0a1410#gistcomment-2327765
+// Used for grid-breakpoints and container-max-widths sorting
+//
+// @param {Map} $map - Initial map
+// @return {Map} - Sorted map
+@function map-sort-by-values($map) {
+    // Transform map to zipped list
+    $keys: ();
+    $values: ();
+
+    @each $key, $val in $map {
+        $keys: append($keys, $key);
+        $values: append($values, $val);
+    }
+
+    $list: zip($keys, $values);
+
+    // Sort zipped list and create sorted map
+    $sortedMap: ();
+    @while length($list) > 0 {
+
+        // Find smallest pair
+        $smallestPair: nth($list, 1);
+        @each $pair in $list {
+            $value: nth($pair, 2);
+            $smallestValue: nth($smallestPair, 2);
+            @if $value < $smallestValue {
+                $smallestPair: $pair;
+            }
+        }
+
+        // Add smallest pair to sorted map
+        $key: nth($smallestPair, 1);
+        $value: nth($smallestPair, 2);
+        $sortedMap: map-merge($sortedMap, ($key: $value));
+
+        // Remove from list smallest pair
+        $newList: ();
+        $smallestPairIndex: index($list, $smallestPair);
+        @for $i from 1 through length($list) {
+            @if $i != $smallestPairIndex {
+                $newList: append($newList, nth($list, $i), "space");
+            }
+        }
+        $list: $newList;
+    }
+
+    @return $sortedMap;
+}


### PR DESCRIPTION
Reasoning: 
When extending `$grid-breakpoints` and `$container-max-widths` be sure that they are sorted ascending, added a new function that sorts maps by their values. 

Notes:
- The `_assert-ascending()` call may be obsolete if maps are being sorted.
- If a user extends mentioned vars after `settings` import, `map-sort-by-values` should be called again to be sure they are sorted.  