### PR TITLE
Forms-Custom File:Fix focus state for IE

### DIFF
--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -27,15 +27,19 @@
 
         // Bring the "active" form control to the top of surrounding elements
         > .form-control:focus,
-        > .form-file .form-file-input:focus-within ~ .form-file-label,
         > .form-file .form-file-input:focus ~ .form-file-label {
+            z-index: 3;
+        }
+        > .form-file .form-file-input:focus-within ~ .form-file-label {
             z-index: 3;
         }
 
         // Bring input back above label for drag and drop to work if
         // the custom file input is focused.
-        > .form-file .form-file-input:focus-within,
         > .form-file .form-file-input:focus {
+            z-index: 4;
+        }
+        > .form-file .form-file-input:focus-within {
             z-index: 4;
         }
 

--- a/scss/forms/_form-file.scss
+++ b/scss/forms/_form-file.scss
@@ -16,8 +16,24 @@
         margin: 0;
         opacity: 0;
 
-        &:focus-within, // Firefox workaround
+        // Separate rules for :focus and :focus-within
+        // IE doesn't support :focus-within and will ignore ruleset otherwise
         &:focus {
+            ~ .form-file-label {
+                color: $input-focus-color;
+                background-color: $input-focus-bg;
+                border-color: $input-focus-border-color;
+                outline: 0;
+                // Avoid using mixin so we can pass custom focus shadow properly
+                @if $enable-shadows {
+                    box-shadow: $input-box-shadow, $input-focus-box-shadow;
+                } @else {
+                    box-shadow: $input-focus-box-shadow;
+                }
+            }
+        }
+
+        &:focus-within {
             ~ .form-file-label {
                 color: $input-focus-color;
                 background-color: $input-focus-bg;

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -248,8 +248,14 @@
                     border-color: $color;
                 }
 
-                &:focus-within, // Firefox workaround
                 &:focus {
+                    ~ .form-file-label {
+                        border-color: $color;
+                        box-shadow: $input-focus-box-shadow-size rgba($color, $input-focus-box-shadow-alpha);
+                    }
+                }
+
+                &:focus-within {
                     ~ .form-file-label {
                         border-color: $color;
                         box-shadow: $input-focus-box-shadow-size rgba($color, $input-focus-box-shadow-alpha);


### PR DESCRIPTION
IE does not recognize `::focus-within` and will ignore the ruleset even if used with another rule.