### PR TITLE
Dropdown: Fix links not working

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -353,7 +353,7 @@
         },
 
         hideMenu : function(e, $trigger, $menu, triggerFocus) {
-            if (e) { e.preventDefault(); }
+            // if (e) { e.preventDefault(); }
 
             if (typeof triggerFocus === 'undefined') { triggerFocus = true; }
 


### PR DESCRIPTION
Get dropdown working for links again.  The updates in #344 broke some basic functionality.  This is just quick work-around until I can revisit the dropdown as a whole.

