### PR TITLE
 Component-Cards: Don't force `.card-img` as a wrapper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -370,5 +370,6 @@ module.exports = function(grunt) {
     grunt.registerTask('docs-test-js', ['eslint:docs']);
     grunt.registerTask('docs-dist-js', ['uglify:docs']);
     grunt.registerTask('docs-test', ['docs-test-css', 'docs-test-js', 'docs-test-html']);
+    grunt.registerTask('docs-dist', ['docs-dist-css', 'docs-dist-js']);
     grunt.registerTask('docs', ['run:npmDocsServe']);
 };

--- a/scss/component/_card.scss
+++ b/scss/component/_card.scss
@@ -155,8 +155,11 @@
 
     // Card images
     @if $enable-card-img {
-        .card-img {
-            min-height: 1px;  // Stop stretch/white-space due to flexbox
+        .card-img,
+        .card-img-top,
+        .card-img-bottom {
+            flex-shrink: 0; // Stop stretch/white-space due to flexbox w/ images in IE
+            min-height: 1px;  // Stop stretch/white-space due to flexbox w/ images in IE
         }
         .card-img-top {
             @include border-top-radius($card-inner-border-radius);
@@ -214,7 +217,7 @@
                                     }
                                 }
                                 @if $enable-card-img {
-                                    > .card-img > .card-img-top {
+                                    > .card-img-top {
                                         @extend %card-hz-col-not-first-down#{$bprule};
                                     }
                                 }
@@ -229,7 +232,7 @@
                                     }
                                 }
                                 @if $enable-card-img {
-                                    > .card-img > .card-img-bottom {
+                                    > .card-img-bottom {
                                         @extend %card-hz-col-not-last-down#{$bprule};
                                     }
                                 }
@@ -250,7 +253,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-top {
+                                > .card-img-top {
                                     @extend %card-hz-col-not-first-top-start-up#{$bprule};
                                 }
                             }
@@ -264,7 +267,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-bottom {
+                                > .card-img-bottom {
                                     @extend %card-hz-col-not-first-bottom-start-up#{$bprule};
                                 }
                             }
@@ -279,7 +282,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-top {
+                                > .card-img-top {
                                     @extend %card-hz-col-not-last-top-end-up#{$bprule};
                                 }
                             }
@@ -293,7 +296,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-bottom {
+                                > .card-img-bottom {
                                     @extend %card-hz-col-not-last-bottom-end-up#{$bprule};
                                 }
                             }
@@ -311,7 +314,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-top {
+                                > .card-img-top {
                                     @extend %card-hzrev-col-not-first-top-end-up#{$bprule};
                                 }
                             }
@@ -325,7 +328,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-bottom {
+                                > .card-img-bottom {
                                     @extend %card-hzrev-col-not-first-bottom-end-up#{$bprule};
                                 }
                             }
@@ -340,7 +343,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-top {
+                                > .card-img-top {
                                     @extend %card-hzrev-col-not-last-top-start-up#{$bprule};
                                 }
                             }
@@ -354,7 +357,7 @@
                                 }
                             }
                             @if $enable-card-img {
-                                > .card-img > .card-img-bottom {
+                                > .card-img-bottom {
                                     @extend %card-hzrev-col-not-last-bottom-start-up#{$bprule};
                                 }
                             }

--- a/site/4.0/components/cards.md
+++ b/site/4.0/components/cards.md
@@ -21,9 +21,7 @@ Below is an example of a basic card with mixed content and a fixed width. Cards 
 
 {% capture example %}
 <div class="card" style="max-width: 18rem;">
-  <div class="card-img">
-    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-  </div>
+  <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -99,7 +97,7 @@ Links can placed next to each other with some spacing by adding `.card-link` to 
 
 Cards include a few options for working with images. Choose from embedding an image in a card, appending "image caps" at either end of a card, or overlaying images with card content.
 
-Images need to be wrapped with `.card-img` to prevent additional whitespace from appearing in some browsers, such as IE.
+Images need to be classed with `.card-img`, or the `.card-img-top`/`.card-img-bottom` variants, to prevent additional whitespace or altered aspect ratios from appearing in some browsers, such as IE.
 
 #### Standard Images
 
@@ -108,9 +106,7 @@ Images can help add some visual interest to your cards.
 {% capture example %}
 <div class="card" style="max-width: 18rem;">
   <h4 class="card-header">Sample Card</h4>
-  <div class="card-img">
-    <img class="img-fluid" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
-  </div>
+  <img class="img-fluid card-img" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
   <div class="card-body">
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
@@ -124,9 +120,7 @@ Images can help add some visual interest to your cards.
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">This is a card with text and a nested image.</p>
-    <div class="card-img mb-0_5">
-      <img class="img-fluid" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
-    </div>
+    <img class="img-fluid card-img mb-0_5" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
   </div>
 </div>
@@ -141,9 +135,7 @@ Use `.card-img-top` on the image, or embedded element, to round over the top cor
 
 {% capture example %}
 <div class="card" style="max-width: 18rem;">
-  <div class="card-img">
-    <img class="img-fluid card-img-top" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image cap">
-  </div>
+  <img class="img-fluid card-img-top" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image cap">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur.</p>
@@ -162,9 +154,7 @@ Use `.card-img-bottom` on the image, or embedded element, to round over the bott
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur.</p>
     <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
   </div>
-  <div class="card-img">
-    <img class="img-fluid card-img-bottom" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image cap">
-  </div>
+  <img class="img-fluid card-img-bottom" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image cap">
 </div>
 {% endcapture %}
 {% renderExample example %}
@@ -180,9 +170,7 @@ Note that content should not be larger than the height of the image.  If content
 
 {% capture example %}
 <div class="card text-white" style="max-width: 18rem;">
-  <div class="card-img">
-    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image background" alt="Card image">
-  </div>
+  <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image background" alt="Card image">
   <div class="card-img-overlay">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur.</p>
@@ -264,9 +252,7 @@ The multiple content types can be easily combined to create the card you need.
 
 {% capture example %}
 <div class="card" style="max-width: 18rem;">
-  <div class="card-img">
-    <img class="img-fluid card-img-top" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
-  </div>
+  <img class="img-fluid card-img-top" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
   <div class="card-body">
     <h4 class="card-title">Card title</h4>
     <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur.</p>
@@ -677,9 +663,7 @@ For basic use cases, `border-radius` updates are handled for switching from colu
 {% capture example %}
 <div class="card card-horizontal">
   <div class="card-col col-5">
-    <div class="card-img">
-      <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
   </div>
   <!-- using `.col-sm` due to pixel rounding -->
   <div class="card-col col">
@@ -699,17 +683,13 @@ For basic use cases, `border-radius` updates are handled for switching from colu
     </div>
   </div>
   <div class="card-col col-md-5">
-    <div class="card-img">
-      <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
   </div>
 </div>
 
 <div class="card card-horizontal-md">
   <div class="card-col col-md-5">
-    <div class="card-img">
-      <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image cap" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image cap" alt="Card image cap">
   </div>
   <!-- using `.col-md` due to pixel rounding -->
   <div class="card-col col-md">
@@ -734,9 +714,7 @@ In the examples below, the card will display the image cap **above** the body co
 {% capture example %}
 <div class="card card-horizontal-sm-reverse">
   <div class="card-col col-sm-5">
-    <div class="card-img">
-      <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px150/?text=Image cap" alt="Card image cap">
   </div>
   <!-- using `.col-sm` due to pixel rounding -->
   <div class="card-col col-sm">
@@ -749,9 +727,7 @@ In the examples below, the card will display the image cap **above** the body co
 
 <div class="card card-horizontal-md-reverse">
   <div class="card-col col-md-5">
-    <div class="card-img">
-      <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image cap" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top card-img-bottom" data-src="holder.js/100px225/?text=Image cap" alt="Card image cap">
   </div>
   <!-- using `.col-md` due to pixel rounding -->
   <div class="card-col col-md">
@@ -774,9 +750,7 @@ Use card groups to render cards as a single, attached element with equal width a
 {% capture example %}
 <div class="card-group-sm">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -784,9 +758,7 @@ Use card groups to render cards as a single, attached element with equal width a
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card.</p>
@@ -794,9 +766,7 @@ Use card groups to render cards as a single, attached element with equal width a
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. This card has even longer content than the first to show that equal height action.</p>
@@ -812,24 +782,18 @@ When using card groups with footers, they will automatically line up along the b
 {% capture example %}
 <div class="card-group-sm">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a card with text and an image.</p>
-      <div class="card-img">
-        <img class="img-fluid" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
-      </div>
+      <img class="img-fluid card-img" src="{{ site.path }}/assets/{{ version.docs }}/img/test.gif" alt="Card image">
     </div>
     <div class="card-footer">
       <small class="text-muted">Last updated 3 mins ago</small>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -839,9 +803,7 @@ When using card groups with footers, they will automatically line up along the b
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. This card has even longer content than the first to show that equal height action.</p>
@@ -861,9 +823,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
 {% capture example %}
 <div class="card-deck-sm">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -871,9 +831,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card.</p>
@@ -881,9 +839,7 @@ Need a set of equal width and height cards that aren't attached to one another? 
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit. This card has even longer content than the first to show that equal height action.</p>
@@ -899,9 +855,7 @@ Just like with card groups, card footers in decks will automatically line up.
 {% capture example %}
 <div class="card-deck-sm">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">This is a card with text and an image.</p>
@@ -914,9 +868,7 @@ Just like with card groups, card footers in decks will automatically line up.
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -926,9 +878,7 @@ Just like with card groups, card footers in decks will automatically line up.
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. This card has even longer content than the first to show that equal height action.</p>
@@ -981,36 +931,28 @@ Controlling the number of cards in a row, based on the screen width is also poss
 {% capture example %}
 <div class="card-deck-sm card-deck-col">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -1029,9 +971,7 @@ Responsive variants are available with the class syntax of `.card-columns{-break
 {% capture example %}
 <div class="card-columns-sm">
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px150/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title that wraps to a new line</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -1050,9 +990,7 @@ Responsive variants are available with the class syntax of `.card-columns{-break
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid card-img-top" data-src="holder.js/100px160/" alt="Card image cap">
-    </div>
+    <img class="img-fluid card-img-top" data-src="holder.js/100px160/" alt="Card image cap">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -1079,9 +1017,7 @@ Responsive variants are available with the class syntax of `.card-columns{-break
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img class="img-fluid" data-src="holder.js/100px260/" alt="Card image">
-    </div>
+    <img class="img-fluid" data-src="holder.js/100px260/" alt="Card image">
   </div>
   <div class="card text-end">
     <div class="card-body">

--- a/site/4.0/get-started/migration.md
+++ b/site/4.0/get-started/migration.md
@@ -76,7 +76,7 @@ ${toc}
 ### Card
 - Contextually colored cards have been removed. Now you will need to use the with text, background, and border color utilities.
 - Cards have been converted to flexbox layout.
-- Images now need to be wrapped with `.card-img` to keep aspect ratio and scaling in check due to flexbox.
+- Images need to use some variant of `.card-img{-top/bottom}`, or sometimes it can be a wrapper, to keep aspect ratio and scaling in check due to flexbox, especially with IE.
 - List and table sub-components now use a `.card-list` or `.card-table` respectively.
 - Responsive horizontal card layouts have been added with `.card-horizontal{breakpoint}`, `.card-horizontal{breakpoint}-reverse`, and child `.card-col` elements.
 

--- a/site/assets/4.0/scss/_toc.scss
+++ b/site/assets/4.0/scss/_toc.scss
@@ -1,31 +1,16 @@
-.cf-toc {
-    padding-left: 1rem;
-}
-
 .cf-toc-list {
     display: flex;
     flex-direction: column;
     min-width: 0;
     margin-bottom: $list-margin-bottom;
-    margin-left: $list-margin-left;
-    @include font-size(.9735rem);
-    @include list-unstyled();
+    margin-left: 0;
+    @include font-size(.9375rem);
 
     .cf-toc-list {
         padding: 0;
         margin-bottom: 0;
         margin-left: $list-margin-left;
         border-left: 0;
-    }
-
-    > .cf-toc-item {
-        list-style: none;
-
-        &::before {
-            position: absolute;
-            margin-left: -$list-margin-left;
-            content: $list-bulleted-content;
-        }
     }
 }
 
@@ -40,7 +25,6 @@
     order: 1;
     padding-top: 1rem;
     padding-bottom: 1rem;
-    @include font-size(.9375rem);
 
     .cf-toc {
         @supports (position: sticky) {
@@ -51,10 +35,15 @@
             overflow-y: auto;
         }
 
-        padding: .25rem 0;
+        padding: .25rem 0 .25rem 1rem;
         margin: 0;
         list-style: none;
         border-left: 1px solid $border-color;
+    }
+
+    .cf-toc-list {
+        @include font-size(.875rem);
+        @include list-unstyled();
     }
 
     .cf-toc-list .cf-toc-list {

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -7,7 +7,7 @@
 <title>Figuration Widget: Player</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
-<link rel="stylesheet" href="../../docs/4.0.0-beta.1/assets/fonts/fontawesome/css/all.min.css">
+<link rel="stylesheet" href="../../site/assets/4.0/fonts/fontawesome/css/all.min.css">
 
 <script src="../../node_modules/jquery/dist/jquery.slim.min.js"></script>
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>
@@ -410,7 +410,7 @@ body {
     </div>
 
     <audio controls>
-        <source src="../../docs/4.0.0-beta.1/assets/audio/Drumroll-Heigh-hoo.mp3" type="audio/mpeg" />
+        <source src="../../site/assets/4.0/audio/Drumroll-Heigh-hoo.mp3" type="audio/mpeg" />
         <p>HTML5 audio not supported</p>
     </audio>
 </div>
@@ -444,7 +444,7 @@ body {
     </div>
 
     <audio controls>
-        <source src="../../docs/4.0.0-beta.1/assets/audio/Ambient_Acoustic-StrangerEight.mp3" type="audio/mpeg" />
+        <source src="../../site/assets/4.0/audio/Ambient_Acoustic-StrangerEight.mp3" type="audio/mpeg" />
         <p>HTML5 audio not supported</p>
     </audio>
 </div>
@@ -477,7 +477,7 @@ body {
     </div>
 
     <audio controls preload="none">
-        <source src="../../docs/4.0.0-beta.1/assets/audio/Drumroll-Heigh-hoo.mp3" type="audio/mpeg" />
+        <source src="../../site/assets/4.0/audio/Drumroll-Heigh-hoo.mp3" type="audio/mpeg" />
         <p>HTML5 audio not supported</p>
     </audio>
 </div>
@@ -487,9 +487,9 @@ body {
 <h2 class="h4">Niagara Falls</h2>
 <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
     <div class="embed-fluid">
-        <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-            <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4" type="video/mp4" />
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
+        <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+            <source src="../../site/assets/4.0/video/niagara_falls.mp4" type="video/mp4" />
+            <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
             <p>HTML5 video not supported</p>
         </video>
     </div>
@@ -539,10 +539,10 @@ body {
 <h2 class="h4">Niagara Falls</h2>
 <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
     <div class="embed-fluid">
-        <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls preload="none">
-            <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+        <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls preload="none">
+            <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+            <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+            <track src="../../site/assets/4.0/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
         </video>
     </div>
     <div class="player-wrapper">
@@ -584,10 +584,10 @@ body {
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" data-cfw-player-transcript="2" role="region" aria-label="video player">
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls preload="none">
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls preload="none">
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+                <track src="../../site/assets/4.0/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
             </video>
         </div>
         <div class="player-wrapper">
@@ -628,9 +628,9 @@ body {
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player" data-cfw-player-transcript-option="false" data-cfw-player-transcript=0>
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4" type="video/mp4" />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4" type="video/mp4" />
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
                 <p>HTML5 video not supported</p>
             </video>
         </div>
@@ -674,9 +674,9 @@ body {
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
             </video>
         </div>
         <div class="player-wrapper">
@@ -719,10 +719,10 @@ body {
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" data-cfw-player-transcript="1" role="region" aria-label="video player">
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls preload="none">
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" default />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls preload="none">
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" default />
+                <track src="../../site/assets/4.0/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
             </video>
         </div>
         <div class="player-wrapper">
@@ -768,13 +768,13 @@ body {
     <!-- <div data-cfw="player" class="video-wrapper" data-cfw-player-transcript="0" data-cfw-player-transcript-describe="false" role="region" aria-label="video player"> -->
     <div data-cfw="player" id="desc1" class="video-wrapper" role="region" aria-label="video player" data-cfw-player-media-describe="true">
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls preload="none">
-            <!-- <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls> -->
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4" data-src-describe="../../docs/4.0.0-beta.1/assets/video/niagara_falls-describe-en.mp4">
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-describe-en.vtt" label="English Description" kind="descriptions" srclang="en" />
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-describe-es.vtt" label="Descripción Espa&ntilde;ola" kind="descriptions" srclang="es" />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls preload="none">
+            <!-- <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls> -->
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4" data-src-describe="../../site/assets/4.0/video/niagara_falls-describe-en.mp4">
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+                <track src="../../site/assets/4.0/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+                <track src="../../site/assets/4.0/video/niagara_falls-describe-en.vtt" label="English Description" kind="descriptions" srclang="en" />
+                <track src="../../site/assets/4.0/video/niagara_falls-describe-es.vtt" label="Descripción Espa&ntilde;ola" kind="descriptions" srclang="es" />
             </video>
         </div>
         <div class="player-wrapper">
@@ -820,9 +820,9 @@ body {
 <div class="video-transcript">
     <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
         <div class="embed-fluid">
-            <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-                <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-                <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+            <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+                <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+                <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
             </video>
             <div class="player-caption-display" data-cfw-player="caption-display"></div>
         </div>
@@ -863,10 +863,10 @@ body {
 <h2 class="h4">Using Range Inputs</h2>
 <div data-cfw="player" class="video-wrapper" role="region" aria-label="video player">
     <div class="embed-fluid">
-        <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-            <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4">
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
+        <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+            <source src="../../site/assets/4.0/video/niagara_falls.mp4">
+            <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English" kind="subtitles" srclang="en" />
+            <track src="../../site/assets/4.0/video/niagara_falls-es.vtt" label="Espa&ntilde;ol" kind="subtitles" srclang="es" />
         </video>
     </div>
     <div class="player-wrapper">

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -8,11 +8,11 @@
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
 
-<script type="text/javascript" src="../../docs/4.0.0-beta.1/assets/js/vendor/jquery.slim.min.js"></script>
-<script type="text/javascript" src="../../docs/4.0.0-beta.1/assets/js/vendor/popper.min.js"></script>
+<script type="text/javascript" src="../../site/assets/4.0/js/vendor/jquery.slim.min.js"></script>
+<script type="text/javascript" src="../../site/assets/4.0/js/vendor/popper.min.js"></script>
 <script type="text/javascript" src="../../dist/js/figuration.js"></script>
 
-<script type="text/javascript" src="../../docs/4.0.0-beta.1/assets/js/vendor/holder.min.js"></script>
+<script type="text/javascript" src="../../site/assets/4.0/js/vendor/holder.min.js"></script>
 <script type="text/javascript">
 Holder.addTheme("gray", {
     bg: "#999",
@@ -1441,9 +1441,9 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Embed responsive</h3>
 <div class="video-sample">
     <div class="embed-fluid">
-        <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-            <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4" type="video/mp4" />
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
+        <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+            <source src="../../site/assets/4.0/video/niagara_falls.mp4" type="video/mp4" />
+            <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
             <p>HTML5 video not supported</p>
         </video>
     </div>
@@ -1452,9 +1452,9 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Embed responsive - in flex element</h3>
 <div class="video-sample" style="display: flex;">
     <div class="embed-fluid">
-        <video poster="../../docs/4.0.0-beta.1/assets/video/niagara_falls.jpg" controls>
-            <source src="../../docs/4.0.0-beta.1/assets/video/niagara_falls.mp4" type="video/mp4" />
-            <track src="../../docs/4.0.0-beta.1/assets/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
+        <video poster="../../site/assets/4.0/video/niagara_falls.jpg" controls>
+            <source src="../../site/assets/4.0/video/niagara_falls.mp4" type="video/mp4" />
+            <track src="../../site/assets/4.0/video/niagara_falls-en.vtt" label="English subtitles" kind="subtitles" srclang="en" default />
             <p>HTML5 video not supported</p>
         </video>
     </div>
@@ -2782,9 +2782,7 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Card</h3>
 <div class="card-sample">
     <div class="card">
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
       <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
@@ -2796,9 +2794,7 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Card - content types</h3>
 <div class="card-sample">
     <div class="card">
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
       <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
@@ -2823,9 +2819,7 @@ Showing a <kbd>kdb sample</kbd>
     </div>
 
     <div class="card">
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
       <div class="card-body">
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
       </div>
@@ -2845,9 +2839,7 @@ Showing a <kbd>kdb sample</kbd>
         <h4 class="card-title">Card title</h4>
         <h6 class="card-subtitle text-muted">Support card subtitle</h6>
       </div>
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img" alt="Placeholder image">
       <div class="card-body">
         <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
         <a href="#" class="card-link">Card link</a>
@@ -2965,9 +2957,7 @@ Showing a <kbd>kdb sample</kbd>
 
     <h3>Card - image caps</h3>
     <div class="card">
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
       <div class="card-body">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -2980,9 +2970,7 @@ Showing a <kbd>kdb sample</kbd>
         <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
       </div>
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-bottom" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-bottom" alt="Placeholder image">
     </div>
 
     <div class="card" style="width: 18rem;">
@@ -2990,7 +2978,7 @@ Showing a <kbd>kdb sample</kbd>
         <h4 class="card-title">Card title</h4>
         <p class="card-text">This is a card with text and a nested image.</p>
         <div class="card-img mb-0_5">
-          <img class="img-fluid" src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="Card image">
+          <img class="img-fluid" src="../../site/assets/4.0/img/test.gif" alt="Card image">
         </div>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
       </div>
@@ -2998,9 +2986,7 @@ Showing a <kbd>kdb sample</kbd>
 
     <h3>Card - image overlay</h3>
     <div class="card">
-      <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
       <div class="card-img-overlay text-white">
         <h4 class="card-title">Card title</h4>
         <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3165,9 +3151,7 @@ Showing a <kbd>kdb sample</kbd>
 <div class="card-sample">
     <div class="card-group">
       <div class="card">
-        <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+        <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3175,9 +3159,7 @@ Showing a <kbd>kdb sample</kbd>
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-        </div>
+        <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3185,9 +3167,7 @@ Showing a <kbd>kdb sample</kbd>
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-        </div>
+        <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3200,9 +3180,7 @@ Showing a <kbd>kdb sample</kbd>
 <h3>Card deck</h3>
 <div class="card-deck">
   <div class="card">
-    <div class="card-img">
-      <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-    </div>
+    <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3210,9 +3188,7 @@ Showing a <kbd>kdb sample</kbd>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-    </div>
+    <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3220,9 +3196,7 @@ Showing a <kbd>kdb sample</kbd>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-      <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-    </div>
+    <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3258,9 +3232,7 @@ Showing a <kbd>kdb sample</kbd>
 
 <div class="card-columns">
   <div class="card">
-    <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+      <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
     <div class="card-body">
       <h4 class="card-title">Card title that wraps to a new line</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3278,9 +3250,7 @@ Showing a <kbd>kdb sample</kbd>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+    <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
     <div class="card-body">
       <h4 class="card-title">Card title</h4>
       <p class="card-text">Some sample text to build out the size of the card. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
@@ -3300,9 +3270,7 @@ Showing a <kbd>kdb sample</kbd>
     </div>
   </div>
   <div class="card">
-    <div class="card-img">
-        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
-      </div>
+     <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top" alt="Placeholder image">
   </div>
   <div class="card text-end">
     <div class="card-body">

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -688,7 +688,7 @@ $(window).ready(function() {
                         <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
                         <div class="row">
                             <div class="col-4">
-                                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
+                                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
                             </div>
                         </div>
                     </div>
@@ -819,7 +819,7 @@ $(window).ready(function() {
                 <h3 class="popover-header">Popover selector</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
-                    <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
+                    <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
                 </div>
                 <div class="popover-arrow"></div>
             </div>
@@ -829,7 +829,7 @@ $(window).ready(function() {
                 <h3 class="popover-header">Popover selector</h3>
                 <div class="popover-body">
                     <p>Sed posuere consectetur est at lobortis. Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.</p>
-                    <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
+                    <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
                 </div>
                 <div class="popover-arrow"></div>
             </div>
@@ -1120,7 +1120,7 @@ $(window).ready(function() {
                         <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
                         <div class="row">
                             <div class="col-4">
-                                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
+                                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
                             </div>
                         </div>
                     </div>
@@ -1758,13 +1758,13 @@ $(window).ready(function() {
 
             <h2 id="lazy">Lazy:</h2>
             <div>
-                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" data-cfw-lazy-trigger="click" width="320" height="180" style="max-width: 100%" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" data-cfw-lazy-trigger="click" width="320" height="180" style="max-width: 100%" />
                 <br />
-                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" width="320" height="180" style="max-width: 100%" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" width="320" height="180" style="max-width: 100%" />
                 <br />
-                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" width="320" height="180" style="max-width: 100%" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" width="320" height="180" style="max-width: 100%" />
                 <br />
-                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue; display: none;" width="320" height="180" style="max-width: 100%" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue; display: none;" width="320" height="180" style="max-width: 100%" />
             </div>
 
             <div id="lazytest" class="my-1 border" style="height: 125px; overflow-y: scroll;">
@@ -1772,13 +1772,13 @@ $(window).ready(function() {
                     \/ Scroll down \/
                 </p>
                 <p>
-                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-animate="true" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-animate="true" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
                 </p>
                 <p>
-                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-animate="true" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-animate="true" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
                 </p>
                 <p>
-                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-container="#lazytest" data-cfw-lazy-delay=1000 data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" width="320" height="180" />
                 </p>
             </div>
 
@@ -1798,14 +1798,14 @@ $(window).ready(function() {
                     <div class="well" data-cfw-equalize-group="eqtest0">
                         <h3>Panel 2</h3>
                         <p>Etiam nec pulvinar quam. Duis aliquam ut turpis et vulputate. Proin malesuada sem purus, in hendrerit ex dapibus sed. Cras orci quam, vestibulum eget purus at, ultricies ultricies libero! Morbi fringilla accumsan purus, eu sodales enim suscipit nec.</p>
-                        <img data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
+                        <img data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
                     </div>
                 </div>
                 <div class="col-md-4">
                     <div class="well" data-cfw-equalize-group="eqtest0">
                         <h3>Panel 3</h3>
                         <p>Nam porta malesuada mi, quis hendrerit purus.</p>
-                        <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" />
+                        <img src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" />
                     </div>
                 </div>
             </div>
@@ -1828,7 +1828,7 @@ $(window).ready(function() {
                     <div class="well">
                         <h3>Panel 3</h3>
                         <p>Nam porta malesuada mi, quis hendrerit purus.</p>
-                        <!-- <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" /> -->
+                        <!-- <img src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" /> -->
                     </div>
                 </div>
                 <div class="col-md-4 d-none">
@@ -1933,7 +1933,7 @@ $(window).ready(function() {
                 <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
             </div>
             <div class="modal-body">
-                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
+                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid" />
                 <h4>Text in a modal</h4>
                 <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
                 <h4>Popover in a modal</h4>

--- a/test/visual/button-group.html
+++ b/test/visual/button-group.html
@@ -7,7 +7,7 @@
 <title>Figuration - Button Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
-<link rel="stylesheet" href="../../docs/4.0.0-beta.1/assets/fonts/fontawesome/css/all.min.css">
+<link rel="stylesheet" href="../../site/assets/4.0/fonts/fontawesome/css/all.min.css">
 
 <script src="../../node_modules/jquery/dist/jquery.slim.min.js"></script>
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>

--- a/test/visual/button.html
+++ b/test/visual/button.html
@@ -7,7 +7,7 @@
 <title>Figuration - Button</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
-<link rel="stylesheet" href="../../docs/4.0.0-beta.1/assets/fonts/fontawesome/css/all.min.css">
+<link rel="stylesheet" href="../../site/assets/4.0/fonts/fontawesome/css/all.min.css">
 
 <script src="../../node_modules/jquery/dist/jquery.slim.min.js"></script>
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>

--- a/test/visual/card.html
+++ b/test/visual/card.html
@@ -12,7 +12,7 @@
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>
 <script src="../../dist/js/figuration.js"></script>
 
-<script src="../../docs/4.0.0-beta.1/assets/js/vendor/holder.min.js"></script>
+<script src="../../site/assets/4.0/js/vendor/holder.min.js"></script>
 <script>
 Holder.addTheme("gray", {
     bg: "#999",
@@ -71,9 +71,7 @@ Holder.addTheme("gray", {
 
     <div class="card card-horizontal">
         <div class="card-col col-5">
-            <div class="card-img">
-                <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-            </div>
+            <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
         </div>
         <div class="card-col col">
             <div class="card-header">Header</div>
@@ -84,9 +82,7 @@ Holder.addTheme("gray", {
 
     <div class="card card-horizontal-sm">
         <div class="card-col col-sm-5">
-            <div class="card-img">
-                <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-            </div>
+            <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
         </div>
         <!-- using `.col-sm` due to pixel rounding -->
         <div class="card-col col-sm">
@@ -98,9 +94,7 @@ Holder.addTheme("gray", {
 
     <div class="card card-horizontal-md-reverse">
         <div class="card-col col-md-5">
-            <div class="card-img">
-                <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-            </div>
+            <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
         </div>
         <div class="card-col col-md">
             <div class="card-header">Header</div>
@@ -116,9 +110,7 @@ Holder.addTheme("gray", {
             <div class="card-footer">Footer</div>
         </div>
         <div class="card-col col-lg-5">
-            <div class="card-img">
-                <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-            </div>
+            <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
         </div>
     </div>
 
@@ -129,9 +121,7 @@ Holder.addTheme("gray", {
             <div class="card-footer">Footer</div>
         </div>
         <div class="card-col col-xl-5">
-            <div class="card-img">
-                <img src="../../docs/4.0.0-beta.1/assets/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
-            </div>
+            <img src="../../site/assets/4.0/img/test.gif" class="img-fluid card-img-top card-img-bottom" alt="Placeholder image">
         </div>
     </div>
 </div>
@@ -147,9 +137,7 @@ Holder.addTheme("gray", {
 
     <div class="card-deck-sm">
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -157,9 +145,7 @@ Holder.addTheme("gray", {
             </div>
         </div>
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -175,9 +161,7 @@ Holder.addTheme("gray", {
             </div>
         </div>
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -224,9 +208,7 @@ Holder.addTheme("gray", {
 
     <div class="card-group-sm">
       <div class="card">
-        <div class="card-img">
-            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -234,9 +216,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -252,9 +232,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -299,9 +277,7 @@ Holder.addTheme("gray", {
 
     <div class="card-group-sm">
       <div class="card">
-        <div class="card-img">
-            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -317,9 +293,7 @@ Holder.addTheme("gray", {
     <h3>Deck</h3>
     <div class="card-deck-md">
       <div class="card">
-        <div class="card-img">
-          <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a longer card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -329,9 +303,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -341,9 +313,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -358,9 +328,7 @@ Holder.addTheme("gray", {
 
     <div class="card-group-md">
       <div class="card">
-        <div class="card-img">
           <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
@@ -370,9 +338,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
@@ -382,9 +348,7 @@ Holder.addTheme("gray", {
         </div>
       </div>
       <div class="card">
-        <div class="card-img">
-          <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-        </div>
+        <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
         <div class="card-body">
           <h4 class="card-title">Card title</h4>
           <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
@@ -401,18 +365,14 @@ Holder.addTheme("gray", {
 
     <div class="card-deck card-deck-col">
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a card with some amount of text. This is a card with some amount of text.</p>
             </div>
         </div>
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <div class="card">
@@ -426,18 +386,14 @@ Holder.addTheme("gray", {
             </div>
         </div>
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a card with some amount of text. This is a card with some amount of text.</p>
             </div>
         </div>
         <div class="card">
-            <div class="card-img">
-                <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
-            </div>
+            <img class="img-fluid card-img-top" data-src="holder.js/100px180/" alt="Card image cap">
             <div class="card-body">
                 <h4 class="card-title">Card title</h4>
                 <p class="card-text">This is a card with some amount of text. This is a card with some amount of text.</p>

--- a/test/visual/equalize.html
+++ b/test/visual/equalize.html
@@ -190,7 +190,7 @@
                     <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                 </div>
                 <div class="modal-body">
-                    <img data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
+                    <img data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
     <div data-cfw="equalize" id="modalRow2" data-cfw-equalize-target=".row2">
     <div data-cfw="equalize" id="modalRow1" data-cfw-equalize-target=".row1">
     <div data-cfw="equalize" id="modalRow0" data-cfw-equalize-target=".row0">
@@ -198,7 +198,7 @@
             <div class="col">
                 <div class="row0 card card-block">
                     One<br />
-                    <img data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
+                    <img data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
                 </div>
                 <div class="row1 card card-block">
                     One<br />
@@ -236,7 +236,7 @@
                     Three<br />
                     Three<br />
                     Three<br />
-                    <img data-cfw-lazy-src="../../docs/4.0.0-beta.1/assets/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
+                    <img data-cfw-lazy-src="../../site/assets/4.0/img/test.gif" alt="test pattern" class="img-fluid" data-cfw="lazy" data-cfw-lazy-speed=1000 />
                 </div>
             </div>
         </div>

--- a/test/visual/input-group.html
+++ b/test/visual/input-group.html
@@ -7,7 +7,7 @@
 <title>Figuration - Input Group</title>
 
 <link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css" />
-<link rel="stylesheet" href="../../docs/4.0.0-beta.1/assets/fonts/fontawesome/css/all.min.css">
+<link rel="stylesheet" href="../../site/assets/4.0/fonts/fontawesome/css/all.min.css">
 
 <script src="../../node_modules/jquery/dist/jquery.slim.min.js"></script>
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>

--- a/test/visual/media-object.html
+++ b/test/visual/media-object.html
@@ -12,7 +12,7 @@
 <script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>
 <script src="../../dist/js/figuration.js"></script>
 
-<script src="../../docs/4.0.0-beta.1/assets/js/vendor/holder.min.js"></script>
+<script src="../../site/assets/4.0/js/vendor/holder.min.js"></script>
 <script>
 Holder.addTheme("gray", {
     bg: "#999",


### PR DESCRIPTION
Make it optionally useable as a wrapper.  But IE will either need to have it as  a wrapper, or have to use one of the card image classes to prevent 'blow-out'.
- `.card-img`
- `.card-img-top`
- `.card-img-bottom`