### PR TITLE
Component sizing- Convert to using `em` units

### DIFF
--- a/docs/content/buttons.md
+++ b/docs/content/buttons.md
@@ -426,7 +426,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
             <tr>
                 <td><code>$btn-padding-y</code></td>
                 <td>string</td>
-                <td><code>.25rem</code></td>
+                <td><code>.25em</code></td>
                 <td>
                     Base button vertical padding.
                 </td>
@@ -434,7 +434,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
             <tr>
                 <td><code>$btn-padding-x</code></td>
                 <td>string</td>
-                <td><code>.75rem</code></td>
+                <td><code>.75em</code></td>
                 <td>
                     Base button horizontal padding.
                 </td>
@@ -562,7 +562,7 @@ The available [Customization options]({{ site.baseurl }}/get-started/options/), 
             <tr>
                 <td><code>$btn-icon-multiplier</code></td>
                 <td>string</td>
-                <td><code>.625</code></td>
+                <td><code>.5</code></td>
                 <td>
                     Multiplier for horizontal padding of icon button variants.
                 </td>

--- a/docs/get-started/options.md
+++ b/docs/get-started/options.md
@@ -185,45 +185,72 @@ There are additional options in our `_settings_options.scss` that can be used to
 
 ## Component Sizes
 
-The button, button group, pagination, form-control and input-group components all use the same base sizing settings for consitency.
+The button, button group, pagination, form-control and input-group components all use the same base sizing settings for consistency.
 
 By using a map, we can be sure the components are all the same height when horizontally aligned.
 
-{% capture callout %}
-`<select>` Sizing Caveat
-{:.h5 .no_toc}
+You can modify, remove, or add additional sizes, beyond the default sizing, by redefining the `$component-sizes` map.  The `null` values will use the component's default line-height and `em` padding for the that particular size variant.
 
-Currently there is a minor issue with vertical sizing and `<select>` elements with Internet Explorer.  IE will render `<select>` elements slightly shorter in vertical height than other browsers.
-
-This has not undergone stringent testing on mobile devices yet.
-{% endcapture %}
-{% include callout.html content=callout type="info" %}
-
-You can modify, remove, or add additional sizes, beyond the default sizing, by redefining the `$component-sizes` variable and
-Below is the default additional settings for reference.  Try not to confuse the size designations (`sm`, `lg`, etc.) with the grid breakpoints designations.
+Below is the default additional settings for reference.
 
 {% highlight scss %}
 // Used for button, button groups, pagination, form-control, and input-group
 $component-sizes: (
-    xs: (
+    "xsmall": (
+        "padding-y":     null,
+        "padding-x":     null,
+        "font-size":     ($font-size-base * .75),
+        "line-height":   null,
+        "border-radius": .1875rem
+    ),
+    "small": (
+        "padding-y":     null,
+        "padding-x":     null,
+        "font-size":     ($font-size-base * .875),
+        "line-height":   null,
+        "border-radius": .1875rem
+    ),
+    "large": (
+        "padding-y":     null,
+        "padding-x":     null,
+        "font-size":     ($font-size-base * 1.125),
+        "line-height":   null,
+        "border-radius": .3125rem
+    ),
+    "xlarge": (
+        "padding-y":     null,
+        "padding-x":     null,
+        "font-size":     ($font-size-base * 1.25),
+        "line-height":   null,
+        "border-radius": .3125rem
+    )
+);
+{% endhighlight %}
+
+If you wish to have more concise control over components, you can always force the sizing values to fit your needs.
+
+{% highlight scss %}
+// Used for button, button groups, pagination, form-control, and input-group
+$component-sizes: (
+    xsmall: (
         font-size:      .75rem,
         padding-y:      .1875rem,
         padding-x:      .375rem,
         border-radius:  .1875rem
     ),
-    sm: (
+    small: (
         font-size:      .875rem,
         padding-y:      .25rem,
         padding-x:      .5rem,
         border-radius:  .1875rem
    ),
-    lg: (
+    large: (
         font-size:      1.25rem,
         padding-y:      .625rem,
         padding-x:      1.25rem,
         border-radius:  .3125rem
     ),
-    xl: (
+    xlarge: (
         font-size:      1.5rem,
         padding-y:      .75rem,
         padding-x:      1.5rem,

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -467,31 +467,31 @@ $component-sizes: () !default;
 $component-sizes: map-merge(
     (
         "xsmall": (
-            "padding-y":     .125rem,
-            "padding-x":     .375rem,
+            "padding-y":     null,
+            "padding-x":     null,
             "font-size":     ($font-size-base * .75),
-            "line-height":   1.5,
+            "line-height":   null,
             "border-radius": .1875rem
         ),
         "small": (
-            "padding-y":     .1875rem,
-            "padding-x":     .5rem,
+            "padding-y":     null,
+            "padding-x":     null,
             "font-size":     ($font-size-base * .875),
-            "line-height":   1.5,
+            "line-height":   null,
             "border-radius": .1875rem
         ),
         "large": (
-            "padding-y":     .3125rem,
-            "padding-x":     1.125rem,
+            "padding-y":     null,
+            "padding-x":     null,
             "font-size":     ($font-size-base * 1.125),
-            "line-height":    1.5,
+            "line-height":   null,
             "border-radius": .3125rem
         ),
         "xlarge": (
-            "padding-y":     .375rem,
-            "padding-x":     1.25rem,
+            "padding-y":     null,
+            "padding-x":     null,
             "font-size":     ($font-size-base * 1.25),
-            "line-height":    1.5,
+            "line-height":   null,
             "border-radius": .3125rem
         )
     ),
@@ -667,8 +667,8 @@ $table-hover-alt-box-shadow:    inset 0 0 0 999rem rgba($white, .2) !default;
 
 // Buttons
 // =====
-$btn-padding-y:             .25rem !default;
-$btn-padding-x:             .75rem !default;
+$btn-padding-y:             .25em !default;
+$btn-padding-x:             .75em !default;
 $btn-font-family:           null !default;
 $btn-font-size:             $font-size-base !default;
 $btn-font-weight:           $font-weight-normal !default;
@@ -687,7 +687,7 @@ $btn-outline-bg:            transparent !default;
 $btn-disabled-opacity:      .6 !default;
 
 $btn-block-spacing-y:       .25rem !default;
-$btn-icon-multiplier:       .625 !default;
+$btn-icon-multiplier:       .5 !default;
 
 $btn-default-bg:                    $white !default;
 $btn-default-color:                 color-if-contrast($uibase-500, $btn-default-bg) !default;

--- a/scss/component/_button-group.scss
+++ b/scss/component/_button-group.scss
@@ -113,7 +113,7 @@
                 }
                 @if $enable-btn-icon {
                     .btn-group-#{$size} > .btn-icon {
-                        @extend %btn-icon-#{$size};
+                        @extend %btn-icon-#{$size} !optional;
                     }
                 }
             }

--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -160,7 +160,7 @@
                 }
                 @if $enable-btn-icon {
                     .input-group-#{$size} > .input-group-addon > .btn-icon {
-                        @extend %btn-icon-#{$size};
+                        @extend %btn-icon-#{$size} !optional;
                     }
                 }
             }

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -212,8 +212,10 @@
             }
 
             %btn-icon-#{$size} {
-                padding-right: $sz-padding-x * $btn-icon-multiplier;
-                padding-left: $sz-padding-x * $btn-icon-multiplier;
+                @if $sz-padding-x != null {
+                    padding-right: $sz-padding-x * $btn-icon-multiplier;
+                    padding-left: $sz-padding-x * $btn-icon-multiplier;
+                }
             }
 
             .btn-#{$size} {
@@ -223,7 +225,7 @@
 
                 &.btn-icon {
                     @if $enable-btn-icon and $enable-btn-icon-sizing {
-                        @extend %btn-icon-#{$size};
+                        @extend %btn-icon-#{$size} !optional;
                     }
                 }
             }

--- a/scss/core/_custom-forms.scss
+++ b/scss/core/_custom-forms.scss
@@ -241,7 +241,7 @@
         .custom-select {
             display: block;
             width: 100%;
-            height: $input-height-outer;
+            height: calc-input-height-outer($input-padding-y, $input-line-height);
             padding: $input-padding-y calc(#{$input-padding-x} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset}) $input-padding-y $input-padding-x;
             @include font-size($input-font-size);
             font-family: $input-font-family;
@@ -297,15 +297,19 @@
             $sz-padding-y:     map-get($dims, "padding-y");
             $sz-padding-x:     map-get($dims, "padding-x");
             $sz-border-radius: map-get($dims, "border-radius");
-            $sz-inner-height:  ((1em * #{$sz-line-height}) + (#{$sz-padding-y * 2}));
-            $sz-outer-height:  calc(#{$sz-inner-height} + #{($border-width * 2)});
 
             @if $enable-custom-select and $enable-custom-select-sizing {
                 // stylelint-disable declaration-block-no-duplicate-properties
                 .custom-select-#{$size} {
-                    height: $sz-outer-height;
-                    padding: $sz-padding-y $sz-padding-x;
-                    padding-right: calc(#{$sz-padding-x} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                    height: calc-input-height-outer($sz-padding-y, $sz-line-height);
+                    @if $sz-padding-y != null and $sz-padding-x != null {
+                        $my-padding-y: if($sz-padding-y != null, $sz-padding-y, $input-padding-y);
+                        $my-padding-x: if($sz-padding-x != null, $sz-padding-x, $input-padding-x);
+                        padding: $my-padding-y $my-padding-x;
+                    }
+                    @if $sz-padding-x != null {
+                        padding-right: calc(#{$sz-padding-x} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                    }
                     @include font-size($sz-font-size);
                     line-height: $sz-line-height;
                     @include border-radius($sz-border-radius);
@@ -322,7 +326,7 @@
             position: relative;
             display: inline-block;
             width: 100%;
-            height: $input-height-outer;
+            height: calc-input-height-outer($input-padding-y, $input-line-height);
             margin-bottom: 0;
         }
 
@@ -330,7 +334,7 @@
             position: relative;
             z-index: 2;
             width: 100%;
-            height: $input-height-outer;
+            height: calc-input-height-outer($input-padding-y, $input-line-height);
             margin: 0;
             opacity: 0;
 
@@ -378,7 +382,7 @@
             right: 0;
             left: 0;
             z-index: 1;
-            height: $input-height-outer;
+            height: calc-input-height-outer($input-padding-y, $input-line-height);
             padding: $input-padding-y $input-padding-x;
             overflow: hidden;
             font-family: $input-font-family;
@@ -398,7 +402,7 @@
                 right: 0;
                 z-index: 2;
                 display: block;
-                height: $input-height-outer;
+                height: calc-input-height-outer($input-padding-y, $input-line-height);
                 padding: $input-padding-y $input-padding-x;
                 font-family: $btn-font-family;
                 line-height: $input-line-height;
@@ -417,8 +421,8 @@
         .custom-color {
             display: block;
             width: auto;
-            min-width: $input-height-inner;
-            height: $input-height-inner;
+            min-width: calc-input-height-inner($input-padding-y, $input-line-height);
+            height: calc-input-height-inner($input-padding-y, $input-line-height);
             @include font-size($input-font-size);
             line-height: $input-line-height;
             color: $input-color;

--- a/scss/core/_forms.scss
+++ b/scss/core/_forms.scss
@@ -1,18 +1,12 @@
 // stylelint-disable selector-no-qualifying-type
 
-// Base input/select height calculation
-// Additional ones for each size are done during size processing generation
-$input-height-inner:    (1em * #{$input-line-height}) + (#{$input-padding-y * 2}) !default;
-$input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2)}) !default;
-
 @if $enable-form {
     // Textual form controls
     @if $enable-form-control {
         .form-control {
             display: block;
             width: 100%;
-            // Make inputs the height of their button counterpart (line-height + padding + border)
-            height: $input-height-outer;
+            height: calc-input-height-outer($input-padding-y, $input-line-height);
             padding: $input-padding-y $input-padding-x;
             font-family: $input-font-family;
             @include font-size($input-font-size);
@@ -137,12 +131,14 @@ $input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2
             $sz-padding-y:     map-get($dims, "padding-y");
             $sz-padding-x:     map-get($dims, "padding-x");
             $sz-border-radius: map-get($dims, "border-radius");
-            $sz-inner-height:  ((1em * #{$sz-line-height}) + (#{$sz-padding-y * 2}));
-            $sz-outer-height:  calc(#{$sz-inner-height} + #{($input-border-width * 2)});
 
             %form-control-#{$size} {
-                height: $sz-outer-height;
-                padding: $sz-padding-y $sz-padding-x;
+                height: calc-input-height-outer($sz-padding-y, $sz-line-height);
+                @if $sz-padding-y != null and $sz-padding-x != null {
+                    $my-padding-y: if($sz-padding-y != null, $sz-padding-y, $input-padding-y);
+                    $my-padding-x: if($sz-padding-x != null, $sz-padding-x, $input-padding-x);
+                    padding: $my-padding-y $my-padding-x;
+                }
                 @include font-size($sz-font-size);
                 line-height: $sz-line-height;
                 @include border-radius($sz-border-radius);
@@ -155,8 +151,10 @@ $input-height-outer:    calc(#{$input-height-inner} + #{($input-border-width * 2
             }
 
             %form-control-label-#{$size} {
-                padding-top: calc(#{$sz-padding-y} + #{$input-border-width});
-                padding-bottom: calc(#{$sz-padding-y} + #{$input-border-width});
+                @if $sz-padding-y != null {
+                    padding-top: calc(#{$sz-padding-y} + #{$input-border-width});
+                    padding-bottom: calc(#{$sz-padding-y} + #{$input-border-width});
+                }
                 @include font-size($sz-font-size);
                 line-height: $sz-line-height;
             }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -116,7 +116,15 @@
 
 // Button sizes
 @mixin button-size($padding-y, $padding-x, $font-size, $line-height, $border-radius) {
-    padding: $padding-y $padding-x;
+    @if $padding-y == null and $padding-x == null {
+        // No padding output
+    } @else if $padding-y == null or $padding-x == null {
+        $padding-y: if($padding-y != null, $padding-y, $btn-padding-y);
+        $padding-x: if($padding-x != null, $padding-x, $btn-padding-x);
+        padding: $padding-y $padding-x;
+    } @else {
+        padding: $padding-y $padding-x;
+    }
     @include font-size($font-size);
     line-height: $line-height;
     // Provide a fallback to override to the browser default

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -1,3 +1,31 @@
+// Calculate input height
+// Make inputs the height of their button counterpart (line-height + padding + border)
+@function calc-input-height-inner($padding-y, $line-height) {
+    @if $padding-y == null and $line-height == null {
+        @return null;
+    }
+    $height-font:    1em * if($line-height != null, $line-height, $input-line-height);
+    $height-padding: 2 * if($padding-y != null, $padding-y, $input-padding-y);
+
+    $height-inner: #{$height-font} unquote("+") #{$height-padding};
+
+    @return calc(#{$height-inner});
+}
+
+@function calc-input-height-outer($padding-y, $line-height) {
+    @if $padding-y == null and $line-height == null {
+        @return null;
+    }
+    $height-font:    1em * if($line-height != null, $line-height, $input-line-height);
+    $height-padding: 2 * if($padding-y != null, $padding-y, $input-padding-y);
+    $height-border:  $input-border-width * 2;
+
+    $height-inner: #{$height-font} unquote("+") #{$height-padding};
+    $height-outer: #{$height-inner} unquote("+") #{$height-border};
+
+    @return calc(#{$height-outer});
+}
+
 // Form validation states
 // Generate the form validation CSS for valid and invalid states.
 @mixin form-validation-state($state, $color, $icon) {
@@ -188,32 +216,34 @@
         @each $size, $dims in $input-sizes {
             $sz-padding-x:     map-get($dims, "padding-x");
 
-            @if $enable-validation-icons {
-                @if $enable-form-control {
-                    .form-control-#{$size}:not(textarea),
-                    .input-group-#{$size} > .form-control:not(textarea) {
-                        .was-validated &.has-validation-icon:#{$state},
-                        &.has-validation-icon.is-#{$state} {
-                            padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+            @if $sz-padding-x != null {
+                @if $enable-validation-icons {
+                    @if $enable-form-control {
+                        .form-control-#{$size}:not(textarea),
+                        .input-group-#{$size} > .form-control:not(textarea) {
+                            .was-validated &.has-validation-icon:#{$state},
+                            &.has-validation-icon.is-#{$state} {
+                                padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+                            }
+                        }
+
+                        // stylelint-disable-next-line selector-no-qualifying-type
+                        textarea.form-control-#{$size},
+                        .input-group-#{$size} > textarea.form-control {
+                            .was-validated &.has-validation-icon:#{$state},
+                            &.has-validation-icon.is-#{$state} {
+                                padding-left: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
+                            }
                         }
                     }
 
-                    // stylelint-disable-next-line selector-no-qualifying-type
-                    textarea.form-control-#{$size},
-                    .input-group-#{$size} > textarea.form-control {
-                        .was-validated &.has-validation-icon:#{$state},
-                        &.has-validation-icon.is-#{$state} {
-                            padding-left: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset});
-                        }
-                    }
-                }
-
-                @if $enable-custom-select {
-                    .custom-select-#{$size},
-                    .input-group-#{$size} > .custom-select {
-                        .was-validated &.has-validation-icon:#{$state},
-                        &.has-validation-icon.is-#{$state} {
-                            padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                    @if $enable-custom-select {
+                        .custom-select-#{$size},
+                        .input-group-#{$size} > .custom-select {
+                            .was-validated &.has-validation-icon:#{$state},
+                            &.has-validation-icon.is-#{$state} {
+                                padding-right: calc(#{$sz-padding-x} + #{$form-feedback-icon-width} + #{$form-feedback-icon-offset} + #{$custom-select-indicator-width} + #{$custom-select-indicator-offset});
+                            }
                         }
                     }
                 }

--- a/scss/mixins/_pagination.scss
+++ b/scss/mixins/_pagination.scss
@@ -2,7 +2,15 @@
 @mixin pagination-size($padding-y, $padding-x, $font-size, $line-height, $border-radius) {
     .page-text,
     .page-link {
-        padding: $padding-y $padding-x;
+        @if $padding-y == null and $padding-x == null {
+            // No padding output
+        } @else if $padding-y == null or $padding-x == null {
+            $padding-y: if($padding-y != null, $padding-y, $pagination-padding-y);
+            $padding-x: if($padding-x != null, $padding-x, $pagination-padding-x);
+            padding: $padding-y $padding-x;
+        } @else {
+            padding: $padding-y $padding-x;
+        }
         @include font-size($font-size);
         line-height: $line-height;
         @include border-radius($border-radius);


### PR DESCRIPTION
Use `em` sizing for buttons, input, button groups, and input groups.  This cuts out a fair bit of generated CSS just to handle sizing.

Additional logic has been added so that we can handle both the legacy case of specific sizing settings, such as padding and line-height, where they are specifically defined per size, or the new case where `null` is defined so the new `em` defaults will pass through.  This also means we can override just one size  with legacy fallbacks if needed.