### PR TITLE
Simplify some disabled styles and fix some cursor issues

### DIFF
--- a/docs/4.0.0-alpha.6/content/forms.md
+++ b/docs/4.0.0-alpha.6/content/forms.md
@@ -2341,7 +2341,7 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
                 </td>
             </tr>
             <tr>
-                <td><code>$form-range-border</code></td>
+                <td><code>$form-range-track-border</code></td>
                 <td>string</td>
                 <td><code>0</code></td>
                 <td>

--- a/scss/component/_close.scss
+++ b/scss/component/_close.scss
@@ -8,7 +8,7 @@
         opacity: $close-opacity;
 
         // Override anchor styling
-        @include hover() {
+        @include hover-focus() {
             color: inherit;
             text-decoration: none;
         }

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -43,7 +43,6 @@
         &.disabled {
             color: $pagination-disabled-color;
             pointer-events: none;
-            cursor: auto;
             background-color: $pagination-disabled-bg;
         }
 

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -1,4 +1,3 @@
-// stylelint-disable selector-no-qualifying-type
 @if $enable-btn {
     // Base button
     .btn {
@@ -8,6 +7,7 @@
         text-align: center;
         text-decoration: none;
         vertical-align: middle;
+        cursor: pointer;
         user-select: none;
         border: $btn-border-width solid transparent;
         @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
@@ -35,6 +35,7 @@
 
     // Disabled comes first so active can restyle
     %btn-common-disabled {
+        pointer-events: none;
         opacity: $btn-disabled-opacity;
         @include box-shadow(none);
     }
@@ -48,15 +49,11 @@
         }
     }
 
-    .btn:not(:disabled):not(.disabled) {
-        cursor: pointer;
-    }
-
     %btn-common-active {
         @include box-shadow($btn-active-box-shadow);
     }
-    .btn:not(:disabled):not(.disabled):active,
-    .btn:not(:disabled):not(.disabled).active,
+    .btn:active,
+    .btn.active,
     .btn.open[data-cfw="dropdown"] {
         @extend %btn-common-active !optional;
     }
@@ -69,8 +66,8 @@
     %btn-common-active-focus {
         @include box-shadow($btn-active-box-shadow, $btn-focus-box-shadow);
     }
-    .btn:not(:disabled):not(.disabled):active:focus,
-    .btn:not(:disabled):not(.disabled).active:focus,
+    .btn:active:focus,
+    .btn.active:focus,
     .btn.open[data-cfw="dropdown"]:focus {
         @extend %btn-common-active-focus !optional;
     }
@@ -84,7 +81,7 @@
     %btn-common-disabled-pointer {
         pointer-events: none;
     }
-    a.btn.disabled,
+    // stylelint-disable-next-line selector-no-qualifying-type
     fieldset:disabled a.btn {
         @extend %btn-common-disabled-pointer;
     }
@@ -166,13 +163,12 @@
             &:disabled {
                 color: $btn-link-disabled-color;
                 text-decoration: none;
-                pointer-events: none;
                 background-color: transparent;
                 border-color: transparent;
             }
 
-            &:not(:disabled):not(.disabled):active,
-            &:not(:disabled):not(.disabled).active,
+            &:active,
+            &.active,
             &.open[data-cfw="dropdown"] {
                 color: $btn-link-hover-color;
                 background-color: transparent;

--- a/scss/forms/_form-range.scss
+++ b/scss/forms/_form-range.scss
@@ -59,16 +59,6 @@
             @include border-radius($form-range-track-border-radius);
         }
 
-        &:not(:disabled) {
-            &::-webkit-slider-runnable-track {
-                cursor: $form-range-track-cursor;
-            }
-            &::-moz-range-track {
-                cursor: $form-range-track-cursor;
-            }
-            // Cursor does seem to have affect in IE/Edge so no rules set.
-        }
-
         // Thumb
         &::-webkit-slider-thumb {
             @include form-range-thumb();
@@ -88,6 +78,8 @@
         }
 
         &:disabled {
+            pointer-events: none;
+
             &::-webkit-slider-thumb {
                 background-color: $form-range-thumb-disabled-bg;
             }

--- a/scss/mixins/_buttons.scss
+++ b/scss/mixins/_buttons.scss
@@ -56,8 +56,8 @@
         background-color: $active-bg;
         border-color: $active-border;
     }
-    #{$parent}:not(:disabled):not(.disabled):active,
-    #{$parent}:not(:disabled):not(.disabled).active,
+    #{$parent}:active,
+    #{$parent}.active,
     #{$parent}.open[data-cfw="dropdown"] {
         @extend %btn-variant-#{$parent}-active;
     }
@@ -72,8 +72,8 @@
         %btn-variant-#{$parent}-active-focus {
             box-shadow: $btn-active-box-shadow, $btn-focus-box-shadow-size rgba($focus-shadow, $btn-focus-box-shadow-alpha);
         }
-        #{$parent}:not(:disabled):not(.disabled):active:focus,
-        #{$parent}:not(:disabled):not(.disabled).active:focus,
+        #{$parent}:active:focus,
+        #{$parent}.active:focus,
         #{$parent}.open[data-cfw="dropdown"]:focus {
             @extend %btn-variant-#{$parent}-active-focus;
         }

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -340,6 +340,7 @@
     height: $form-range-track-height;
     margin: 0 $form-range-thumb-focus-box-shadow-width;
     color: transparent;
+    cursor: $form-range-track-cursor;
     border: $form-range-track-border;
     @include border-radius($form-range-track-border-radius);
     @include box-shadow($form-range-track-box-shadow);

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -2220,13 +2220,13 @@ Showing a <kbd>kdb sample</kbd>
 
 <h3>Close</h3>
 <p>
-   Anchor: <a href="#" role="button" class="close" data-cfw-alert-animate=false aria-label="Close"><span aria-hidden="true">&times;</span></a>
-   Button: <button type="button" class="close" data-cfw-alert-animate=false aria-label="Close"><span aria-hidden="true">&times;</span></button>
+   Anchor: <a href="#" role="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+   Button: <button type="button" class="close" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 </p>
 <h4>Close: Disabled</h4>
 <p>
-   Anchor: <a href="#" role="button" class="close disabled" tabindex="-1" data-cfw-alert-animate=false aria-label="Close"><span aria-hidden="true">&times;</span></a>
-   Button: <button type="button" class="close" disabled data-cfw-alert-animate=false aria-label="Close"><span aria-hidden="true">&times;</span></button>
+   Anchor: <a href="#" role="button" class="close disabled" tabindex="-1" aria-label="Close"><span aria-hidden="true">&times;</span></a>
+   Button: <button type="button" class="close" disabled aria-label="Close"><span aria-hidden="true">&times;</span></button>
 </p>
 
 <h3>Base Navigation</h3>

--- a/test/visual/button.html
+++ b/test/visual/button.html
@@ -100,27 +100,27 @@
 
 Anchor variants:<br />
 <p>
-    <a href="#" role="button" class="btn disabled">Default</a>
-    <a href="#" role="button" class="btn btn-primary disabled">Primary</a>
-    <a href="#" role="button" class="btn btn-secondary disabled">Secondary</a>
-    <a href="#" role="button" class="btn btn-success disabled">Success</a>
-    <a href="#" role="button" class="btn btn-info disabled">Info</a>
-    <a href="#" role="button" class="btn btn-warning disabled">Warning</a>
-    <a href="#" role="button" class="btn btn-danger disabled">Danger</a>
-    <a href="#" role="button" class="btn btn-light disabled">Light</a>
-    <a href="#" role="button" class="btn btn-dark disabled">Dark</a>
-    <a href="#" role="button" class="btn btn-link disabled">Link</a>
+    <a href="#" role="button" class="btn disabled" tabindex="-1" aria-disabled="true">Default</a>
+    <a href="#" role="button" class="btn btn-primary disabled" tabindex="-1" aria-disabled="true">Primary</a>
+    <a href="#" role="button" class="btn btn-secondary disabled" tabindex="-1" aria-disabled="true">Secondary</a>
+    <a href="#" role="button" class="btn btn-success disabled" tabindex="-1" aria-disabled="true">Success</a>
+    <a href="#" role="button" class="btn btn-info disabled" tabindex="-1" aria-disabled="true">Info</a>
+    <a href="#" role="button" class="btn btn-warning disabled" tabindex="-1" aria-disabled="true">Warning</a>
+    <a href="#" role="button" class="btn btn-danger disabled" tabindex="-1" aria-disabled="true">Danger</a>
+    <a href="#" role="button" class="btn btn-light disabled" tabindex="-1" aria-disabled="true">Light</a>
+    <a href="#" role="button" class="btn btn-dark disabled" tabindex="-1" aria-disabled="true">Dark</a>
+    <a href="#" role="button" class="btn btn-link disabled" tabindex="-1" aria-disabled="true">Link</a>
 </p>
 <p>
-    <a href="#" role="button" class="btn btn-outline disabled">Default</a>
-    <a href="#" role="button" class="btn btn-outline-primary disabled">Primary</a>
-    <a href="#" role="button" class="btn btn-outline-secondary disabled">Secondary</a>
-    <a href="#" role="button" class="btn btn-outline-success disabled">Success</a>
-    <a href="#" role="button" class="btn btn-outline-info disabled">Info</a>
-    <a href="#" role="button" class="btn btn-outline-warning disabled">Warning</a>
-    <a href="#" role="button" class="btn btn-outline-danger disabled">Danger</a>
-    <a href="#" role="button" class="btn btn-outline-light disabled">Light</a>
-    <a href="#" role="button" class="btn btn-outline-dark disabled">Dark</a>
+    <a href="#" role="button" class="btn btn-outline disabled" tabindex="-1" aria-disabled="true">Default</a>
+    <a href="#" role="button" class="btn btn-outline-primary disabled" tabindex="-1" aria-disabled="true">Primary</a>
+    <a href="#" role="button" class="btn btn-outline-secondary disabled" tabindex="-1" aria-disabled="true">Secondary</a>
+    <a href="#" role="button" class="btn btn-outline-success disabled" tabindex="-1" aria-disabled="true">Success</a>
+    <a href="#" role="button" class="btn btn-outline-info disabled" tabindex="-1" aria-disabled="true">Info</a>
+    <a href="#" role="button" class="btn btn-outline-warning disabled" tabindex="-1" aria-disabled="true">Warning</a>
+    <a href="#" role="button" class="btn btn-outline-danger disabled" tabindex="-1" aria-disabled="true">Danger</a>
+    <a href="#" role="button" class="btn btn-outline-light disabled" tabindex="-1" aria-disabled="true">Light</a>
+    <a href="#" role="button" class="btn btn-outline-dark disabled" tabindex="-1" aria-disabled="true">Dark</a>
 </p>
 
 <h2>Sizes</h2>


### PR DESCRIPTION
We can simplify some rules for disabled states due the use of `pointer-events: none;` and the dropping of support or IE 10.

However, according to https://caniuse.com/#feat=pointer-events:
Does not work on links in IE11 and Edge 17 and below unless display is set to `block` or `inline-block`, or position is set to `absolute` or `fixed`.

This means that the close and drag icons cannot be simplified at this time since they hover state is still happens in IE even if disabled.