### PR TITLE
Widget-Modal: Add close is blocked animation

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -266,15 +266,22 @@
         escape : function() {
             var $selfRef = this;
             var KEYCODE_ESC = 27;
-            if (this.isShown && this.settings.keyboard) {
+
+            if (!this.isShown) {
+                this.$target.off('keydown.dismiss.cfw.modal');
+            }
+
+            if (this.isShown) {
                 this.$target.on('keydown.dismiss.cfw.modal', function(e) {
                     if (e.which === KEYCODE_ESC) {
-                        e.preventDefault();
-                        $selfRef.hide();
+                        if ($selfRef.settings.keyboard) {
+                            e.preventDefault();
+                            $selfRef.hide();
+                        } else {
+                            $selfRef.hideBlocked();
+                        }
                     }
                 });
-            } else if (!this.isShown) {
-                this.$target.off('keydown.dismiss.cfw.modal');
             }
         },
 
@@ -433,7 +440,7 @@
                     }
                     if (e.target !== e.currentTarget) { return; }
                     if ($selfRef.settings.backdrop === 'static') {
-                        $selfRef.$target.trigger('focus');
+                        $selfRef.hideBlocked();
                     } else {
                         $selfRef.hide();
                     }
@@ -463,6 +470,21 @@
                 this.$backdrop.remove();
                 this.$backdrop = null;
             }
+        },
+
+        hideBlocked : function() {
+            var $selfRef = this;
+            if (!this.$target.CFW_trigger('beforeHide.cfw.modal')) {
+                return;
+            }
+
+            var complete = function() {
+                $selfRef.$target.trigger('focus');
+                $selfRef.$target.removeClass('modal-blocked');
+            };
+
+            this.$target.addClass('modal-blocked');
+            this.$dialog.CFW_transition(null, complete);
         },
 
         unlink : function() {

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -579,7 +579,7 @@ $transition-collapse-x:     width .3s ease !default;
 // Component transitions
 $btn-transition:            color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 $input-transition:          background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
-$modal-transition:          transform .3s ease-out !default;
+$modal-transition:          transform .15s linear !default;
 $progress-bar-transition:   width .3s ease !default;
 $switch-transition:         all .15s ease-in-out !default;
 
@@ -1300,6 +1300,7 @@ $modal-lg-breakpoint:           lg !default; // The minimum breakpoint to allow 
 $modal-transform-fade:          translate(0, -3rem) !default;
 $modal-transform-in:            none !default;
 $modal-transform-side-offset:   -5rem !default;
+$modal-transform-blocked:       scale(1.01) !default;
 
 
 // Player

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -138,6 +138,11 @@
         transform: $modal-transform-in;
     }
 
+    // Close is blocked animation
+    .modal.modal-blocked .modal-dialog {
+        transform: $modal-transform-blocked;
+    }
+
     // Actual modal
     .modal-content {
         position: relative;

--- a/site/4.0/widgets/modal.md
+++ b/site/4.0/widgets/modal.md
@@ -709,6 +709,45 @@ Position a modal to the side of the page with a `.modal-dialog-side-start` or `.
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
+### Static Backdrop
+
+When `backdrop` option is set to `static`, the modal will not close when clicking outside it. Click the button below to try it.
+
+<div class="modal" id="modalStaticBackdrop">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Static backdrop modal</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        <p>I will not close if you click outside me.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="cf-example">
+  <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-backdrop="static" data-cfw-modal-target="#modalStaticBackdrop">Static backdrop modal</button>
+</div>
+
+{% capture highlight %}
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-backdrop="static" data-cfw-modal-target="#modalStaticBackdrop">Static backdrop modal</button>
+
+<div class="modal" id="modalStaticBackdrop">
+  <div class="modal-dialog modal-dialog-side-end modal-dialog-scrollable modal-sm">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
 ## Usage
 
 The modal widget toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
@@ -803,7 +842,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>keyboard</td>
         <td>boolean</td>
         <td><code>true</code></td>
-        <td>Closes the modal when escape key is pressed</td>
+        <td>Closes the modal when escape key is pressed.</td>
       </tr>
       <tr>
         <td>show</td>
@@ -1325,11 +1364,19 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$modal-transform-blocked</code></td>
+        <td>string</td>
+        <td><code>scale(1.01)</code></td>
+        <td>
+          Transform state of <code>.modal-dialog</code> for the close is blocked animation.
+        </td>
+      </tr>
+      <tr>
         <td><code>$modal-transition</code></td>
         <td>string</td>
-        <td><code>transform .3s ease-out</code></td>
+        <td><code>transform .15s linear</code></td>
         <td>
-          Transition settings for the <code>.modal-dialog</code> fade-in animation.
+          Transition settings for the <code>.modal-dialog</code> animations.
         </td>
       </tr>
     </tbody>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -405,6 +405,28 @@ $(window).ready(function() {
 
             <h2 id="modal">Modal:</h2>
             <p>
+                <button class="btn btn-primary" data-cfw="modal" data-cfw-modal-backdrop="static" data-cfw-modal-keyboard="false" data-cfw-modal-target="#modalStaticBackdrop">Static backdrop modal</button>
+            </p>
+            <div class="modal" id="modalStaticBackdrop">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h4 class="modal-title">Static backdrop modal</h4>
+                    <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  </div>
+                  <div class="modal-body">
+                    <p>I will not close if you click outside me. Don't even try to press escape key.</p>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary">Save</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            </p>
+            <p>
                 <button class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalCenter">
                     Centered modal
                 </button>

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -249,6 +249,30 @@ $(function() {
         $trigger.CFW_Modal('show');
     });
 
+    QUnit.test('should not close modal when escape key is pressed via keydown with "keyboard:false"', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal" data-cfw-modal-keyboard="false">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"/>').appendTo(document.body);
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.ok($target.is(':visible'), 'modal visible');
+                $target.trigger($.Event('keydown', {
+                    which: 27 // Esc
+                }));
+
+                setTimeout(function() {
+                    assert.ok($target.is(':visible'), 'modal still visible');
+                    done();
+                }, 0);
+            });
+
+        $trigger.CFW_Modal();
+        $trigger.CFW_Modal('show');
+    });
+
     QUnit.test('should not close modal when clicking outside of modal-content with "backdrop:static"', function(assert) {
         assert.expect(1);
         var done = assert.async();


### PR DESCRIPTION
If the close is blocked due to either a `backdrop:'static'` or `keyboard:false` setting, the modal dialog will get a minor scaling animation to help visually indicate the close is blocked.