### PR TITLE
Stylelint: Blacklist the `font size` property

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -264,6 +264,7 @@
       "border-top-right-radius",
       "border-bottom-right-radius",
       "border-bottom-left-radius",
+      "font-size",
       "transition"
     ],
     "property-no-vendor-prefix": true,

--- a/scss/mixins/_font-size.scss
+++ b/scss/mixins/_font-size.scss
@@ -1,3 +1,5 @@
+// stylelint-disable property-blacklist
+
 // Make sure only one responsive typography method is enabled.
 @if $enable-rfs-fluid and $enable-rfs-scale {
     @error "More than one Responsive Typography (font-size) method has been selected. Please update your settings to only use one of the available Repsonsive Typography methods.";


### PR DESCRIPTION
The `font-size` property should be fed through the responsive font size mixin.