### PR TITLE
Form-Switch: Use `top` instead of `transform`

### DIFF
--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -154,12 +154,11 @@
 
             .form-check-input {
                 @extend %form-check-input-hide;
-                top: 0;
+                top: calc((.5em * #{$line-height-base}) - (#{$form-switch-track-height} / 2));
                 left: 0;
                 width: $form-switch-width;
                 height: $form-switch-track-height;
                 margin-left: 0;
-                transform: translateY(.5em * $line-height-base) translateY($form-switch-track-height / -2);
             }
 
             .form-check-label {
@@ -174,8 +173,7 @@
 
                 // Track
                 &::before {
-                    top: 0;
-                    //top: calc(((1em * #{$line-height-base}) - #{$form-switch-track-height}) / 2);
+                    top: calc((.5em * #{$line-height-base}) - (#{$form-switch-track-height} / 2));
                     left: 0;
                     width: $form-switch-width;
                     height: $form-switch-track-height;
@@ -183,13 +181,11 @@
                     border: $form-switch-track-border-width solid $form-switch-track-border-color;
                     @include border-radius($form-switch-track-border-radius);
                     @include box-shadow($form-switch-track-box-shadow);
-                    transform: translateY(.5em * $line-height-base) translateY($form-switch-track-height / -2);
                 }
 
                 // Thumb
                 &::after {
-                    top: 0;
-                    //top: calc(((1em * #{$line-height-base}) - #{$form-switch-thumb-height}) / 2);
+                    top: calc((.5em * #{$line-height-base}) - (#{$form-switch-thumb-height} / 2));
                     left: $form-switch-thumb-offset;
                     width: $form-switch-thumb-width;
                     height: $form-switch-thumb-height;
@@ -197,7 +193,6 @@
                     border: $form-switch-thumb-border-width solid $form-switch-thumb-border-color;
                     @include border-radius($form-switch-thumb-border-radius);
                     @include box-shadow($form-switch-thumb-box-shadow);
-                    transform: translateY(.5em * $line-height-base) translateY($form-switch-thumb-height / -2);
                 }
             }
 


### PR DESCRIPTION
Allows CSS vars to be used, at least for `line-height`.