### PR TITLE
Rework link decorations to reduce output

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -352,7 +352,7 @@ $body-text-align:       null !default;
 $link-color:                    $primary !default;
 $link-decoration:               underline !default;
 $link-hover-color:              palette($primary, 700) !default;
-$link-hover-decoration:         underline !default;
+$link-hover-decoration:         null !default;
 
 $link-stretch-pseudo-element:   after !default;
 $link-stretch-z-index:          1 !default;
@@ -1097,8 +1097,11 @@ $dropdown-back-spacer-x:        .375rem !default;
 // =====
 $nav-link-padding-x:            1rem !default;
 $nav-link-padding-y:            .3125rem !default;
+$nav-link-decoration:           if($link-decoration == none, null, none) !default;
+$nav-link-hover-decoration:     if($link-hover-decoration == underline, none, null) !default;
 $nav-link-disabled-opacity:     .6 !default;
 $nav-link-disabled-color:       $component-disabled-color !default;
+
 
 $nav-tabs-border-color:         $component-border-color !default;
 $nav-tabs-border-width:         $border-width !default;

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -79,7 +79,7 @@
         font-weight: $font-weight-normal;
         color: $dropdown-link-color;
         text-align: inherit; // 1
-        text-decoration: none;
+        text-decoration: if($link-decoration == none, null, none);
         white-space: nowrap; // prevent links from randomly breaking onto new lines
         background: none; // 1
         border: 0; // 1
@@ -97,13 +97,12 @@
 
         &.active {
             color: $dropdown-link-active-color;
-            text-decoration: none;
             background-color: $dropdown-link-active-bg;
         }
 
         @include hover-focus() {
             color: $dropdown-link-hover-color;
-            text-decoration: none;
+            text-decoration: if($link-hover-decoration == underline, none, null);
             background-color: $dropdown-link-hover-bg;
         }
 

--- a/scss/component/_nav.scss
+++ b/scss/component/_nav.scss
@@ -13,11 +13,17 @@
     .nav-link {
         display: block;
         padding: $nav-link-padding-y $nav-link-padding-x;
+        text-decoration: $nav-link-decoration;
+
+        @include hover-focus() {
+            text-decoration: $nav-link-hover-decoration;
+        }
 
         // Disabled state lightens text and removes hover/focus effects
         // By default it also influences `.nav-tab` and `.nav-pills`
         &.disabled {
             color: $nav-link-disabled-color;
+            text-decoration: none;
             pointer-events: none;
             cursor: default;
             opacity: $nav-link-disabled-opacity;

--- a/scss/component/_pagination.scss
+++ b/scss/component/_pagination.scss
@@ -25,14 +25,14 @@
     .page-link {
         position: relative;
         color: $pagination-color;
-        text-decoration: none;
+        text-decoration: if($link-decoration == none, null, none);
         background-color: $pagination-bg;
 
         &:hover,
         &:focus {
             z-index: 2;
             color: $pagination-hover-color;
-            text-decoration: none;
+            text-decoration: if($link-hover-decoration == underline, none, null);
             background-color: $pagination-hover-bg;
             border-color: $pagination-hover-border-color;
         }

--- a/scss/core/_buttons.scss
+++ b/scss/core/_buttons.scss
@@ -5,7 +5,7 @@
         font-family: $btn-font-family;
         font-weight: $btn-font-weight;
         text-align: center;
-        text-decoration: none;
+        text-decoration: if($link-decoration == none, null, none);
         white-space: $btn-white-space;
         vertical-align: middle;
         cursor: pointer;
@@ -17,7 +17,7 @@
     }
 
     .btn:hover {
-        text-decoration: none;
+        text-decoration: if($link-hover-decoration == underline, none, null);
     }
 
     %btn-common-focus {

--- a/site/4.0/components/navs.md
+++ b/site/4.0/components/navs.md
@@ -430,6 +430,22 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$nav-link-decoration</code></td>
+        <td>string</td>
+        <td><code>if($link-decoration == none, null, none)</code></td>
+        <td>
+          Text decoration for base nav links.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$nav-link-hover-decoration</code></td>
+        <td>string</td>
+        <td><code>if($link-hover-decoration == underline, none, null)</code></td>
+        <td>
+          Text decoration for base nav links in hover or focus state.
+        </td>
+      </tr>
+      <tr>
         <td><code>$nav-link-disabled-opacity</code></td>
         <td>string</td>
         <td><code>.6</code></td>
@@ -518,7 +534,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
-        <td><code>$component-active-color</code></td>
+        <td><code>$nav-pills-active-color</code></td>
         <td>string</td>
         <td><code>$component-active-color</code></td>
         <td>
@@ -526,7 +542,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
-        <td><code>$component-active-bg</code></td>
+        <td><code>$nav-pills-active-bg</code></td>
         <td>string</td>
         <td><code>$component-active-bg</code></td>
         <td>

--- a/site/4.0/content/reboot.md
+++ b/site/4.0/content/reboot.md
@@ -507,7 +507,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$link-hover-decoration</code></td>
         <td>string</td>
-        <td><code>underline</code></td>
+        <td><code>null</code></td>
         <td>
           Text decoration for hovered or focused links.
         </td>


### PR DESCRIPTION
Also adds variables for `text-decoration` on the base `.nav-link` items.  They still have overrides for the pill and tab variants.