### PR TITLE
Dropdown alignment updates

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -152,9 +152,9 @@
             var selector = this.$element.CFW_getSelectorFromChain('dropdown', this.settings.target);
             var $target = $(selector);
 
-            // Target by sibling class
+            // Target by next sibling class
             if (!$target.length) {
-                $target = $(this.$element.siblings('.dropdown-menu, ul, ol')[0]);
+                $target = $(this.$element.next('.dropdown-menu, ul, ol')[0]);
             }
             if (!$target.length) { return; }
             this.$target = $target;
@@ -213,11 +213,11 @@
                 }
 
                 // Manipulate directions of submenus
-                var $dirNode = $this.closest('.dropend, .dropstart');
-                if ($dirNode.hasClass('dropend')) {
-                    $this.addClass('dropdown-subalign-reverse');
+                var $dirNode = $subTarget.closest('.dropreverse, .dropend, .dropstart');
+                if ($dirNode.hasClass('dropreverse') || $dirNode.hasClass('dropstart')) {
+                    $subTarget.addClass('dropdown-subalign-reverse');
                 } else {
-                    $this.addClass('dropdown-subalign-forward');
+                    $subTarget.addClass('dropdown-subalign-forward');
                 }
             });
 
@@ -518,25 +518,26 @@
                 TOPEND: isRTL ? 'top-start' : 'top-end',
                 FORWARD: isRTL ? 'left-start' : 'right-start',
                 FORWARDEND: isRTL ? 'left-end' : 'right-end',
-                RIGHT: 'right-start',
-                RIGHTEND: 'right-end',
                 BOTTOM: isRTL ? 'bottom-end' : 'bottom-start',
                 BOTTOMEND: isRTL ? 'bottom-start' : 'bottom-end',
                 REVERSE: isRTL ? 'right-start' : 'left-start',
-                REVERSEEND: isRTL ? 'right-end' : 'left-end',
-                LEFT: 'left-start',
-                LEFTEND: 'left-end'
+                REVERSEEND: isRTL ? 'right-end' : 'left-end'
             };
 
-            var $dirNode = this.$element.closest('.dropend, .dropstart, .dropup');
-            var dirH = $dirNode.hasClass('dropup') ? 'TOP' : 'BOTTOM';
-            var appendH = $dirNode.hasClass('dropend') ? 'END' : '';
-            var dirV = $dirNode.hasClass('dropend') ? 'REVERSE' : 'FORWARD';
-            var appendV = $dirNode.hasClass('dropup') ? 'END' : '';
+            var $dirNode = this.$target.closest('.dropup, .dropreverse, .dropstart, .dropend');
+            var dirV = $dirNode.hasClass('dropup') ? 'TOP' : 'BOTTOM';
+            var appendV = $dirNode.hasClass('dropreverse') ? 'END' : '';
+            var dirH = $dirNode.hasClass('dropstart') || $dirNode.hasClass('dropreverse') ? 'REVERSE' : 'FORWARD';
+            var appendH = $dirNode.hasClass('dropup') ? 'END' : '';
 
-            var placement = attachmentMap[dirH + appendH];
+            var placement = attachmentMap[dirV + appendV];
+
+            if ($dirNode.hasClass('dropstart') || $dirNode.hasClass('dropend')) {
+                placement = attachmentMap[dirH + appendH];
+            }
+
             if (this.settings.isSubmenu) {
-                placement = attachmentMap[dirV + appendV];
+                placement = attachmentMap[dirH + appendH];
             }
             return placement;
         },

--- a/scss/component/_caret.scss
+++ b/scss/component/_caret.scss
@@ -1,10 +1,19 @@
+%caret-base {
+    display: inline-block;
+    width: $caret-width;
+    text-align: center;
+}
+%caret-after {
+    @include caret(null, null);
+}
+
 @if $enable-utility-caret {
     .caret {
-        display: inline-block;
-        width: $caret-width;
-        text-align: center;
+        @extend %caret-base;
+
         &::after {
-            @include caret(down, $caret-border-width);
+            @extend %caret-after;
+            @include caret-down($caret-border-width);
         }
     }
     .open .caret {
@@ -12,4 +21,47 @@
             @include caret-up($caret-border-width);
         }
     }
+
+    .caretup {
+        @extend %caret-base;
+
+        &::after {
+            @extend %caret-after;
+            @include caret-up($caret-border-width);
+        }
+    }
+    .open .caretup {
+        &::after {
+            @include caret-down($caret-border-width);
+        }
+    }
+
+    .caretstart {
+        @extend %caret-base;
+
+        &::after {
+            @extend %caret-after;
+            @include caret-start($caret-border-width);
+        }
+    }
+    .open .caretstart {
+        &::after {
+            @include caret-end($caret-border-width);
+        }
+    }
+
+    .caretend {
+        @extend %caret-base;
+
+        &::after {
+            @extend %caret-after;
+            @include caret-end($caret-border-width);
+        }
+    }
+    .open .caretend {
+        &::after {
+            @include caret-start($caret-border-width);
+        }
+    }
 }
+

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -1,7 +1,6 @@
 // stylelint-disable selector-no-qualifying-type
 @if $enable-dropdown {
     // The dropdown wrapper (`<div>`) and submenu (`<ul>`)
-    .dropup,
     .dropdown,
     .dropdown-submenu {
         position: relative;
@@ -42,7 +41,7 @@
     .dropdown-submenu {
         > .dropdown-menu {
             top: 0;
-            left: 100%;
+            //left: 100%;
             margin-top: calc(#{$dropdown-border-width} - #{$dropdown-spacer} - #{$dropdown-padding-y});
         }
 
@@ -62,41 +61,27 @@
         }
     }
 
-    // Open state for the dropdown
-    // .open {
-    //     // Show the menu
-    //     > .dropdown-menu {
-    //         display: block;
-    //     }
-    // }
-
-    // Allow for menus to go left - aligning to right side of the control
-    .dropend {
-        .dropdown-menu {
-            right: 0;
-            left: auto;
-        }
+    // Allow for menus to in reverse direction - aligning to end side of the control
+    .dropreverse {
+        right: 0;
+        left: auto;
     }
 
     // Submenu alignment
     // The `.dropdown-subalign-*` classes are added automatically by the dropdown.js widget
     // This removes the need for overly convoluted CSS rules
     .dropdown-subalign-forward {
-        > .dropdown-menu {
-            right: auto;
-            left: 100%;
-            margin-right: -($dropdown-border-width * 2);
-            margin-left: 0;
-        }
+        right: auto;
+        left: 100%;
+        margin-right: 0;
+        margin-left: 0;
     }
 
     .dropdown-subalign-reverse {
-        > .dropdown-menu {
-            right: 100%;
-            left: auto;
-            margin-right: 0;
-            margin-left: -($dropdown-border-width * 2);
-        }
+        right: 100%;
+        left: auto;
+        margin-right: 0;
+        margin-left: 0;
     }
 
     // Links within a dropdown menu
@@ -182,31 +167,39 @@
         }
     }
 
-    // Allow for dropdowns to go bottom up (aka, dropup-menu)
-    // Add .dropup after the standard .dropdown class
+
+    .dropstart {
+        top: 0;
+        right: 100%;
+        left: auto;
+        margin-top: 0;
+        margin-right: $dropdown-spacer;
+
+        .dropdown-menu {
+            margin-right: 0;
+        }
+    }
+
+    .dropend {
+        top: 0;
+        right: auto;
+        left: 100%;
+        margin-top: 0;
+        margin-left: $dropdown-spacer;
+
+        .dropdown-menu {
+            margin-left: 0;
+        }
+    }
+
+    // Allow for dropdowns to go bottom up (aka, dropup menu)
+    // Add .dropup onto the .dropdown-menu element
     @if $enable-dropdown-dropup {
         .dropup {
-            // Reverse the caret
-            .caret {
-                &::after {
-                    @include caret-up();
-                }
-            }
-            &.open {
-                .caret {
-                    &::after {
-                        @include caret-down();
-                    }
-                }
-            }
-
-            // Different positioning for bottom up menu
-            .dropdown-menu {
-                top: auto;
-                bottom: 100%;
-                margin-top: 0;
-                margin-bottom: $dropdown-spacer;
-            }
+            top: auto;
+            bottom: 100%;
+            margin-top: 0;
+            margin-bottom: $dropdown-spacer;
 
             .dropdown-submenu {
                 > .dropdown-menu {
@@ -216,6 +209,13 @@
                     margin-bottom: calc(#{$dropdown-border-width} - #{$dropdown-spacer} - #{$dropdown-padding-y});
                 }
             }
+
+            &.dropstart,
+            &.dropend {
+                bottom: 0;
+                margin-bottom: 0;
+            }
+
         }
     }
 

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -51,8 +51,8 @@
                 position: absolute;
                 top: 50%;
                 right: $dropdown-caret-spacer-x;
-                margin-top: -$dropdown-caret-width;
                 @include caret(end, $dropdown-caret-width, $dropdown-caret-color);
+                transform: translateY(-25%);
             }
 
             &.active:not(:hover):not(:focus)::after {
@@ -237,8 +237,8 @@
                 position: absolute;
                 top: 50%;
                 left: $dropdown-back-spacer-x;
-                margin-top: -$dropdown-caret-width;
                 @include caret(start, $dropdown-back-width, $dropdown-back-color);
+                transform: translateY(-25%);
             }
         }
 

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -67,23 +67,6 @@
         left: auto;
     }
 
-    // Submenu alignment
-    // The `.dropdown-subalign-*` classes are added automatically by the dropdown.js widget
-    // This removes the need for overly convoluted CSS rules
-    .dropdown-subalign-forward {
-        right: auto;
-        left: 100%;
-        margin-right: 0;
-        margin-left: 0;
-    }
-
-    .dropdown-subalign-reverse {
-        right: 100%;
-        left: auto;
-        margin-right: 0;
-        margin-left: 0;
-    }
-
     // Links within a dropdown menu
     // Because we support nested dropdowns, it is currently required to use a
     // list for semantic markup, but we include a `.dropdown-item`
@@ -167,29 +150,32 @@
         }
     }
 
+    // Submenu and side alignments
+    // The `.dropdown-subalign-*` classes are added automatically by the dropdown.js widget
+    // This removes the need for overly convoluted CSS rules
 
+    .dropdown-subalign-reverse,
     .dropstart {
         top: 0;
         right: 100%;
         left: auto;
         margin-top: 0;
         margin-right: $dropdown-spacer;
-
-        .dropdown-menu {
-            margin-right: 0;
-        }
+    }
+    .dropdown-subalign-reverse {
+        margin-right: 0;
     }
 
+    .dropdown-subalign-forward,
     .dropend {
         top: 0;
         right: auto;
         left: 100%;
         margin-top: 0;
         margin-left: $dropdown-spacer;
-
-        .dropdown-menu {
-            margin-left: 0;
-        }
+    }
+    .dropdown-subalign-forward {
+        margin-left: 0;
     }
 
     // Allow for dropdowns to go bottom up (aka, dropup menu)

--- a/scss/mixins/_caret.scss
+++ b/scss/mixins/_caret.scss
@@ -24,6 +24,7 @@
 }
 
 @mixin caret-start($width: $caret-border-width, $color: null) {
+    margin-top: $width / -2;
     @if ($color != null) {
         $color:  #{" " + $color};
     }
@@ -34,6 +35,7 @@
 }
 
 @mixin caret-end($width: $caret-border-width, $color: null) {
+    margin-top: $width / -2;
     @if ($color != null) {
         $color:  #{" " + $color};
     }

--- a/site/4.0/examples/navbar-fixed-bottom/index.html
+++ b/site/4.0/examples/navbar-fixed-bottom/index.html
@@ -45,9 +45,9 @@ body {
             <li class="nav-item">
                 <a href="#" class="nav-link disabled" tabindex="-1" aria-disabled="true">Disabled</a>
             </li>
-            <li class="nav-item dropdown dropup">
-                <a class="nav-link" href="#" data-cfw="dropdown">Dropup<span class="caret ms-0_25" aria-hidden="true"></span></a>
-                <ul class="dropdown-menu">
+            <li class="nav-item dropdown">
+                <a class="nav-link" href="#" data-cfw="dropdown">Dropup<span class="caretup ms-0_25" aria-hidden="true"></span></a>
+                <ul class="dropdown-menu dropup">
                     <li><a href="#">Action</a></li>
                     <li><a href="#">Another action</a></li>
                     <li><a href="#">Something else here</a></li>

--- a/site/4.0/get-started/migration.md
+++ b/site/4.0/get-started/migration.md
@@ -116,9 +116,14 @@ ${toc}
 - Dropped button widget in favor of CSS input buttons.  Single state toggles can be replaced with checkbox `.btn-check` variant.
 
 ### Dropdown
-- Dropdown has been reworked to use a recursive model, and now requires [Popper.js](https://popper.js.org/) for positioning, meaning changes to the available options.
-- Horizontal menu direction classes have been updated to use the following alternates: `.dropend`, `.dropstart`, replacing the previous `.dropdown-menu-reverse` and `.dropdown-menu-forward` classes.
-- The classed used to show menus, `.open`, is now used on the `.dropdown-menu` iteself, instead of the parent container.
+- Dropdown has been reworked to use a recursive model, and now uses [Popper.js](https://popper.js.org/) for advanced positioning.  This also had an affect of changing all the available options.
+  - There are positioning fallbacks in place if dynamic placement is disabled, or Popper is not available.
+- Menu direction classes have been expanded to use the following alternates: `.dropup`, `.dropreverse`, `.dropend`, `.dropstart`, replacing the previous `.dropdown-menu-reverse` and `.dropdown-menu-forward` classes.
+  - The directions classes are now applied directly to the `.dropdown-menu` element, or the submenu `ol`/`ul` list elements, rather than it's parent container.
+  - `.dropreverse` replaces `.dropdown-menu-reverse` on primary menus.
+  - `.dropend` replaces `.dropdown-menu-reverse` on submenus.
+  - `.dropstart` replaces `.dropdown-menu-forward` on all menus.
+- The class used to show menus, `.open`, is now used on the `.dropdown-menu` iteself, instead of the parent container.
 
 ### Lazy
 - Dropped support for jQuery animations as the slim build does not support them.  Added an optional fade-in CSSS animation.
@@ -127,16 +132,17 @@ ${toc}
 - Dropped support for sliders using the Slider widget, and added support for `<input type="range">` elements.  A few improvements on the accesibility of the sliders were also added.
 
 ### Popover
-- Popover now require [Popper.js](https://popper.js.org/) for positioning, replacing our custom code.  This also means changes to the available options.
+- Popover now requires [Popper.js](https://popper.js.org/) for positioning, replacing our custom code.  This also means changes to the available options.
 
 ### Slider
 - Dropped the slider widget as a bundled plugin.  This has been replaced with the `.form-range` styled `<input type="range">` element.
 
 ### Tooltip
-- Tooltip now require [Popper.js](https://popper.js.org/) for positioning, replacing our custom code.  This also means changes to the available options.
+- Tooltip now requires [Popper.js](https://popper.js.org/) for positioning, replacing our custom code.  This also means changes to the available options.
 
 ## Documentation
 - We have stopped using Jekyll, and changed to using [Eleventy](https://11ty.dev) to generate the documentation.
 
 ## Build Tools
 - Figuration now requires Node.js v10 or newer if using our build tools.  This is due to the minimum Node.js requirement for `grunt-sass`.
+- The `grunt` directory has been removed, and replaced with a `build` directory.

--- a/site/4.0/utilities/icons.md
+++ b/site/4.0/utilities/icons.md
@@ -9,24 +9,17 @@ group: utilities
 
 ${toc}
 
-## Caret Icon
+## Caret Icons
 
-Use carets to indicate some meaning of functionality or direction. Note that the default caret will reverse automatically in [dropup menus]({{ site.path }}/{{ version.docs }}/widgets/dropdown/).
+Use carets to indicate some meaning of functionality or direction.
 
-If inside of an element marked as `.open` the caret will reverse direction accordingly to indicate state.
+If used inside of an element marked as `.open` the caret will reverse direction accordingly to indicate state.
 
 {% capture example %}
 <span class="caret" aria-hidden="true"></span>
-<span class="open">
-  <span class="caret" aria-hidden="true"></span>
-</span>
-&mdash;
-<span class="dropup">
-  <span class="caret" aria-hidden="true"></span>
-</span>
-<span class="dropup open">
-  <span class="caret" aria-hidden="true"></span>
-</span>
+<span class="caretup" aria-hidden="true"></span>
+<span class="caretstart" aria-hidden="true"></span>
+<span class="caretend" aria-hidden="true"></span>
 {% endcapture %}
 {% renderExample example %}
 
@@ -129,7 +122,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         <td>boolean</td>
         <td><code>true</code></td>
         <td>
-          Enable generation of the caret icon utility class.
+          Enable generation of the caret icon utility classes.
         </td>
       </tr>
       <tr>

--- a/site/4.0/widgets/dropdown.md
+++ b/site/4.0/widgets/dropdown.md
@@ -234,7 +234,7 @@ Add `.disabled` to the `a` item in the dropdown to make them visually _appear_ d
 
 ### Active Menu Items
 
-Add `.active` to the `li` item in the dropdown to show a visual emphasis.
+Add `.active` to the child of the `li` item in the dropdown to show a visual emphasis.
 
 To convey the active state to assistive technologies, use the `aria-current` attribute &mdash; using the `page` value for the current page, or `true` for the current item in a set.
 

--- a/site/4.0/widgets/dropdown.md
+++ b/site/4.0/widgets/dropdown.md
@@ -54,7 +54,7 @@ Here is a static example showing the dropdown layout and content pieces.
       <li><a href="#" class="disabled" tabindex="-1" aria-disabled="true">Disabled action</a></li>
       <li class="dropdown-submenu">
         <a href="#" class="open">Something else here</a>
-        <ul class="dropdown-menu open">
+        <ul class="dropdown-menu dropdown-subalign-forward open">
           <li class="dropdown-back"><button type="button" class="dropdown-item">Back</button></li>
           <li><a href="#">Action</a></li>
           <li><a href="#">Another action</a></li>
@@ -111,7 +111,7 @@ You can also use `<button>` elements in your dropdowns instead of `<a>`s.  You c
 
 {% capture example %}
 <div class="btn-group">
-  <button type="button" class="btn btn-group-end" data-cfw="dropdown">
+  <button type="button" class="btn btn-info btn-group-end" data-cfw="dropdown">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -131,8 +131,8 @@ The use of the `.btn-group-end` class allows us to place the dropdown within the
 
 {% capture example %}
 <div class="btn-group">
-  <button type="button" class="btn">Default</button>
-  <button type="button" class="btn btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
+  <button type="button" class="btn btn-info">Default</button>
+  <button type="button" class="btn btn-info btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
     <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -278,7 +278,7 @@ Using the [`backlink` option](#options), you can have 'back' menu items automati
 
 {% capture example %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -317,7 +317,7 @@ You can optionally use `<button>` elements in your dropdowns instead of just `<a
 
 {% capture example %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -337,7 +337,7 @@ Checkbox and radio inputs are allowed, but only **one per menu item**.
 
 {% capture example %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -366,7 +366,7 @@ Checkbox and radio inputs are allowed, but only **one per menu item**.
 
 {% capture example %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -399,7 +399,7 @@ Add `<input type="text">` or `textarea` items to your dropdown menu.  Other type
 
 {% capture example %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
   <ul class="dropdown-menu">
@@ -425,56 +425,20 @@ Add `<input type="text">` or `textarea` items to your dropdown menu.  Other type
 
 ## Variants
 
-### Dropup
-
-Trigger dropdown menus above elements by adding `.dropup` to the parent element.  The visual `.caret` for the toggle control will reverse direction automatically.
-
-{% capture example %}
-<div class="dropdown dropup">
-  <button type="button" class="btn btn-primary" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
-    Dropup <span class="caret" aria-hidden="true"></span>
-  </button>
-  <ul class="dropdown-menu">
-    <li class="dropdown-header">Dropdown header</li>
-    <li><a href="#">Action</a></li>
-    <li><a href="#">Another action</a></li>
-    <li>
-      <a href="#">Something else here</a>
-      <ul>
-        <li><a href="#">Action</a></li>
-        <li><a href="#">Another action</a></li>
-        <li>
-          <a href="#">Something else here</a>
-          <ul>
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-          </ul>
-        </li>
-        <li class="dropdown-divider"></li>
-        <li><a href="#">Separated link</a></li>
-      </ul>
-    </li>
-    <li class="dropdown-divider"></li>
-    <li><a href="#" class="disabled" tabindex="-1" aria-disabled="true">Disabled link</a></li>
-  </ul>
-</div>
-{% endcapture %}
-{% renderExample example %}
-
-### Menu Alignment
+### Reverse Alignment
 
 By default, a dropdown menu is automatically positioned 100% from the top and aligned to the left side of its parent.  While submenu items are aligned 100% from the left and to the top of its parent.
 
-Add `.dropend` to a `.dropdown-menu` to align the dropdown menu to the right side of the parent. This will also make all submenus open out to the left side.  This can also be combined with `.dropup`.
+Add `.dropreverse` to a `.dropdown-menu` to align the dropdown menu to the right side of the parent. This will also make all submenus open out to the left side.  This can also be combined with `.dropup`.
 
 **Heads up!** When using the right-to-left, `rtl`, variant of Figuration all horizontal directions will be reversed.  Meaning left becomes right, and vice-versa.
 
 {% capture example %}
-<div class="dropdown dropend float-end">
-  <button type="button" class="btn btn-primary" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+<div class="dropdown float-end">
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
     Reverse Dropdown <span class="caret" aria-hidden="true"></span>
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu dropreverse">
     <li class="dropdown-header">Dropdown header</li>
     <li><a href="#">Action</a></li>
     <li><a href="#">Another action</a></li>
@@ -501,50 +465,225 @@ Add `.dropend` to a `.dropdown-menu` to align the dropdown menu to the right sid
 {% endcapture %}
 {% renderExample example, "clearfix" %}
 
-### Submenu Alignment
+### Dropup
 
-The menu alignment class of `.dropend` will also work with submenu items, and you can use the available `.dropstart` to switch submenu directions if needed.  Simply place either class on the `li` parent of the submenu list.
+Trigger dropdown menus above elements by adding `.dropup` to the `.dropdown-menu` element.  The visual caret for the toggle control can be reversed in direction by switching to `.caretup`.
 
-{% capture example %}
+<div class="cf-example">
+  <div class="dropdown">
+    <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+      Dropup <span class="caretup" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu dropup">
+      <li class="dropdown-header">Dropdown header</li>
+      <li><a href="#">Action</a></li>
+      <li><a href="#">Another action</a></li>
+      <li>
+        <a href="#">Something else here</a>
+        <ul>
+          <li><a href="#">Action</a></li>
+          <li><a href="#">Another action</a></li>
+          <li>
+            <a href="#">Something else here</a>
+            <ul>
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+            </ul>
+          </li>
+          <li class="dropdown-divider"></li>
+          <li><a href="#">Separated link</a></li>
+        </ul>
+      </li>
+      <li class="dropdown-divider"></li>
+      <li><a href="#" class="disabled" tabindex="-1" aria-disabled="true">Disabled link</a></li>
+    </ul>
+  </div>
+</div>
+
+{% capture highlight %}
 <div class="dropdown">
-  <button type="button" class="btn" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
-    Dropdown <span class="caret" aria-hidden="true"></span>
+  <button type="button" class="btn btn-info" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
+    Dropup <span class="caretup" aria-hidden="true"></span>
   </button>
-  <ul class="dropdown-menu">
-    <li class="dropdown-header">Dropdown header</li>
-    <li><a href="#">Action</a></li>
-    <li class="dropend">
-      <a href="#">Reverse menu</a>
-      <ul>
-        <li class="dropend">
-          <a href="#">Reverse menu</a>
-          <ul>
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-          </ul>
-        </li>
-        <li class="dropstart">
-          <a href="#">Forward menu</a>
+  <ul class="dropdown-menu dropup">
+    ...
+  </ul>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Side Aligned
+
+Use `.dropstart` and `.dropend` to attach the menu to the side of the trigger.  As indicated by the classnames, `.dropstart` attaches the submenu to the start side of the parent menu, while `.dropend` attaches on the end side. Simply place either class on the `.dropdown-menu` element. This can also be combined with `.dropup`.
+
+Submenus will continue to open in the same direction as the parent, unless [Submenu Alignment](#submenu-alignment) overrides are used.
+
+<div class="cf-example">
+  <div class="btn-toolbar flex-center">
+    <div class="btn-group me-1">
+      <button type="button" class="btn btn-info btn-group-end" data-cfw="dropdown">
+        <span class="caretstart" aria-hidden="true"></span> Dropstart
+      </button>
+      <ul class="dropdown-menu dropstart">
+        <li><a href="#">Action</a></li>
+        <li><a href="#">Another action</a></li>
+        <li>
+          <a href="#">Something else here</a>
           <ul>
             <li><a href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
           </ul>
         </li>
       </ul>
-    </li>
-    <li class="dropstart">
-      <a href="#">Forward menu</a>
-      <ul>
-        <li class="dropend">
-          <a href="#">Reverse menu</a>
+    </div>
+    <div class="btn-group">
+      <button type="button" class="btn btn-info btn-group-end" data-cfw="dropdown">
+        Dropend <span class="caretend" aria-hidden="true"></span>
+      </button>
+      <ul class="dropdown-menu dropend">
+        <li><a href="#">Action</a></li>
+        <li><a href="#">Another action</a></li>
+        <li>
+          <a href="#">Something else here</a>
           <ul>
             <li><a href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
           </ul>
         </li>
-        <li class="dropstart">
-          <a href="#">Forward menu</a>
-          <ul>
+      </ul>
+    </div>
+  </div>
+  <div class="btn-toolbar flex-center mt-1">
+    <div class="btn-group me-1">
+      <div class="btn-group">
+        <button type="button" class="btn btn-info btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
+          <span class="caretstart" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropstart">
+          <li><a href="#">Action</a></li>
+          <li><a href="#">Another action</a></li>
+          <li>
+            <a href="#">Something else here</a>
+            <ul>
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <button type="button" class="btn btn-info">Split Dropstart</button>
+    </div>
+    <div class="btn-group">
+      <button type="button" class="btn btn-info">Split Dropend</button>
+      <div class="btn-group">
+        <button type="button" class="btn btn-info btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
+          <span class="caretend" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropend">
+          <li><a href="#">Action</a></li>
+          <li><a href="#">Another action</a></li>
+          <li>
+            <a href="#">Something else here</a>
+            <ul>
+              <li><a href="#">Action</a></li>
+              <li><a href="#">Another action</a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% capture highlight %}
+<div class="btn-group">
+  <button type="button" class="btn btn-info btn-group-end" data-cfw="dropdown">
+    <span class="caret" aria-hidden="true"></span> Dropstart
+  </button>
+  <ul class="dropdown-menu dropstart">
+    ...
+  </ul>
+</div>
+
+<div class="btn-group">
+  <button type="button" class="btn btn-info btn-group-end" data-cfw="dropdown">
+    Dropend <span class="caret" aria-hidden="true"></span>
+  </button>
+  <ul class="dropdown-menu dropend">
+    ...
+  </ul>
+</div>
+
+<div class="btn-group">
+  <div class="btn-group">
+    <button type="button" class="btn btn-info" data-cfw="dropdown" aria-label="Toggle Dropdown">
+      <span class="caret" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu">
+      ...
+    </ul>
+  </div>
+  <button type="button" class="btn btn-info">Split Dropstart</button>
+</div>
+
+<div class="btn-group">
+  <button type="button" class="btn btn-info">Split Dropend</button>
+  <div class="btn-group">
+    <button type="button" class="btn btn-info" data-cfw="dropdown" aria-label="Toggle Dropdown">
+      <span class="caret" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu">
+      ...
+    </ul>
+  </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Submenu Alignment
+
+You can also use the available `.dropstart` and `.dropend` to switch submenu directions if needed.  Place either class on the `ol` or `ul` submenu list element.
+
+{% capture example %}
+<div class="dropdown">
+  <button type="button" class="btn btn-info" data-cfw="dropdown">
+    Dropdown <span class="caret" aria-hidden="true"></span>
+  </button>
+  <ul class="dropdown-menu">
+    <li class="dropdown-header">Dropdown header</li>
+    <li><a href="#">Action</a></li>
+    <li>
+      <a href="#">Start side menu</a>
+      <ul class="dropstart">
+        <li>
+          <a href="#">Start side menu</a>
+          <ul class="dropstart">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#">End side menu</a>
+          <ul class="dropend">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a href="#">End side menu</a>
+      <ul class="dropend">
+        <li>
+          <a href="#">Start side menu</a>
+          <ul class="dropstart">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+          </ul>
+        </li>
+        <li>
+          <a href="#">End side menu</a>
+          <ul class="dropend">
             <li><a href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
           </ul>
@@ -565,8 +704,8 @@ Use the `reference` option to help control the location of a dropdown menu.
 {% capture example %}
 <div class="d-flex">
   <div class="btn-group me-1">
-    <button type="button" class="btn">Default</button>
-    <button type="button" class="btn btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
+    <button type="button" class="btn btn-info">Default</button>
+    <button type="button" class="btn btn-info btn-icon btn-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown">
       <span class="caret" aria-hidden="true"></span>
     </button>
     <ul class="dropdown-menu">
@@ -577,8 +716,8 @@ Use the `reference` option to help control the location of a dropdown menu.
   </div>
 
   <div class="btn-group">
-    <button type="button" class="btn">Reference</button>
-    <button type="button" class="btn btn-icon btn-group-end" data-cfw="dropdown" data-cfw-dropdown-reference="parent" aria-label="Toggle Dropdown">
+    <button type="button" class="btn btn-info">Reference</button>
+    <button type="button" class="btn btn-info btn-icon btn-group-end" data-cfw="dropdown" data-cfw-dropdown-reference="parent" aria-label="Toggle Dropdown">
       <span class="caret" aria-hidden="true"></span>
     </button>
     <ul class="dropdown-menu">

--- a/site/_includes/4.0/partials/settings_menu.html
+++ b/site/_includes/4.0/partials/settings_menu.html
@@ -1,8 +1,8 @@
-<div class="dropdown dropend">
+<div class="dropdown">
   <a href="#" role="button" class="nav-link px-0_5" aria-label="Settings" data-cfw="dropdown">
     {% include "./icons/cog.svg", width: "1rem", height: "1rem" %}
   </a>
-  <ul class="dropdown-menu position-absolute">
+  <ul class="dropdown-menu dropreverse position-absolute">
     <li class="dropdown-header">Direction</li>
     <li><button type="button" class="dropdown-item" id="dir-ltr">Left-to-right</button></li>
     <li><button type="button" class="dropdown-item" id="dir-rtl">Right-to-left</button></li>

--- a/site/assets/4.0/js/src/docs.js
+++ b/site/assets/4.0/js/src/docs.js
@@ -233,9 +233,7 @@
 
     // Direction for player dropdown menus
     $(document, '[data-cfw="player"]').on('ready.cfw.player', function(e) {
-        $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropend');
-        $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropend');
-        $(e.target).closest('[data-cfw="player"]').find('.player-text-describe-wrapper').addClass('dropup dropend');
+        $(e.target).closest('[data-cfw="player"]').find('.dropdown-menu').addClass('dropup dropreverse');
     });
 
     $(window).ready(function() {

--- a/test/dev/player.html
+++ b/test/dev/player.html
@@ -28,9 +28,7 @@ function myLog(item) {
 
 // Direction for player dropdown menus
 $(document, '[data-cfw="player"]').on('ready.cfw.player', function(e) {
-    $(e.target).closest('[data-cfw="player"]').find('.player-caption-wrapper').addClass('dropup dropend');
-    $(e.target).closest('[data-cfw="player"]').find('.player-script-wrapper').addClass('dropup dropend');
-    $(e.target).closest('[data-cfw="player"]').find('.player-text-describe-wrapper').addClass('dropup dropend');
+    $(e.target).closest('[data-cfw="player"]').find('.dropdown-menu').addClass('dropup dropreverse');
 });
 </script>
 
@@ -514,7 +512,7 @@ body {
             <span class="player-volume" data-cfw-player="volume">
                 <input type="range" class="form-range" aria-label="Volume">
             </span>
-            <div class="dropup dropleft" style="display: inline-block; position: relative;">
+            <div style="display: inline-block; position: relative;">
                 <button type="button" class="btn btn-icon player-speed" data-cfw="dropdown" data-cfw-dropdown-target="#speed0" title="Playback speed" aria-label="Playback speed"><span class="fas fa-fw fa-sort"></span></button>
                 <ul class="dropdown" id="speed0" style="min-width: 75px; width: 75px; text-align: center;">
                     <li><a href="#" onclick="javascript:$(this).closest('[data-cfw]').CFW_Player('speed', 0.25); return false;">0.25&times;</a></li>

--- a/test/dev/styles.html
+++ b/test/dev/styles.html
@@ -1799,11 +1799,11 @@ function toggleRadio () {
         </ul>
     </div>
 
-    <div class="btn-group dropup">
+    <div class="btn-group">
         <button type="button" class="btn btn-group-end" data-cfw="dropdown">
-            Drop Up <span class="caret"></span>
+            Drop Up <span class="caretup"></span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu dropup">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -1858,11 +1858,11 @@ function toggleRadio () {
         </ul>
     </div>
 
-    <div class="btn-group dropdown-menu-reverse" style="float: right;">
+    <div class="btn-group" style="float: right;">
         <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
             Drop Left <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu dropreverse">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
             <li>
@@ -1926,38 +1926,38 @@ function toggleRadio () {
     <ul class="dropdown-menu">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
@@ -1969,45 +1969,45 @@ function toggleRadio () {
     </ul>
 </div>
 
-<div class="btn-group dropdown-menu-forward">
+<div class="btn-group">
     <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Right <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropstart">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
@@ -2019,45 +2019,45 @@ function toggleRadio () {
     </ul>
 </div>
 
-<div class="btn-group dropdown-menu-reverse" style="float: right;">
+<div class="btn-group" style="float: right;">
     <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
         Drop Left <span class="caret"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropreverse">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class=""dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
@@ -2071,45 +2071,45 @@ function toggleRadio () {
 
 <h3>Dropup submenu alignment</h3>
 
-<div class="btn-group dropup">
+<div class="btn-group">
     <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-backlink="true">
-        Dropup <span class="caret"></span>
+        Dropup <span class="caretup"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropup">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
@@ -2122,45 +2122,45 @@ function toggleRadio () {
 </div>
 
 
-<div class="btn-group dropup dropdown-menu-forward">
+<div class="btn-group">
     <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
-        Dropup Right <span class="caret"></span>
+        Dropup Right <span class="caretup"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropup">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
@@ -2172,45 +2172,45 @@ function toggleRadio () {
     </ul>
 </div>
 
-<div class="btn-group dropup dropdown-menu-reverse">
+<div class="btn-group">
     <button type="button" class="btn btn-group-end" data-cfw="dropdown data-cfw-dropdown-backlink="true" data-cfw-dropdown-backtop="true">
-        Dropup Left <span class="caret"></span>
+        Dropup Left <span class="caretup"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropup dropreverse">
         <li class="dropdown-header">Dropdown header</li>
         <li><a href="#">Action</a></li>
-        <li class="dropdown-menu-reverse">
+        <li>
             <a href="#">Left menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropstart">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
             </ul>
         </li>
-        <li class="dropdown-menu-forward">
+        <li>
             <a href="#">Right menu</a>
-            <ul>
-                <li class="dropdown-menu-reverse">
+            <ul class="dropend">
+                <li>
                     <a href="#">Left menu</a>
-                    <ul>
+                    <ul class="dropstart">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>
                 </li>
-                <li class="dropdown-menu-forward">
+                <li>
                     <a href="#">Right menu</a>
-                    <ul>
+                    <ul class="dropend">
                         <li><a href="#">Action</a></li>
                         <li><a href="#">Another action</a></li>
                     </ul>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1217,11 +1217,11 @@ $(window).ready(function() {
                 </div>
             </div>
             <div class="mb-1">
-                <div class="dropdown dropup dropdown-menu-reverse d-inline-block">
+                <div class="dropdown d-inline-block">
                   <a href="#" role="button" data-cfw="dropdown" data-cfw-dropdown-container="body">
                     Reverse dropup w/ container<span class="caret ms-0_25"></span>
                   </a>
-                  <ul class="dropdown-menu">
+                  <ul class="dropdown-menu dropup dropreverse ">
                     <li class="dropdown-text">Non-interactive text</li>
                     <li><a href="#">Action</a></li>
                     <li>
@@ -1608,11 +1608,11 @@ $(window).ready(function() {
             </div>
 
             <!-- Single button -->
-            <div class="btn-group dropdown-menu-reverse" style="float: right;">
+            <div class="btn-group" style="float: right;">
                 <button type="button" class="btn btn-group-end" data-cfw="dropdown" data-cfw-dropdown-target="#dropdownTest_5" data-cfw-dropdown-backlink=true>
                     Reverse Dropdown <span class="caret"></span>
                 </button>
-                <ul class="dropdown-menu" id="dropdownTest_5">
+                <ul class="dropdown-menu dropreverse" id="dropdownTest_5">
                     <li class="dropdown-header">Dropdown header</li>
                     <li><a href="#5-1">Action</a></li>
                     <li>

--- a/test/visual/dropdown.html
+++ b/test/visual/dropdown.html
@@ -126,51 +126,119 @@
                 <li><a href="#3-3-2">Something else here</a></li>
             </ul>
         </li>
-        <li class="dropdown-divider"></li>
-        <li><a href="#3-4">Separated link</a></li>
+    </ul>
+</div>
+
+<div class="dropdown mb-1">
+    <a href="#" id="dropdown4" class="btn btn-info" role="button" data-cfw="dropdown" data-cfw-dropdown-container="#container">
+        Container Dropup <span class="caretup" aria-hidden="true"></span>
+    </a>
+    <ul class="dropdown-menu dropup">
+        <li class="dropdown-header">Sample Header</li>
+        <li><a href="#3-0">Action</a></li>
+        <li><a href="#3-1" class="active">Active action</a></li>
+        <li><a href="#3-2" class="disabled" tabindex="-1">Disabled action</a></li>
+        <li>
+            <a href="#3-3">Something else here</a>
+            <ul>
+                <li><a href="#3-3-0">Action</a></li>
+                <li><a href="#3-3-1">Another action</a></li>
+                <li><a href="#3-3-2">Something else here</a></li>
+            </ul>
+        </li>
     </ul>
 </div>
 
 <div class="d-flex flex-center">
-    <div class="dropdown">
+    <div class="dropdown me-0_25">
         <button type="button" class="btn" data-cfw="dropdown">
-            Dropdown <span class="caret" aria-hidden="true"></span>
+            Dropdown Dir Parent <span class="caret" aria-hidden="true"></span>
         </button>
         <ul class="dropdown-menu">
             <li class="dropdown-header">Dropdown header</li>
             <li><a href="#">Action</a></li>
-            <li class="dropend">
-                <a href="#">Reverse menu</a>
-                <ul>
-                    <li class="dropend">
-                        <a href="#">Reverse menu</a>
-                        <ul>
+            <li>
+                <a href="#">Start side menu</a>
+                <ul class="dropstart">
+                    <li>
+                        <a href="#">Start side menu</a>
+                        <ul class="dropstart">
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                         </ul>
                     </li>
-                    <li class="dropstart">
-                        <a href="#">Forward menu</a>
-                        <ul>
+                    <li>
+                        <a href="#">End side menu</a>
+                        <ul class="dropend">
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                         </ul>
                     </li>
                 </ul>
             </li>
-            <li class="dropstart">
-                <a href="#">Forward menu</a>
-                <ul>
-                    <li class="dropend">
-                        <a href="#">Reverse menu</a>
-                        <ul>
+            <li>
+                <a href="#">End side menu</a>
+                <ul class="dropend">
+                    <li>
+                        <a href="#">Start side menu</a>
+                        <ul class="dropstart">
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                         </ul>
                     </li>
-                    <li class="dropstart">
-                        <a href="#">Forward menu</a>
-                        <ul>
+                    <li>
+                        <a href="#">End side menu</a>
+                        <ul class="dropend">
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li class="dropdown-divider"></li>
+            <li><a href="#" class="disabled" tabindex="-1" aria-disabled="true">Separated link</a></li>
+        </ul>
+    </div>
+
+    <div class="dropdown">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Dropdown Dir <span class="caret" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu">
+            <li class="dropdown-header">Dropdown header</li>
+            <li><a href="#">Action</a></li>
+            <li>
+                <a href="#">Start side menu</a>
+                <ul class="dropstart">
+                    <li>
+                        <a href="#">Start side menu</a>
+                        <ul class="dropstart">
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                        </ul>
+                    </li>
+                    <li>
+                        <a href="#">End side menu</a>
+                        <ul class="dropend">
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li>
+                <a href="#">End side menu</a>
+                <ul class="dropend">
+                    <li>
+                        <a href="#">Start side menu</a>
+                        <ul class="dropstart">
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                        </ul>
+                    </li>
+                    <li>
+                        <a href="#">End side menu</a>
+                        <ul class="dropend">
                             <li><a href="#">Action</a></li>
                             <li><a href="#">Another action</a></li>
                         </ul>
@@ -187,13 +255,41 @@
     <a href="#">Outer link</a>
 </div>
 
-<div class="dropdown dropend float-end">
+<div class="dropdown float-end">
     <button type="button" class="btn btn-primary" data-cfw="dropdown">
-        Reverse Dropdown YY <span class="caret" aria-hidden="true"></span>
+        Reverse Dropup <span class="caretup" aria-hidden="true"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropup dropreverse">
         <li class="dropdown-header">Dropdown header</li>
-        <li><a href="#">Action</a></li>
+        <li><a href="#">Action UR</a></li>
+        <li><a href="#">Another action</a></li>
+        <li>
+           <a href="#">Something else here</a>
+            <ul>
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li>
+                    <a href="#">Something else here</a>
+                    <ul>
+                        <li><a href="#">Action</a></li>
+                        <li><a href="#">Another action</a></li>
+                    </ul>
+                </li>
+                <li class="dropdown-divider"></li>
+                <li><a href="#">Separated link</a></li>
+            </ul>
+        </li>
+        <li class="dropdown-divider"></li>
+        <li><a href="#" class="disabled" tabindex="-1" aria-disabled="true">Disabled link</a></li>
+    </ul>
+</div>
+<div class="dropdown float-end">
+    <button type="button" class="btn btn-primary" data-cfw="dropdown">
+        Reverse Dropdown <span class="caret" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu dropreverse">
+        <li class="dropdown-header">Dropdown header</li>
+        <li><a href="#">Action R</a></li>
         <li><a href="#">Another action</a></li>
         <li>
            <a href="#">Something else here</a>
@@ -238,6 +334,148 @@
         <li><a href="#">Another action</a></li>
         <li><a href="#">Something else here</a></li>
     </ul>
+</div>
+
+<div class="text-center p-1 m-2 border">
+    Directions:<br>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Default <span class="caret" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Up <span class="caretup" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropup">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Reverse <span class="caret" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropreverse">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Up Reverse <span class="caretup" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropup dropreverse">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <br>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Start <span class="caret" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropstart">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            Start Up <span class="caretup" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropup dropstart">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            End <span class="caret" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropend">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
+
+    <span class="dropdown d-inline-block">
+        <button type="button" class="btn" data-cfw="dropdown">
+            End Up <span class="caretup" aria-hidden="true"></span>
+        </button>
+        <ul class="dropdown-menu dropup dropend">
+            <li><a href="#">Action</a></li>
+            <li><a href="#">Another action</a></li>
+            <li>
+                <a href="#">Something else here</a>
+                <ul>
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                </ul>
+            </li>
+        </ul>
+    </span>
 </div>
 
 </body>

--- a/test/visual/dropdown.html
+++ b/test/visual/dropdown.html
@@ -411,7 +411,7 @@
 
     <span class="dropdown d-inline-block">
         <button type="button" class="btn" data-cfw="dropdown">
-            Start <span class="caret" aria-hidden="true"></span>
+            Start <span class="caretstart" aria-hidden="true"></span>
         </button>
         <ul class="dropdown-menu dropstart">
             <li><a href="#">Action</a></li>
@@ -445,7 +445,7 @@
 
     <span class="dropdown d-inline-block">
         <button type="button" class="btn" data-cfw="dropdown">
-            End <span class="caret" aria-hidden="true"></span>
+            End <span class="caretend" aria-hidden="true"></span>
         </button>
         <ul class="dropdown-menu dropend">
             <li><a href="#">Action</a></li>

--- a/test/visual/input-group.html
+++ b/test/visual/input-group.html
@@ -683,7 +683,7 @@
   <div class="col-lg-6">
     <div class="input-group">
       <input type="text" class="form-control" aria-label="Text input with dropdown button">
-      <div class="input-group-addon dropdown-menu-reverse">
+      <div class="input-group-addon dropreverse">
         <button type="button" class="btn btn-secondary input-group-end" data-cfw="dropdown">
           Action <span class="caret"></span>
         </button>
@@ -723,9 +723,9 @@
     <div class="input-group-addon">
         <button type="button" class="btn btn-outline-secondary">Action</button>
     </div>
-    <div class="input-group-addon dropdown-menu-reverse">
+    <div class="input-group-addon">
         <button type="button" class="btn btn-icon btn-outline-secondary input-group-end" data-cfw="dropdown" aria-label="Toggle Dropdown"><span class="caret"></span></button>
-        <ul class="dropdown-menu ">
+        <ul class="dropdown-menu dropreverse">
             <li><a href="#">Action</a></li>
             <li><a href="#">Another action</a></li>
             <li><a href="#">Something else here</a></li>

--- a/test/visual/navbar.html
+++ b/test/visual/navbar.html
@@ -261,11 +261,17 @@
             </li>
             <li class="nav-item dropdown">
                 <a class="nav-link" href="#" data-cfw="dropdown">Dropdown <span class="caret"></span></a>
-                <div class="dropdown-menu">
-                    <a href="#">Action</a>
-                    <a href="#">Another action</a>
-                    <a href="#">Something else here</a>
-                </div>
+                <ul class="dropdown-menu">
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                    <li>
+                        <a href="#">Something else here</a>
+                        <ul>
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                        </ul>
+                    </li>
+                </ul>
             </li>
         </ul>
         <form class="form-inline ms-auto">


### PR DESCRIPTION
OK, late state breaking change incoming.

Dropdown alignment classes, `.dropstart` and `.dropend`,  have been fixed to make better sense when used with submenus.  They can also now be used with primary dropdown menus to 'attach' menus to the side of the toggle.

This also required a rename of the class used to produce reverse/right-side aligned menus. So we now have `.dropreverse` for this use.

Alignment classes are no longer applied on the parent container, but on the `.dropdown-menu`, or `ol`/`ul` submenu list.

Also, the caret utilites have been upgraded to a 4-way style.  Since `.dropup` is no longer on the parent container, you may have to change from `.caret` to `.caretup`.
