### PR TITLE
Input Group: Allow inputs to shrink smaller than the content

### DIFF
--- a/scss/component/_input-group.scss
+++ b/scss/component/_input-group.scss
@@ -12,6 +12,7 @@
         > .form-file {
             position: relative;  // Needed for z-index on focus/active state
             flex: 1 1 0%;
+            min-width: 0; // https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size
             margin-bottom: 0;
             margin-left: -$input-border-width;
 


### PR DESCRIPTION
Fixes layout issue with Firefox.

https://stackoverflow.com/questions/36247140/why-dont-flex-items-shrink-past-content-size