### PR TITLE
Modal: Add fullscreen variant

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -172,11 +172,11 @@
 
             this.$target.show();
 
-            if (this.$dialog.hasClass('modal-dialog-scrollable') && $modalBody.length) {
-                $modalBody.scrollTop(0);
-            } else {
-                this.$target.scrollTop(0);
+            if ($modalBody.length) {
+                $modalBody.scrollTop(0); // scrollable body variant
             }
+            this.$dialog.scrollTop(0); // fullscreen variant
+            this.$target.scrollTop(0);
 
             this.adjustDialog();
 

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -26,6 +26,7 @@
 @import "mixins/pagination";
 @import "mixins/switch";
 @import "mixins/tables";
+@import "mixins/modal";
 
 // Layout
 @import "mixins/clearfix";

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -196,6 +196,8 @@ $enable-modal-centered:                     true !default;
 $enable-modal-scrollable:                   true !default;
 $enable-modal-side-start:                   true !default;
 $enable-modal-side-end:                     true !default;
+$enable-modal-fullscreen:                   true !default;
+$enable-modal-fullscreen-responsive:        true !default;
 $enable-modal-header:                       true !default;
 $enable-modal-title:                        true !default;
 $enable-modal-body:                         true !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -279,6 +279,7 @@ $card-group-breakpoints:            map-keys($grid-breakpoints) !default;
 $card-columns-breakpoints:          map-keys($grid-breakpoints) !default;
 $navbar-expand-breakpoints:         map-keys($grid-breakpoints) !default;
 $table-scroll-breakpoints:          map-keys($grid-breakpoints) !default;
+$modal-fullscreen-breakpoints:      map-keys($grid-breakpoints) !default;
 $utility-border-breakpoints:        map-keys($grid-breakpoints) !default;
 $utility-display-breakpoints:       map-keys($grid-breakpoints) !default;
 $utility-flex-breakpoints:          map-keys($grid-breakpoints) !default;
@@ -1358,6 +1359,8 @@ $modal-transform-fade:          translate(0, -3rem) !default;
 $modal-transform-in:            none !default;
 $modal-transform-side-offset:   -5rem !default;
 $modal-transform-blocked:       scale(1.01) !default;
+// Remove slide when using fullscreen variant
+$modal-transform-fullscreen:    none !default;
 
 
 // Player

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -152,7 +152,6 @@
         display: flex;
         flex-direction: column;
         width: 100%; // Ensure `.modal-content` extends the full width of the parent `.modal-dialog`
-        height: 100%;
         color: $modal-content-color;
         // Override the `pointer-events: none;` in the .modal-dialog
         pointer-events: auto;
@@ -238,7 +237,6 @@
             // Make body as tall as possible if there is a height defined on `.modal-content`
             flex: 1 1 auto;
             padding: $modal-body-padding-y $modal-body-padding-x;
-            overflow-y: auto;
         }
     }
 

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -152,6 +152,7 @@
         display: flex;
         flex-direction: column;
         width: 100%; // Ensure `.modal-content` extends the full width of the parent `.modal-dialog`
+        height: 100%;
         color: $modal-content-color;
         // Override the `pointer-events: none;` in the .modal-dialog
         pointer-events: auto;
@@ -237,6 +238,7 @@
             // Make body as tall as possible if there is a height defined on `.modal-content`
             flex: 1 1 auto;
             padding: $modal-body-padding-y $modal-body-padding-x;
+            overflow-y: auto;
         }
     }
 
@@ -332,6 +334,26 @@
         @if $enable-modal-side-end {
             .modal-dialog-side-end.modal-dialog-scrollable {
                 @extend %modal-side-scrollable;
+            }
+        }
+    }
+
+    @if $enable-modal-fullscreen {
+        .modal-fullscreen {
+            @include modal-fullscreen();
+        }
+    }
+
+    @if $enable-modal-fullscreen-responsive {
+        @each $bp in $modal-fullscreen-breakpoints {
+
+            // Skip largest for down (equivalent to `.modal-fullscreen`)
+            @if breakpoint-max($bp, $grid-breakpoints) != null {
+                @include media-breakpoint-down($bp) {
+                    .modal-fullscreen-#{$bp}-down {
+                        @include modal-fullscreen();
+                    }
+                }
             }
         }
     }

--- a/scss/mixins/_modal.scss
+++ b/scss/mixins/_modal.scss
@@ -4,17 +4,30 @@
 @mixin modal-fullscreen {
     width: 100vw;
     max-width: none;
-    height: 100vh;
     max-height: 100vh;
     margin: 0;
+    overflow-y: auto; // Scroll here to not overlap the side of `.modal-content`
 
     @at-root .modal.fade #{&} {
         transform: $modal-transform-fullscreen;
     }
 
     .modal-content {
-        max-height: 100vh;
+        height: min-content;
+        min-height: 100vh;
         border: 0;
         @include border-radius(0);
+    }
+
+    @if $enable-modal-scrollable {
+        &.modal-dialog-scrollable {
+            overflow-y: hidden;
+        }
+    }
+
+    @if $enable-modal-centered {
+        &.modal-dialog-centered {
+            align-items: stretch;
+        }
     }
 }

--- a/scss/mixins/_modal.scss
+++ b/scss/mixins/_modal.scss
@@ -1,7 +1,7 @@
 // Modal
 
 // Allow modal to fill viewport
-@mixin modal-fullscreen {
+@mixin modal-fullscreen() {
     width: 100vw;
     max-width: none;
     max-height: 100vh;
@@ -12,6 +12,12 @@
         transform: $modal-transform-fullscreen;
     }
 
+    // Fix content height in legacy Edge
+    @supports (-ms-ime-align: auto) {
+        .modal-content {
+            height: 100%;
+        }
+    }
     .modal-content {
         height: min-content;
         min-height: 100vh;

--- a/scss/mixins/_modal.scss
+++ b/scss/mixins/_modal.scss
@@ -1,0 +1,20 @@
+// Modal
+
+// Allow modal to fill viewport
+@mixin modal-fullscreen {
+    width: 100vw;
+    max-width: none;
+    height: 100vh;
+    max-height: 100vh;
+    margin: 0;
+
+    @at-root .modal.fade #{&} {
+        transform: $modal-transform-fullscreen;
+    }
+
+    .modal-content {
+        max-height: 100vh;
+        border: 0;
+        @include border-radius(0);
+    }
+}

--- a/site/4.0/widgets/modal.md
+++ b/site/4.0/widgets/modal.md
@@ -748,6 +748,274 @@ When `backdrop` option is set to `static`, the modal will not close when clickin
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
+### Fullscreen Modal
+
+Enlarge a modal to fill the entire viewport with a `.modal-fullscreen` modifider class placed on the `.modal-dialog`.
+
+<div class="modal" id="modalFullscreen">
+  <div class="modal-dialog modal-fullscreen">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Fullscreen modal</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        <h4>Overflowing text to show scroll behavior</h4>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="cf-example">
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalFullscreen">Fullscreen modal</button>
+</div>
+
+{% capture highlight %}
+<button class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalFullscreen">Fullscreen modal</button>
+
+<div class="modal" id="modalFullscreen">
+  <div class="modal-dialog modal-fullscreen">
+    <div class="modal-content">
+      ...
+    </div>
+  </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+Responsive variants are also available. These work for a given breakpoint and below with the form `.modal-fullscreen-{breakpoint}-down`.
+
+**Heads up!** There is no `.modal-fullscreen-*-down` class created for the largest breakpoint since it is functionally equivalent to using `.modal-fullscreen`.
+
+<div class="modal" id="modalFullscreenXs">
+  <div class="modal-dialog modal-fullscreen-xs-down">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Fullscreen modal at `xs`</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="modalFullscreenSm">
+  <div class="modal-dialog modal-fullscreen-sm-down">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Fullscreen modal at `sm` and below</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="modalFullscreenMd">
+  <div class="modal-dialog modal-fullscreen-md-down">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Fullscreen modal at `md` and below</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="modalFullscreenLg">
+  <div class="modal-dialog modal-fullscreen-lg-down">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Fullscreen modal at `lg` and below</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="cf-example">
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullscreenXs">Fullscreen `xs` modal</button>
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullscreenSm">Fullscreen `sm` modal</button>
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullscreenMd">Fullscreen `md` modal</button>
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullscreenLg">Fullscreen `lg` modal</button>
+</div>
+
+{% capture highlight %}
+<!-- Fullscreen modal at `xs` breakpoint -->
+<div class="modal-dialog modal-fullscreen-xs-down">
+  ...
+</div>
+
+<!-- Fullscreen modal at `sm` breakpoint and below -->
+<div class="modal-dialog modal-fullscreen-sm-down">
+  ...
+</div>
+
+<!-- Fullscreen modal at `md` breakpoint and below -->
+<div class="modal-dialog modal-fullscreen-md-down">
+  ...
+</div>
+
+<!-- Fullscreen modal at `lg` breakpoint and below -->
+<div class="modal-dialog modal-fullscreen-lg-down">
+  ...
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+You can also combine fullscreen variants with the centered and scrollable variants.  The fullscreen version of the modal will then assume a similar scrolling behavior to match, but centering will not occur since the modal will be stretched to the size of the viewport.
+
+<div class="modal" id="modalFullMdScroll">
+  <div class="modal-dialog modal-fullscreen-md-down modal-dialog-scrollable">
+      <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Modal title</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        <h4>Overflowing text to show scroll behavior</h4>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="modalFullMdCenter">
+  <div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Modal title</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        <h4>Overflowing text to show scroll behavior</h4>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+    </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="modalFullMdCenterScroll">
+  <div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Modal title</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        <h4>Overflowing text to show scroll behavior</h4>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+        <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+        <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+        <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+    </div>
+    </div>
+  </div>
+</div>
+
+<div class="cf-example">
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullMdScroll">Fullscreen scrolling body</button>
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullMdCenter">Fullscreen centered</button>
+<button class="btn btn-primary my-0_25" data-cfw="modal" data-cfw-modal-target="#modalFullMdCenterScroll">Fullscreen centered, scrolling body</button>
+</div>
+
+{% capture highlight %}
+<!-- Fullscreen modals at `md` breakpoint and below -->
+
+<!-- Scrollable body above `md` breakpoint -->
+<div class="modal-dialog modal-fullscreen-md-down modal-dialog-scrollable">
+  ...
+</div>
+
+<!-- Centered above `md` breakpoint -->
+<div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered">
+  ...
+</div>
+
+<!-- Centered and scrollable body above `md` breakpoint -->
+<div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">
+  ...
+</div>
+
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
 ## Usage
 
 The modal widget toggles your hidden content on demand, via data attributes or JavaScript. It also adds `.modal-open` to the `<body>` to override default scrolling behavior and generates a `.modal-backdrop` to provide a click area for dismissing shown modals when clicking outside the modal.
@@ -1076,6 +1344,22 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$enable-modal-fullscreen</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the fullscreen modal variant.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-modal-fullscreen-responsive</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the responsive fullscreen modal variants.
+        </td>
+      </tr>
+      <tr>
         <td><code>$enable-modal-header</code></td>
         <td>boolean</td>
         <td><code>true</code></td>
@@ -1368,7 +1652,15 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         <td>string</td>
         <td><code>scale(1.01)</code></td>
         <td>
-          Transform state of <code>.modal-dialog</code> for the close is blocked animation.
+          Transform state of <code>.modal-dialog</code> for when the close is blocked animation.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$modal-transform-fullscreen</code></td>
+        <td>string</td>
+        <td><code>none</code></td>
+        <td>
+          Transform state of <code>.modal-dialog</code> for the slide animation when the modal in fullscreen mode.
         </td>
       </tr>
       <tr>
@@ -1379,10 +1671,25 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
           Transition settings for the <code>.modal-dialog</code> animations.
         </td>
       </tr>
+      <tr>
+        <td><code>$modal-fullscreen-breakpoints</code></td>
+        <td>list</td>
+        <td><code>map-keys($grid-breakpoints)</code></td>
+        <td>
+          Breakpoint list for responsive fullscreen modals.
+        </td>
+      </tr>
     </tbody>
   </table>
 </div>
 
 ### Mixins
 
-No mixins available.
+#### modal-fullscreen()
+
+Enable fullscreen mode on a `.modal-dialog`.
+
+{% capture highlight %}
+@include modal-fullscreen();
+{% endcapture %}
+{% renderHighlight highlight, "sass" %}

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -779,16 +779,52 @@ $(function() {
             .CFW_Modal('show');
     });
 
-    QUnit.test('should set .modal scrollTop to 0 if using .modal-dialog-scrollable but modal body does not exist', function(assert) {
+    QUnit.test('should set .modal scrollTop to 0', function(assert) {
         assert.expect(1);
         var done = assert.async();
 
         var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
-        var $target = $('<div class="modal" id="modal"><div class="modal-dialog modal-dialog-scrollable"></div></div>').appendTo(document.body);
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"></div></div>').appendTo(document.body);
 
         $target
             .on('afterShow.cfw.modal', function() {
                 assert.strictEqual($('#modal').scrollTop(), 0, 'scrollTop is 0');
+                done();
+            });
+
+        $trigger
+            .CFW_Modal()
+            .CFW_Modal('show');
+    });
+
+    QUnit.test('should set .modal-dialog scrollTop to 0', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"></div></div>').appendTo(document.body);
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.strictEqual($('#modal .modal-dialog').scrollTop(), 0, 'scrollTop is 0');
+                done();
+            });
+
+        $trigger
+            .CFW_Modal()
+            .CFW_Modal('show');
+    });
+
+    QUnit.test('should set .modal-body scrollTop to 0', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body"></div></div></div></div>').appendTo(document.body);
+
+        $target
+            .on('afterShow.cfw.modal', function() {
+                assert.strictEqual($('#modal .modal-body').scrollTop(), 0, 'scrollTop is 0');
                 done();
             });
 

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -197,9 +197,6 @@
                 <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
                 <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
                 <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
-                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
-                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
-                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -126,6 +126,9 @@
     <button class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalCenter">
         Centered modal
     </button>
+    <button class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalCenterTall">
+        Centered modal tall
+    </button>
     <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalScroll">
         Scrollable modal
     </button>
@@ -140,6 +143,23 @@
         Side modal - end
     </button>
 </p>
+<p>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalFull">
+        Fullscreen
+    </button>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalFullMd">
+        Fullscreen-md-down
+    </button>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalFullMdScroll">
+        Fullscreen-md-down - scrollable
+    </button>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalFullMdCenter">
+        Fullscreen-md-down - centered
+    </button>
+    <button type="button" class="btn btn-info" data-cfw="modal" data-cfw-modal-target="#modalFullMdCenterScroll">
+        Fullscreen-md-down - scrollable centered
+    </button>
+</p>
 
 <div class="modal" id="modalCenter">
     <div class="modal-dialog modal-dialog-centered">
@@ -150,6 +170,36 @@
             </div>
             <div class="modal-body">
                 ...
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalCenterTall">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
@@ -281,6 +331,156 @@
 
 <div class="modal" id="modalSideEnd">
     <div class="modal-dialog modal-dialog-side-end modal-dialog-scrollable modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalFull">
+    <div class="modal-dialog modal-fullscreen">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalFullMd">
+    <div class="modal-dialog modal-fullscreen-md-down">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalFullMdScroll">
+    <div class="modal-dialog modal-fullscreen-md-down modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalFullMdCenter">
+    <div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">Modal title</h4>
+                <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="modal-body">
+                <h4>Overflowing text to show scroll behavior</h4>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+                <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
+                <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
+                <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn" data-cfw-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal" id="modalFullMdCenterScroll">
+    <div class="modal-dialog modal-fullscreen-md-down modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <h4 class="modal-title">Modal title</h4>


### PR DESCRIPTION
Always and responsive variants for 'fullscreen' modals, or more correctly, **modals that fill the viewport**.

Also compatible with centered and scrollable body variants, so that when in fullscreen mode, the scrolling behavior is similar, either through viewport scrolling, or modal body scrolling..

Given a `md` breakpoint and below, so a  `.modal-dialog` with `.modal-fullscreen-md-down`:
- A standard or centered modal will overflow off the bottom of the page when full.
- A scrolling body modal, with or without centering, will scroll the modal body region when full.
- Vertical centering is irrelevant when full, since at minimum, the modal will fill the viewport.