### PR TITLE
Modal: Add side aligned variants

### DIFF
--- a/docs/4.0.0-alpha.6/widgets/modal.md
+++ b/docs/4.0.0-alpha.6/widgets/modal.md
@@ -633,6 +633,15 @@ Position a modal to the side of the page with a `.modal-dialog-side-start` or `.
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save</button>
             </div>
         </div>
     </div>
@@ -647,10 +656,17 @@ Position a modal to the side of the page with a `.modal-dialog-side-start` or `.
             </div>
             <div class="modal-body">
                 <h5>Overflowing text to show scroll behavior</h5>
+                <p>Using optional width and scrollable body modifiers.</p>
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save</button>
             </div>
         </div>
     </div>

--- a/docs/4.0.0-alpha.6/widgets/modal.md
+++ b/docs/4.0.0-alpha.6/widgets/modal.md
@@ -152,9 +152,6 @@ When modals become too long for the user's viewport or device, they scroll indep
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
-                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
-                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
@@ -165,14 +162,14 @@ When modals become too long for the user's viewport or device, they scroll indep
 </div>
 
 <div class="cf-example">
-    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScrollBody">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScroll">
         Scrolling modal
     </button>
 </div>
 
 {% highlight html %}
 <!-- Button trigger -->
-<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScrollBody">
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalScroll">
     Scrolling modal
 </button>
 
@@ -213,6 +210,11 @@ Add `.modal-dialog-scrollable` to `.modal-dialog` where the `.modal-body` is the
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
@@ -328,9 +330,6 @@ A vertically centered dialog will also scroll when the content is longer than th
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
-                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
-                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
@@ -387,6 +386,11 @@ You can also combine `.modal-dialog-centered` with `.modal-dialog-scrollable` to
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
@@ -605,6 +609,75 @@ Modals have two optional sizes, provided by Figuration's base CSS, available via
 
 <div class="modal" id="modalSm">
     <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            ...
+        </div>
+    </div>
+</div>
+{% endhighlight %}
+
+### Side Aligned
+
+Position a modal to the side of the page with a `.modal-dialog-side-start` or `.modal-dialog-side-end` modifier class placed on a the `.modal-dialog`. Side aligned modals can be used with `.modal-dialog-scrollable`, and can also use the sizing classes.
+
+<div class="modal" id="modalSideStart">
+    <div class="modal-dialog modal-dialog-side-start">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="myLargeModalLabel">Start side modal</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h5>Overflowing text to show scroll behavior</h5>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalSideEnd">
+    <div class="modal-dialog modal-dialog-side-end modal-dialog-scrollable modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title" id="mySmallModalLabel">End side modal</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h5>Overflowing text to show scroll behavior</h5>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="cf-example">
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSideStart">Start side modal</button>
+    <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSideEnd">End side modal</button>
+</div>
+
+{% highlight html %}
+<!-- Large modal -->
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSideStart">Start side modal</button>
+
+<div class="modal" id="modalSideStart">
+    <div class="modal-dialog modal-dialog-side-start">
+        <div class="modal-content">
+            ...
+        </div>
+    </div>
+</div>
+
+<!-- Small modal -->
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalSideEnd">End side modal</button>
+
+<div class="modal" id="modalStartEnd">
+    <div class="modal-dialog modal-dialog-start-end modal-dialog-scrollable modal-sm">
         <div class="modal-content">
             ...
         </div>
@@ -912,7 +985,31 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
                 <td>boolean</td>
                 <td><code>true</code></td>
                 <td>
-                    Enable the generation of the vertically centered modal header variant.
+                    Enable the generation of the vertically centered modal variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-modal-scrollable</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the scrollable body modal variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-modal-side-start</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the start side aligned modal variant.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$enable-modal-side-end</code></td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>
+                    Enable the generation of the end side aligned modal variant.
                 </td>
             </tr>
             <tr>
@@ -1184,7 +1281,7 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
                 <td>string</td>
                 <td><code>translate(0, -3rem)</code></td>
                 <td>
-                    Transform state of `.modal-dialog` before the modal fade-in animation
+                    Transform state of <code>.modal-dialog</code> before the modal fade-in animation
                 </td>
             </tr>
             <tr>
@@ -1193,6 +1290,14 @@ The available [Customization options]({{ site.baseurl }}/{{ site.docs_version }}
                 <td><code>none</code></td>
                 <td>
                     Transform state of <code>.modal-dialog</code> at the end of the modal fade-in animation.
+                </td>
+            </tr>
+            <tr>
+                <td><code>$modal-transform-side-offset</code></td>
+                <td>string</td>
+                <td><code>-5rem</code></td>
+                <td>
+                    Transform state offset of <code>.modal-dialog</code> before the modal fade-in animation for side variant modals.
                 </td>
             </tr>
             <tr>

--- a/js/modal.js
+++ b/js/modal.js
@@ -398,7 +398,7 @@
         _scrollBlock : function(e) {
             // Allow scrolling for scrollable modal body
             var $content = this.$target.find('.modal-dialog-scrollable');
-            if ($content && ($content[0] === e.target || $content.find('.modal-body')[0].contains(e.target))) {
+            if ($content.length && ($content[0] === e.target || $content.find('.modal-body')[0].contains(e.target))) {
                 e.stopPropagation();
                 return;
             }

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -189,6 +189,8 @@ $enable-dropdown-back:                      true !default;
 $enable-modal:                              true !default;
 $enable-modal-centered:                     true !default;
 $enable-modal-scrollable:                   true !default;
+$enable-modal-side-start:                   true !default;
+$enable-modal-side-end:                     true !default;
 $enable-modal-header:                       true !default;
 $enable-modal-title:                        true !default;
 $enable-modal-body:                         true !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1293,6 +1293,7 @@ $modal-lg-breakpoint:           lg !default; // The minimum breakpoint to allow 
 // When fading in the modal, animate it to slide down
 $modal-transform-fade:          translate(0, -3rem) !default;
 $modal-transform-in:            none !default;
+$modal-transform-side-offset:   -5rem !default;
 
 
 // Player

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -37,9 +37,6 @@
             @include transition($modal-transition);
             transform: $modal-transform-fade;
         }
-        &.in .modal-dialog {
-            transform: $modal-transform-in;
-        }
     }
 
     // Shell div to position the modal
@@ -53,7 +50,7 @@
         pointer-events: none;
     }
 
-    @if $enable-modal-scrollable  {
+    @if $enable-modal-scrollable {
         .modal-dialog-scrollable {
             max-height: calc(100% - #{$modal-dialog-margin * 2});
 
@@ -73,7 +70,7 @@
         }
     }
 
-    @if $enable-modal-centered  {
+    @if $enable-modal-centered {
         .modal-dialog-centered {
             align-items: center;
             min-height: calc(100% - #{$modal-dialog-margin * 2});
@@ -86,7 +83,7 @@
                 content: "";
             }
 
-            @if $enable-modal-scrollable  {
+            @if $enable-modal-scrollable {
                 // Ensure `.modal-body` shows scrollbar (IE10/11)
                 &.modal-dialog-scrollable {
                     flex-direction: column;
@@ -105,6 +102,42 @@
         }
     }
 
+    @if $enable-modal-side-start {
+        .modal-dialog-side-start {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            min-height: 100%;
+            // stylelint-disable-next-line declaration-no-important
+            margin: 0 !important;
+
+            .modal.fade & {
+                transform: translate($modal-transform-side-offset, 0);
+            }
+        }
+    }
+
+    @if $enable-modal-side-end {
+        .modal-dialog-side-end {
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: 100%;
+            min-height: 100%;
+            // stylelint-disable-next-line declaration-no-important
+            margin: 0 !important;
+
+            .modal.fade & {
+                transform: translate(-$modal-transform-side-offset, 0);
+            }
+        }
+    }
+
+    .modal.in .modal-dialog {
+        transform: $modal-transform-in;
+    }
+
     // Actual modal
     .modal-content {
         position: relative;
@@ -121,6 +154,26 @@
         @include box-shadow($modal-content-box-shadow);
         // Remove focus outline from opened modal
         outline: 0;
+    }
+
+    %modal-side-content {
+        // IE fix to get modal full height
+        @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+            min-height: 100vh;
+        }
+        @include border-radius(0);
+    }
+    @if $enable-modal-side-start {
+        .modal-dialog-side-start .modal-content {
+            border-width: 0 $modal-content-border-width 0 0;
+            @extend %modal-side-content;
+        }
+    }
+    @if $enable-modal-side-end {
+        .modal-dialog-side-end .modal-content {
+            border-width: 0 0 0 $modal-content-border-width;
+            @extend %modal-side-content;
+        }
     }
 
     // Modal background
@@ -179,6 +232,20 @@
         }
     }
 
+    %modal-side-body {
+        flex: 1 0 auto;
+    }
+    @if $enable-modal-side-start {
+        .modal-dialog-side-start:not(.modal-dialog-scrollable) .modal-body {
+            @extend %modal-side-body;
+        }
+    }
+    @if $enable-modal-side-end {
+        .modal-dialog-side-end:not(.modal-dialog-scrollable) .modal-body {
+            @extend %modal-side-body;
+        }
+    }
+
     // Footer (for actions)
     @if $enable-modal-footer {
         .modal-footer {
@@ -217,7 +284,7 @@
             }
         }
 
-        @if $enable-modal-centered  {
+        @if $enable-modal-centered {
             .modal-dialog-centered {
                 min-height: calc(100% - #{$modal-dialog-bp-up-margin-y * 2});
 
@@ -232,5 +299,26 @@
 
     @include media-breakpoint-up(#{$modal-lg-breakpoint}) {
         .modal-lg { max-width: $modal-lg; }
+    }
+
+    // Ovveride heights for scrollable side variant
+    @if $enable-modal-scrollable {
+        %modal-side-scrollable {
+            max-height: 100%;
+
+            .modal-content {
+                max-height: 100vh;
+            }
+        }
+        @if $enable-modal-side-start {
+            .modal-dialog-side-start.modal-dialog-scrollable {
+                @extend %modal-side-scrollable;
+            }
+        }
+        @if $enable-modal-side-end {
+            .modal-dialog-side-end.modal-dialog-scrollable {
+                @extend %modal-side-scrollable;
+            }
+        }
     }
 }

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -233,15 +233,15 @@
     }
 
     %modal-side-body {
-        flex: 1 0 auto;
+        flex-shrink: 0;
     }
     @if $enable-modal-side-start {
-        .modal-dialog-side-start:not(.modal-dialog-scrollable) .modal-body {
+        .modal-dialog-side-start .modal-body {
             @extend %modal-side-body;
         }
     }
     @if $enable-modal-side-end {
-        .modal-dialog-side-end:not(.modal-dialog-scrollable) .modal-body {
+        .modal-dialog-side-end .modal-body {
             @extend %modal-side-body;
         }
     }
@@ -308,6 +308,10 @@
 
             .modal-content {
                 max-height: 100vh;
+            }
+
+            .modal-body {
+                flex-shrink: 1;
             }
         }
         @if $enable-modal-side-start {

--- a/scss/core/_tables.scss
+++ b/scss/core/_tables.scss
@@ -71,7 +71,7 @@
         .table-celled,
         .table-divided {
             thead {
-                tr:first-child  {
+                tr:first-child {
                     th,
                     td {
                         border-top-width: 0;
@@ -120,7 +120,7 @@
         .table-celled {
             th,
             td {
-                &:first-child  {
+                &:first-child {
                     border-left-width: 0;
                 }
                 &:last-child {

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -132,6 +132,13 @@
     <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalCenterScroll">
         Scrollable centered modal
     </button>
+
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalSideStart">
+        Side modal - start
+    </button>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalSideEnd">
+        Side modal - end
+    </button>
 </p>
 
 <div class="modal" id="modalCenter">
@@ -184,6 +191,96 @@
 
 <div class="modal" id="modalCenterScroll">
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalCenterScroll">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalSideStart">
+    <div class="modal-dialog modal-dialog-side-start">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalSideEnd">
+    <div class="modal-dialog modal-dialog-side-end modal-dialog-scrollable modal-sm">
         <div class="modal-content">
             <div class="modal-header">
                 <h4 class="modal-title">Modal title</h4>


### PR DESCRIPTION
Creates full height, side aligned modals.  Can be combined with sizing and scrollable body modifiers.

This 'drawer' concept should probably be put into its own component with some concepts possibly borrowed from https://material-ui.com/components/drawers/. 

For now this gets us part way there, and can be revisited later since a refactor of the JS would probably be needed due to overlapping functionality.