### PR TITLE
Grid: Fix missing responsive base container

### DIFF
--- a/scss/component/_grid.scss
+++ b/scss/component/_grid.scss
@@ -26,6 +26,11 @@
                     max-width: $rc-max-width;
                 }
 
+                // Extend base container
+                .container {
+                    @extend %responsive-container-#{$breakpoint};
+                }
+
                 // Extend each breakpoint which should be smaller or
                 // equal to the current breakpoint
                 $extend-breakpoint: true;


### PR DESCRIPTION
Fixes issue caused by changes in #614 where responsive `max-width` was accidentally removed from base `.container`.