### PR TITLE
Remove `flex: 1 0 100%` from `.row`

### DIFF
--- a/scss/mixins/_grid.scss
+++ b/scss/mixins/_grid.scss
@@ -4,7 +4,6 @@
 // Rows
 @mixin make-row($gutter: $grid-gutter-width) {
     display: flex;
-    flex: 1 0 100%;
     flex-wrap: wrap;
     margin-right: ($gutter / -2);
     margin-left: ($gutter / -2);


### PR DESCRIPTION
This will stop rows from unexpected growth at the cost of `.row`s collapsing in flex containers, such as navbars.  Use of `.flex-fill` on the `.row` within flex containers will restore the row to full width.