### PR TITLE
Dropdown: Update boundary value to keep menus 'attached' to trigger

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -50,7 +50,7 @@
         backtext  : 'Back', // Text for back links
         container : false,   // Where to place dropdown in DOM
         reference : 'toggle',
-        boundary  : 'viewport',
+        boundary  : 'scrollParent',
         flip      : true,
         display   : 'dynamic',
         popperConfig    : null


### PR DESCRIPTION
Stops menu from following down the page when scrolling.