### PR TITLE
Input group: Simpllify `.form-file-label` border radius reset

### DIFF
--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -54,10 +54,8 @@
                 display: flex;
                 align-items: center;
 
-                &:not(:last-child) .form-file-label,
-                &:not(:last-child) .form-file-button { @include border-end-radius(0); }
-                &:not(:first-child) .form-file-label,
-                &:not(:first-child) .form-file-text { @include border-start-radius(0); }
+                &:not(:last-child) .form-file-label { @include border-end-radius(0); }
+                &:not(:first-child) .form-file-label { @include border-start-radius(0); }
             }
         }
     }


### PR DESCRIPTION
Border radius for `.form-file-text` and `.form-file-button` are inherited.  No need for explicit reset.