### PR TITLE
Form: Revert legend changes - add min-height to textareas

### DIFF
--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -408,19 +408,19 @@ fieldset {
     border: 0;
 }
 
-// 1. By using `float: left`, the legend will behave like a block element
+// 1. Correct the text wrapping in Edge and IE.
 // 2. Correct the color inheritance from `fieldset` elements in IE.
-// 3. Correct the text wrapping in Edge and IE.
 legend {
-    float: left; //1
+    display: block; // 1
     width: 100%;
+    max-width: 100%; // 1
     padding: 0;
     margin-bottom: $legend-margin-bottom;
     @include font-size($legend-font-size);
     font-weight: $legend-font-weight;
     line-height: inherit;
     color: inherit; // 2
-    white-space: normal; // 3
+    white-space: normal; // 1
 }
 
 progress {

--- a/scss/forms/_form-control.scss
+++ b/scss/forms/_form-control.scss
@@ -90,6 +90,8 @@
         }
 
         textarea.form-control {
+            min-height: calc-input-height-outer($input-padding-y, $input-line-height);
+
             &:not([rows="1"]) {
                 height: auto;
             }
@@ -135,6 +137,13 @@
                 @include font-size($sz-font-size);
                 line-height: $sz-line-height;
                 @include border-radius($sz-border-radius);
+            }
+
+            @if $sz-padding-y != null and $sz-line-height != null {
+                $my-padding-y: if($sz-padding-y != null, $sz-padding-y, $input-padding-y);
+                textarea.form-control {
+                    min-height: calc-input-height-outer($my-padding-y, $sz-line-height);
+                }
             }
 
             @if $enable-form-control and $enable-form-control-sizing {


### PR DESCRIPTION
- Float on legend was causing wrapping issues with `.form-check`.
- Add `min-height` on `textarea.form-control` to keep from being shrunk too small.