### PR TITLE
Layout-Grid: Rework columns to use `width`

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -29,5 +29,6 @@
 
 // Layout
 @import "mixins/clearfix";
+@import "mixins/containers";
 @import "mixins/grid";
 @import "mixins/float";

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -312,13 +312,13 @@ $container-max-widths: map-merge(
 // =====
 // Set the number of columns and pecify the width of the gutter.
 $grid-columns:      12 !default;
-$grid-gutter-width: 2rem !default;
+$grid-gutter-width: 1.5rem !default;
 $grid-row-columns:  6 !default;
 
 
 // Container Padding
 // =====
-$container-padding-x:   $grid-gutter-width / 2 !default;
+$container-padding-x:   1rem !default;
 
 
 // Borders

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -312,13 +312,13 @@ $container-max-widths: map-merge(
 // =====
 // Set the number of columns and pecify the width of the gutter.
 $grid-columns:      12 !default;
-$grid-gutter-width: 1.5rem !default;
+$grid-gutter-width: 2rem !default;
 $grid-row-columns:  6 !default;
 
 
 // Container Padding
 // =====
-$container-padding-x:   1rem !default;
+$container-padding-x:   $grid-gutter-width / 2 !default;
 
 
 // Borders

--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -81,8 +81,3 @@
 @if $enable-grid-classes {
     @include make-grid-columns();
 }
-
-// Responsive Row Columns
-@if $enable-grid-classes  and $enable-grid-row-cols {
-    @include make-row-columns();
-}

--- a/scss/mixins/_containers.scss
+++ b/scss/mixins/_containers.scss
@@ -1,0 +1,18 @@
+// Containers
+@mixin make-container($padding-x: $container-padding-x) {
+    width: 100%;  // Prevent too narrow
+    max-width: 100%; // Prevent too wide
+    padding-right: $padding-x;
+    padding-left: $padding-x;
+    margin-right: auto;
+    margin-left: auto;
+}
+
+// For each breakpoint, define the maximum width of the container in a media query
+@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
+    @each $breakpoint, $container-max-width in $max-widths {
+        @include media-breakpoint-up($breakpoint, $breakpoints) {
+            max-width: $container-max-width;
+        }
+    }
+}

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -12,7 +12,6 @@
 
 // Columns
 @mixin make-col-ready($gutter: $grid-gutter-width) {
-    position: relative;
     width: 100%; // Prevent too narrow
     padding-right: ($gutter / 2);
     padding-left: ($gutter / 2);

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -12,23 +12,19 @@
 
 // Columns
 @mixin make-col-ready($gutter: $grid-gutter-width) {
-    width: 100%; // Prevent too narrow
+    flex: 0 0 auto;
+    width: 100%; // Prevent too narrow - width is reset later
+    max-width: 100%; // Prevent too wide
     padding-right: ($gutter / 2);
     padding-left: ($gutter / 2);
 }
 
 @mixin make-col($size, $columns: $grid-columns) {
-    flex: 0 0 percentage($size / $columns);
-    // Add a `max-width` to ensure content within each column does not blow out
-    // the width of the column. Applies to IE10+ and Firefox. Chrome and Safari
-    // do not appear to require this.
-    max-width: percentage($size / $columns);
+    width: percentage($size / $columns);
 }
 
 @mixin make-col-auto() {
-    flex: 0 0 auto;
     width: auto;
-    max-width: 100%;
 }
 
 @mixin make-col-offset($size, $columns: $grid-columns) {
@@ -44,8 +40,8 @@
 // style grid.
 @mixin row-cols($count) {
     & > * {
-        flex: 0 0 100% / $count;
-        max-width: 100% / $count;
+        flex: 0 0 auto;
+        width: 100% / $count;
     }
 }
 
@@ -54,10 +50,7 @@
 @mixin make-grid-columns($columns: $grid-columns, $breakpoints: $grid-breakpoints, $gutter: $grid-gutter-width) {
     // Use a placeholder selector to extend upon
     %col {
-        position: relative;
-        width: 100%; // Prevent too narrow
-        padding-right: ($gutter / 2);
-        padding-left: ($gutter / 2);
+        @include make-col-ready();
     }
 
     @each $breakpoint in map-keys($breakpoints) {
@@ -76,22 +69,13 @@
 
         @include media-breakpoint-up($breakpoint, $breakpoints) {
             // Provide basic `.col-{bp}` classes for equal-width flexbox columns
-            %col-flex-basic-#{$breakpoint} {
+            .col#{$bprule} {
                 flex-basis: 0;
                 flex-grow: 1;
                 min-width: 0;
-                max-width: 100%;
-            }
-
-            %col-flex-auto-#{$breakpoint} {
-                @include make-col-auto();
-            }
-
-            .col#{$bprule} {
-                @extend %col-flex-basic-#{$breakpoint};
             }
             .col#{$bprule}-auto {
-                @extend %col-flex-auto-#{$breakpoint};
+                @include make-col-auto();
             }
             @for $i from 1 through $columns {
                 .col#{$bprule}-#{$i} {
@@ -113,10 +97,15 @@
 
 // Responsive Row Columns
 @mixin make-row-columns($columns: $grid-row-columns, $breakpoints: $grid-breakpoints) {
+
     @each $breakpoint in $row-columns-breakpoints {
         $bprule: breakpoint-designator($breakpoint);
 
         @include media-breakpoint-up($breakpoint, $breakpoints) {
+            .row-cols#{$bprule}-auto > * {
+                @include make-col-auto();
+            }
+
             @for $i from 1 through $columns {
                 .row-cols#{$bprule}-#{$i} {
                     @include row-cols($i);

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -24,6 +24,7 @@
 }
 
 @mixin make-col-auto() {
+    flex: 0 0 auto;
     width: auto;
 }
 
@@ -74,9 +75,38 @@
                 flex-grow: 1;
                 min-width: 0;
             }
+        }
+    }
+
+    // Responsive Row Columns
+    @each $breakpoint in $row-columns-breakpoints {
+        $bprule: breakpoint-designator($breakpoint);
+
+        @include media-breakpoint-up($breakpoint, $breakpoints) {
+            @if $enable-grid-row-cols {
+                .row-cols#{$bprule}-auto > * {
+                    @include make-col-auto();
+                }
+
+                @for $i from 1 through $grid-row-columns {
+                    .row-cols#{$bprule}-#{$i} {
+                        @include row-cols($i);
+                    }
+                }
+            }
+        }
+    }
+
+
+    // Standard columns
+    @each $breakpoint in map-keys($breakpoints) {
+        $bprule: breakpoint-designator($breakpoint);
+
+        @include media-breakpoint-up($breakpoint, $breakpoints) {
             .col#{$bprule}-auto {
                 @include make-col-auto();
             }
+
             @for $i from 1 through $columns {
                 .col#{$bprule}-#{$i} {
                     @include make-col($i, $columns);
@@ -89,26 +119,6 @@
                     .offset#{$bprule}-#{$i} {
                         @include make-col-offset($i, $columns);
                     }
-                }
-            }
-        }
-    }
-}
-
-// Responsive Row Columns
-@mixin make-row-columns($columns: $grid-row-columns, $breakpoints: $grid-breakpoints) {
-
-    @each $breakpoint in $row-columns-breakpoints {
-        $bprule: breakpoint-designator($breakpoint);
-
-        @include media-breakpoint-up($breakpoint, $breakpoints) {
-            .row-cols#{$bprule}-auto > * {
-                @include make-col-auto();
-            }
-
-            @for $i from 1 through $columns {
-                .row-cols#{$bprule}-#{$i} {
-                    @include row-cols($i);
                 }
             }
         }

--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -1,26 +1,6 @@
 /// Grid system
 // Generate semantic grid columns with these mixins.
 
-// Containers
-@mixin make-container($padding-x: $container-padding-x) {
-    width: 100%;  // Prevent too narrow
-    max-width: 100%; // Prevent too wide
-    padding-right: $padding-x;
-    padding-left: $padding-x;
-    margin-right: auto;
-    margin-left: auto;
-}
-
-// For each breakpoint, define the maximum width of the container in a media query
-@mixin make-container-max-widths($max-widths: $container-max-widths, $breakpoints: $grid-breakpoints) {
-    @each $breakpoint, $container-max-width in $max-widths {
-        @include media-breakpoint-up($breakpoint, $breakpoints) {
-            max-width: $container-max-width;
-        }
-    }
-}
-
-
 // Rows
 @mixin make-row($gutter: $grid-gutter-width) {
     display: flex;

--- a/site/4.0/examples/grid/index.html
+++ b/site/4.0/examples/grid/index.html
@@ -201,7 +201,7 @@ h2 {
         </div>
         <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
 
-        <!-- Add the extra clearfix for only the required viewport -->
+        <!-- Force next columns to break to a new line for only the required viewport -->
         <div class="w-100 d-sm-none"></div>
 
         <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>

--- a/site/4.0/get-started/migration.md
+++ b/site/4.0/get-started/migration.md
@@ -62,7 +62,7 @@ ${toc}
 
 ## Grid
 - Dropped the `.push` and `.pull` modifiers in favor of `.offset-*` and flex utilities.
-
+- Dropped the `position: relative` from grid columns.
 
 ## Components
 

--- a/site/4.0/layout/grid.md
+++ b/site/4.0/layout/grid.md
@@ -323,7 +323,7 @@ Don't want your columns to simply stack in some grid tiers. Use a combination of
 
 ### Row Columns
 
-Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.col-md-4`), the row columns classes are set on the parent `.row` as a shortcut.
+Use the responsive `.row-cols-*` classes to quickly set the number of columns that best render your content and layout. Whereas normal `.col-*` classes apply to the individual columns (e.g., `.col-md-4`), the row columns classes are set on the parent `.row` as a shortcut. With `.row-cols-*-auto` you can give the columns their natural width.
 
 Use these row columns classes to quickly create basic grid layouts or to control your card layouts.
 
@@ -342,6 +342,18 @@ Use these row columns classes to quickly create basic grid layouts or to control
 {% capture example %}
 <div class="container">
   <div class="row row-cols-3">
+    <div class="col">Column</div>
+    <div class="col">Column</div>
+    <div class="col">Column</div>
+    <div class="col">Column</div>
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example, "cf-example-row" %}
+
+{% capture example %}
+<div class="container">
+  <div class="row row-cols-auto">
     <div class="col">Column</div>
     <div class="col">Column</div>
     <div class="col">Column</div>

--- a/test/visual/grid.html
+++ b/test/visual/grid.html
@@ -104,7 +104,7 @@
     </div>
 
     <h2>Full width, single column</h2>
-    <p class="text-warning">No grid classes are necessary for full-width elements.</p>
+    <p class="text-info">No grid classes are necessary for full-width elements.</p>
 
     <hr />
 

--- a/test/visual/grid.html
+++ b/test/visual/grid.html
@@ -169,8 +169,8 @@
         </div>
         <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
 
-        <!-- Add the extra clearfix for only the required viewport -->
-        <div class="clearfix d-sm-none"></div>
+        <!-- Force next columns to break to a new line for only the required viewport -->
+        <div class="w-100 d-sm-none"></div>
 
         <div class="col-4 col-sm-3">.col-4 .col-sm-3</div>
         <div class="col-8 col-sm-3">.col-8 .col-sm-3</div>


### PR DESCRIPTION
- Removed `position; relative;` from cols - holdover from older push/pull.
- Splits the container mixins into their own file.
- Columns now use `width` instead of `flex-basis` and `max-width`.
- Consolidated some of the CSS output for columns.
- Added `row-cols-*-auto` variants to allow child columns to auto size.
