### PR TITLE
Adjust `.sr-only-*` with !important, update focusable variants

### DIFF
--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -4,7 +4,7 @@
 {% include head.html %}
 </head>
 <body>
-    <a class="skipnav" href="#content">Skip to main content</a>
+    <a class="skipnav sr-only-focusable" href="#content">Skip to main content</a>
 
     {% include nav-main.html %}
 

--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -4,7 +4,7 @@
 {% include head.html %}
 </head>
 <body>
-    <a class="skipnav" href="#content">Skip to main content</a>
+    <a class="skipnav sr-only-focusable" href="#content">Skip to main content</a>
 
     {% include nav-main.html %}
 

--- a/docs/assets/scss/docs.scss
+++ b/docs/assets/scss/docs.scss
@@ -11,24 +11,19 @@ $docs-color: #246;
 // Skipnav
 .skipnav {
     position: absolute;
-    top: -100px;
+    top: .5rem;
+    left: 50%;
     z-index: 1200;
     display: block;
     width: 12em;
     max-width: 100%;
+    margin-left: -6em;
     @include font-size(1rem);
     font-weight: $font-weight-bold;
     color: $black;
     text-align: center;
     background: $uibase-50;
     border: 2px solid $uibase-700;
-
-    &:focus {
-        top: .5rem;
-        left: 50%;
-        margin-left: -6em;
-        color: $black;
-    }
 }
 
 .v4-warning {

--- a/docs/get-started/accessibility.md
+++ b/docs/get-started/accessibility.md
@@ -20,6 +20,8 @@ It is possible to create projects that meet the [<abbr title="Web Content Access
 
 ## Skip Navigation
 
+For visually hidden interactive controls, such as traditional "skip" links, use the `.sr-only-focusable` class. This will ensure that the control becomes visible once focused (for sighted keyboard users). **Do not use the `.sr-only-focusable` class in combination with the `.sr-only` class.**
+
 If your navigation contains many links and comes before the main content in the DOM, add a `Skip to main content` link before the navigation (for a simple explanation, see this [A11Y Project article on skip navigation links](https://a11yproject.com/posts/skip-nav-links/)). Using the `.sr-only` class will visually hide the skip link, and the <code>.sr-only-focusable</code> class will ensure that the link becomes visible once focused (for sighted keyboard users).
 
 {% capture callout %}
@@ -33,7 +35,7 @@ Note that this bug will also affect any other in-page links your site may be usi
 
 {% highlight html %}
 <body>
-  <a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
+  <a href="#content" class="sr-only-focusable">Skip to main content</a>
   ...
   <div class="container" id="content" tabindex="-1">
     <!-- The main page content -->

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,6 +18,9 @@ Some changes will most likely have been missed, so please refer to the documenta
 ## Browser Support
 - **Support for Internet Explorer 10 has been dropped!** IE 10 is getting old, and the market share is less than 0.1% in terms of global usage according to many trackers.  Plus our use of MutationObservers in the Widgets either needs a polyfill, or things just don't work right.
 
+## Accessibility
+- `.sr-only-focusable` does not require `.sr-only` anymore, and elements should not use a combination of the two classes.
+
 ## Color
 - Reworked the colors, internal palette system, and consolidated the re-used component colors.
 - Added functions to check, and/or determine the best color, these can be found in `/scss/functions/_color-util.scss`.

--- a/docs/utilities/screen-readers.md
+++ b/docs/utilities/screen-readers.md
@@ -14,25 +14,24 @@ Hide content without sacrificing accessibility.
 
 ## Screen Reader Only Content
 
-Hide an element to all devices **except screen readers** with `.sr-only`. Combine `.sr-only` with `.sr-only-focusable` to show the element again when it's focused (e.g. by a keyboard-only user). Can also be used as mixins.
+Hide an element to all devices **except screen readers** with `.sr-only`. Use `.sr-only-focusable` to show an element only when it becomes focused (e.g. by a keyboard-only user). Can also be used as mixins.
 
-There are also responsive variants available in the form `.sr-only{-breakpoint}-{up/down}`.  For example, to visually hide content, **except for screen readers**, for a `sm` or smaller screens you would use `.sr-only-sm-down`.
+There are also responsive variants available in the forms `.sr-only{-breakpoint}`, `.sr-only{-breakpoint}-down`, `.sr-only{-breakpoint}-focusable`, and `.sr-only{-breakpoint}-down-focusable`.  For example, to visually hide content, **except for screen readers**, for a `sm` or smaller screens you would use `.sr-only-sm-down`, or `.sr-only-sm-down-focusable` when the element should be shown only when focused for smaller screens.
 
 These classes are exceptionally useful helping to follow [accessibility best practices]({{ site.baseurl }}/get-started/accessibility).
 
-**Heads up!** There is no `.sr-only-*` class created for the smallest breakpoint and no `.sr-only-*-down` class created for the largest breakpoint, `.sr-only-xs` and `.sr-only-xl-down` respectively, since they are functionally equivalent to using `.sr-only`.
+**Heads up!** There is no `.sr-only-*` classes created for the smallest breakpoint and no `.sr-only-*-down` classes created for the largest breakpoint, `.sr-only-xs`, `.sr-only-xs-focusable`, `.sr-only-xl-down`, `.sr-only-xl-focusable-down`, since they are functionally equivalent to using `.sr-only` or `.sr-only-focusable`.
 
 {% capture example %}
-<a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
+<h3 class="sr-only-sm-down">Title for Screen Readers</h3>
 
-<span class="sr-only-sm-down">...</span>
+<a class="sr-only-focusable" href="#content">Skip to main content</a>
 {% endcapture %}
 {% include example.html content=example %}
 
 {% highlight scss %}
 // Usage as a mixin
 .skip-navigation {
-  @include sr-only;
   @include sr-only-focusable;
 }
 {% endhighlight %}

--- a/scss/mixins/_screen-reader.scss
+++ b/scss/mixins/_screen-reader.scss
@@ -1,44 +1,26 @@
+// stylelint-disable declaration-no-important
+
 // Only display content to screen readers
 //
-// See: http://a11yproject.com/posts/how-to-hide-content
-//
-// 1. For long content, line feeds are not interpreted as spaces and small width
-//    causes content to wrap 1 word per line:
-//    https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-// 2. `clip` is deprecated, use `clip-path` for future-proofing
-//    https://www.w3.org/TR/css-masking-1/#clip-property
-// See also:
-//    https://hugogiraudel.com/2016/10/13/css-hide-and-seek/
-
-
+// See: https://a11yproject.com/posts/how-to-hide-content/
+// See: https://hugogiraudel.com/2016/10/13/css-hide-and-seek/
 @mixin sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    //clip-path: inset(50%); //2
-    white-space: nowrap; // 1
-    border: 0;
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
 }
 
 // Use in conjunction with .sr-only to only display content when it's focused.
 //
 // Useful for "Skip to main content" links; see https://www.w3.org/TR/2013/NOTE-WCAG20-TECHS-20130905/G1
-//
-// Credit: HTML5 Boilerplate
-
 @mixin sr-only-focusable {
-    &:active,
-    &:focus {
-        position: static;
-        width: auto;
-        height: auto;
-        overflow: visible;
-        clip: auto;
-        //clip-path: none;
-        white-space: inherit;
+    &:not(:focus) {
+        @include sr-only();
     }
 }

--- a/scss/utilities/_screen-reader.scss
+++ b/scss/utilities/_screen-reader.scss
@@ -1,14 +1,18 @@
 // Screenreaders
 @if $enable-utility-sronly {
+    %sr-only-base {
+        @include sr-only();
+    }
+
     @if $enable-utility-sronly-common {
         .sr-only {
-            @include sr-only();
+            @extend %sr-only-base;
         }
     }
 
     @if $enable-utility-sronly-focusable {
-        .sr-only-focusable {
-            @include sr-only-focusable();
+        .sr-only-focusable:not(:focus) {
+            @extend %sr-only-base;
         }
     }
 
@@ -17,9 +21,19 @@
         // Skip smallest breakpoint for up (equivalent to `.sr-only`)
         @if $enable-utility-sronly-responsive {
             @if breakpoint-min($bp, $grid-breakpoints) != null {
-                .sr-only-#{$bp} {
-                    @include media-breakpoint-up($bp) {
+                @include media-breakpoint-up($bp) {
+                    %sr-only-#{$bp} {
                         @include sr-only();
+                    }
+
+                    .sr-only-#{$bp} {
+                        @extend %sr-only-#{$bp};
+                    }
+
+                    @if $enable-utility-sronly-focusable {
+                        .sr-only-#{$bp}-focusable:not(:focus) {
+                            @extend %sr-only-#{$bp};
+                        }
                     }
                 }
             }
@@ -28,9 +42,19 @@
         // Skip largest breakpoint for down (equivalent to `.sr-only`)
         @if $enable-utility-sronly-responsive-down {
             @if breakpoint-max($bp, $grid-breakpoints) != null {
-                .sr-only-#{$bp}-down {
-                    @include media-breakpoint-down($bp) {
+                @include media-breakpoint-up($bp) {
+                    %sr-only-#{$bp}-down {
                         @include sr-only();
+                    }
+
+                    .sr-only-#{$bp}-down {
+                        @extend %sr-only-#{$bp}-down;
+                    }
+
+                    @if $enable-utility-sronly-focusable {
+                        .sr-only-#{$bp}-down-focusable:not(:focus) {
+                            @extend %sr-only-#{$bp}-down;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Add `!important` to `sr-only()` mixin. 
- Added `.sr-only-{bp}-down-focusable` responsive utilities.
- Updated docs to reflect changes.