### PR TITLE
Forms: Add `strip-calc()` function, allow string values on `.form-con…

### DIFF
--- a/scss/functions/_str-util.scss
+++ b/scss/functions/_str-util.scss
@@ -33,3 +33,15 @@
 
     @return $string;
 }
+
+// Strip the `calc` surrounding a string if one is found, leaves the '()'s
+// in place to preserve operator precedence.
+@function strip-calc($string) {
+    @if type-of($string) == "string" {
+        @if str-index($string, "calc(") == 1 {
+            $string: str-slice($string, 5, -1);
+        }
+    }
+
+    @return $string;
+}

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -4,7 +4,10 @@
     @if $padding-y == null and $line-height == null {
         @return null;
     }
-    $height-font:    1em * if($line-height != null, $line-height, $input-line-height);
+    $lh: if($line-height != null, $line-height, $input-line-height);
+    $lh: strip-calc($lh);
+
+    $height-font:    1em * #{$lh};
     $height-padding: 2 * if($padding-y != null, $padding-y, $input-padding-y);
 
     $height-inner: #{$height-font} unquote("+") #{$height-padding};
@@ -16,7 +19,10 @@
     @if $padding-y == null and $line-height == null {
         @return null;
     }
-    $height-font:    1em * if($line-height != null, $line-height, $input-line-height);
+    $lh: if($line-height != null, $line-height, $input-line-height);
+    $lh: strip-calc($lh);
+
+    $height-font:    1em * #{$lh};
     $height-padding: 2 * if($padding-y != null, $padding-y, $input-padding-y);
     $height-border:  $input-border-width * 2;
 

--- a/site/4.0/content/forms.md
+++ b/site/4.0/content/forms.md
@@ -193,6 +193,12 @@ Add the `disabled` attribute on an input to prevent user interactions and make i
 
 {% capture example %}
 <input class="form-control" id="disabled-input" type="text" placeholder="Disabled input" aria-label="Disabled input example" disabled>
+
+<select class="form-control" aria-label="Disable select example" disabled>
+  <option>Disabled select example</option>
+</select>
+
+<textarea class="form-control" id="disabled-input" type="text" placeholder="Disabled textarea" aria-label="Disabled textarea example" disabled></textarea>
 {% endcapture %}
 {% renderExample example %}
 
@@ -510,7 +516,7 @@ However, the stylized inputs will need to keep their label in order for the visu
 Label can be supplied outside of the `.form-check` container also.
 
 {% capture example %}
-<div class="row">
+<div class="row gx-0_5">
   <label class="col-md-auto" for="extlabel0">External label</label>
   <div class="col">
     <div class="form-check form">
@@ -519,7 +525,7 @@ Label can be supplied outside of the `.form-check` container also.
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row gx-0_5">
   <label class="col-md-auto" for="extlabel1">External label</label>
   <div class="col">
     <div class="form-check form-checkradio">
@@ -528,7 +534,7 @@ Label can be supplied outside of the `.form-check` container also.
     </div>
   </div>
 </div>
-<div class="row">
+<div class="row gx-0_5">
   <label class="col-md-auto" for="extlabel2">External label</label>
   <div class="col">
     <div class="form-check form-switch">
@@ -606,6 +612,19 @@ The file input requires additional JavaScript if you would like to have a functi
 <div class="form-file">
   <input type="file" class="form-file-input" id="formFile">
   <label class="form-file-label" for="formFile">
+    <span class="form-file-text">Choose file...</span>
+    <span class="form-file-button">Browse</span>
+  </label>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
+Add the `disabled` attribute to the `<input>` and the custom markup will be updated to appear disabled.
+
+{% capture example %}
+<div class="form-file">
+  <input type="file" class="form-file-input" id="formFileDisabled" disabled>
+  <label class="form-file-label" for="formFileDisabled">
     <span class="form-file-text">Choose file...</span>
     <span class="form-file-button">Browse</span>
   </label>


### PR DESCRIPTION
…trol` line-heights, additional form examples