### PR TITLE
Modal/Popover/Tooltip: Drop use of `role="document"` from dialogs

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -68,7 +68,6 @@
                 'aria-hidden': 'true',
                 'tabindex': -1
             });
-            this.$dialog.attr('role', 'document');
 
             // Bind click handler
             this.$element.on('click.cfw.modal', this.toggle.bind(this));

--- a/js/popover.js
+++ b/js/popover.js
@@ -12,7 +12,6 @@
 
     var CFW_Widget_Popover = function(element, options) {
         this.dragAdded = false;
-        this.docAdded = false;
         this.keyTimer = null;
         this.keyDelay = 750;
 
@@ -91,20 +90,6 @@
         }
 
         if (!$title.html()) { $title.hide(); }
-
-        if (this.isDialog && !this.docAdded) {
-            if (!this.$target.find('[role="document"]').length) {
-                // Inject a role="document" container
-                var $children = this.$target.children().not(this.$arrow);
-                var docDiv = document.createElement('div');
-                docDiv.setAttribute('role', 'document');
-                $children.wrapAll(docDiv);
-                // Make sure arrow is at end of popover for roles to work properly with screen readers
-                this._arrow();
-                this.$arrow.appendTo(this.$target);
-            }
-            this.docAdded = true;
-        }
     };
 
     CFW_Widget_Popover.prototype.getContent = function() {
@@ -340,7 +325,6 @@
         this.$target.detach();
         this.$target = null;
         this.dragAdded = false;
-        this.docAdded = false;
     };
 
     CFW_Widget_Popover.prototype._updateZ = function() {
@@ -369,7 +353,6 @@
 
     CFW_Widget_Popover.prototype._unlinkCompleteExt = function() {
         this.dragAdded = null;
-        this.docAdded = null;
         this.keyTimer = null;
         this.keyDelay = null;
     };

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -367,14 +367,8 @@
                 if (!this.$focusFirst) {
                     this.$focusFirst = $(document.createElement('span'))
                         .addClass(this.type + '-focusfirst')
-                        .attr('tabindex', 0);
-
-                    var $dialog =  this.isDialog ? this.$target.find('[role="document"]').first() : {};
-                    if ($dialog.length) {
-                        this.$focusFirst.prependTo($dialog);
-                    } else {
-                        this.$focusFirst.prependTo(this.$target);
-                    }
+                        .attr('tabindex', 0)
+                        .prependTo(this.$target);
                 }
                 if (this.$focusFirst) {
                     this.$focusFirst


### PR DESCRIPTION
Was a workaround a bug with NVDA which seems to have been resolved.