### PR TITLE
Code-Pre: Inherit color by default

### DIFF
--- a/docs/4.0.0-alpha.5/content/code.md
+++ b/docs/4.0.0-alpha.5/content/code.md
@@ -192,7 +192,7 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
             <tr>
                 <td><code>$pre-color</code></td>
                 <td>string</td>
-                <td><code>$uibase-700</code></td>
+                <td><code>null</code></td>
                 <td>
                     Pre element text color.
                 </td>

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -625,7 +625,7 @@ $kbd-box-shadow:            inset 0 -.1rem 0 rgba($black, .25) !default;
 $kbd-nested-font-weight:    $font-weight-bold !default;
 $kbd-border-radius:         .1875rem !default;
 
-$pre-color:                 $uibase-700 !default;
+$pre-color:                 null !default;
 
 
 // Figures


### PR DESCRIPTION
Inherit text color by default so it text should be visible on dark background without needing a specific override.