### PR TITLE
Add SVG encoder and revise some icons

### DIFF
--- a/docs/4.0.0-alpha.6/get-started/options.md
+++ b/docs/4.0.0-alpha.6/get-started/options.md
@@ -361,6 +361,13 @@ The default setting for the color levels to be generated is defined as the follo
 $palette-levels: 50 100 200 300 400 500 600 700 800 900;
 {% endhighlight %}
 
+## Encoding SVG
+
+An `encode-svg` function is available in our SASS to encode the `<`, `>` and `#` characters for SVG images provided through data URLs. These characters need to be encoded to properly render the background images in some browsers, such as IE.
+
+{% highlight css %}
+$form-checkradio-radio-icon: encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle fill='#{$form-checkradio-checked-color}' r='3'/></svg>")) !default;
+{% endhighlight %}
 
 ## CSS Variables
 
@@ -428,9 +435,9 @@ And here's an example of **what is supported:**
 }
 {% endhighlight %}
 
-### SASS Reference
+## SASS Reference
 
-#### Variables
+### Variables
 
 The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}/get-started/options/), or Sass variables, that can be customized for generating the root CSS variables.
 
@@ -490,6 +497,6 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
     </table>
 </div>
 
-#### Mixins
+### Mixins
 
 No mixins available.

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -20,6 +20,14 @@ $enable-color-warnings:         false !default;     // false
 $enable-validation-icons:       true !default;      // true
 
 
+// Characters to encode for SVG data URLs, used by `encode-svg()` SCSS function
+$encode-svg-chars: (
+    ("<", "%3c"),
+    (">", "%3e"),
+    ("#", "%23")
+) !default;
+
+
 // Palette
 // =====
 // List of levels to build CSS out for each of the palette themes
@@ -805,13 +813,13 @@ $form-checkradio-checked-color:             $white !default;
 $form-checkradio-checked-border-color:      $primary !default;
 
 $form-checkradio-checkbox-border-radius:    $border-radius !default;
-$form-checkradio-checkbox-icon:             str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$form-checkradio-checked-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-checkradio-checkbox-icon:             encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-checkradio-checked-color}' d='M6.41 1l-.69.72L2.94 4.5l-.81-.78L1.41 3 0 4.41l.72.72 1.5 1.5.69.72.72-.72 3.5-3.5.72-.72L6.41 1z'/></svg>")) !default;
 
 $form-checkradio-radio-border-radius:       50% !default;
-$form-checkradio-radio-icon:                str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='#{$form-checkradio-checked-color}'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-checkradio-radio-icon:                encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle fill='#{$form-checkradio-checked-color}' r='3'/></svg>")) !default;
 
 $form-checkradio-indeterminate-bg:          $primary !default;
-$form-checkradio-indeterminate-icon:        str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3e%3cpath stroke='#{$form-checkradio-checked-color}' d='M0 2h4'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-checkradio-indeterminate-icon:        encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'><path stroke='#{$form-checkradio-checked-color}' d='M0 2h4'/></svg>")) !default;
 
 // Form switch
 $form-switch-width:                         1.75em !default;
@@ -852,7 +860,7 @@ $form-select-indicator-offset:      .375em !default;
 $form-select-indicator-width:       .75em !default;
 $form-select-indicator-height:      .75em !default;
 $form-select-indicator-color:       rgba($uibase-700, .85) !default;
-$form-select-indicator-image:       str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$form-select-indicator-color}' d='M3 0l-3 3h6l-3-3zm-3 5l3 3 3-3h-6z'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-select-indicator-image:       encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-select-indicator-color}' d='M3 0l-3 3h6l-3-3zm-3 5l3 3 3-3h-6z'/></svg>")) !default;
 $form-select-indicator:             $form-select-indicator-image no-repeat right $form-select-indicator-offset center / $form-select-indicator-width $form-select-indicator-height !default; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
 
 // Form file
@@ -897,9 +905,9 @@ $form-feedback-icon-width:          1em !default;
 $form-feedback-icon-height:         1em !default;
 
 $form-feedback-icon-valid-color:    $form-feedback-valid-color !default;
-$form-feedback-icon-valid-image:    str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='#{$form-feedback-icon-valid-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-feedback-icon-valid-image:    encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-feedback-icon-valid-color}' d='M6.41 1l-.69.72L2.94 4.5l-.81-.78L1.41 3 0 4.41l.72.72 1.5 1.5.69.72.72-.72 3.5-3.5.72-.72L6.41 1z'/></svg>")) !default;
 $form-feedback-icon-invalid-color:  $form-feedback-invalid-color !default;
-$form-feedback-icon-invalid-image:  str-replace(url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{palette($danger, 500)}' viewBox='-2 -2 7 7'%3e%3cpath stroke='#{$form-feedback-icon-invalid-color}' d='M0 0l3 3m0-3L0 3'/%3e%3ccircle r='.5'/%3e%3ccircle cx='3' r='.5'/%3e%3ccircle cy='3' r='.5'/%3e%3ccircle cx='3' cy='3' r='.5'/%3e%3c/svg%3e"), "#", "%23") !default;
+$form-feedback-icon-invalid-image:  encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-feedback-icon-invalid-color}' d='M3.09 0c-.06 0-.1.04-.13.09L.02 6.9c-.02.05-.03.13-.03.19v.81c0 .05.04.09.09.09h6.81c.05 0 .09-.04.09-.09v-.81c0-.05-.01-.14-.03-.19L4.01.09A.142.142 0 0 0 3.88 0h-.81zM3 3h1v2H3V3zm0 3h1v1H3V6z'/></svg>")) !default;
 
 $form-validation-states: () !default;
 // stylelint-disable-next-line scss/dollar-variable-default

--- a/scss/functions/_str-util.scss
+++ b/scss/functions/_str-util.scss
@@ -14,3 +14,16 @@
 
     @return $string;
 }
+
+// Encode SVG data URLs into CSS friendly versions, otherwise
+// pass through the original string.
+// From https://codepen.io/kevinweber/pen/dXWoRw
+@function encode-svg($string) {
+    @if str-index($string, "data:image/svg+xml") {
+        @each $char, $encoded in $encode-svg-chars{
+            $string: str-replace($string, $char, $encoded);
+        }
+    }
+
+    @return $string;
+}


### PR DESCRIPTION
- Add Sass function to encode SVG so we can stop doing it manually.
- Change the `invalid` validation icon to reduce confusion with the clear icon.
- Normalize more icons onto the Open Iconic set to be more visually consistent.
- Normalize the SVG attribute order in settings file.