### PR TITLE
Dropdown: Add line-height setting

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1002,6 +1002,7 @@ $dropdown-min-width:            10rem !default;
 $dropdown-padding-y:            .3125rem !default;
 $dropdown-spacer:               .125rem !default;
 $dropdown-font-size:            $font-size-base !default;
+$dropdown-line-height:          $line-height-base !default;
 $dropdown-bg:                   $component-bg !default;
 $dropdown-color:                $body-color !default;
 $dropdown-border-color:         $component-border-color !default;

--- a/scss/component/_dropdown.scss
+++ b/scss/component/_dropdown.scss
@@ -22,6 +22,7 @@
         padding: $dropdown-padding-y 0;
         margin: $dropdown-spacer 0; // override default ul
         @include font-size($dropdown-font-size);
+        line-height: $dropdown-line-height;
         color: $dropdown-color;
         text-align: left; // Ensures proper alignment if parent has it changed (e.g., modal footer)
         list-style: none;
@@ -47,7 +48,7 @@
         > .dropdown-item {
             &::after {
                 position: absolute;
-                top: calc((#{$line-height-base} * #{$dropdown-font-size}) / 2);
+                top: calc((#{$dropdown-line-height} * #{$dropdown-font-size}) / 2);
                 right: $dropdown-caret-spacer-x;
                 @include caret(end, $dropdown-caret-width, $dropdown-caret-color);
             }
@@ -217,7 +218,7 @@
 
             > button::before {
                 position: absolute;
-                top: calc((#{$line-height-base} * #{$dropdown-font-size}) / 2);
+                top: calc((#{$dropdown-line-height} * #{$dropdown-font-size}) / 2);
                 left: $dropdown-back-spacer-x;
                 @include caret(start, $dropdown-back-width, $dropdown-back-color);
             }

--- a/site/4.0/widgets/dropdown.md
+++ b/site/4.0/widgets/dropdown.md
@@ -1103,6 +1103,14 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
                 </td>
             </tr>
             <tr>
+                <td><code>$dropdown-line-height</code></td>
+                <td>string</td>
+                <td><code>$line-height-base</code></td>
+                <td>
+                    Line height for dropdown menus.
+                </td>
+            </tr>
+            <tr>
                 <td><code>$dropdown-bg</code></td>
                 <td>string</td>
                 <td><code>$component-bg</code></td>


### PR DESCRIPTION
Add new setting, and reset the line-height for dropdown consistency when used in places where line-height is adjusted.