### PR TITLE
Tooltip/Popover/Modal - Fix unlink and dispose options

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -48,6 +48,9 @@
 
             this.$element.attr('data-cfw', 'modal');
 
+            this.disposeOnHide = this.settings.dispose;
+            this.unlinkOnHide = this.settings.unlink;
+
             // Check for presence of ids - set if not present
             // var triggerID = this.$element.CFW_getID('cfw-modal');
             var targetID = this.$target.CFW_getID('cfw-modal');
@@ -169,7 +172,7 @@
                 this.$target.appendTo(this.$body); // don't move modals dom position
             }
 
-            this.$target.show();
+            this.$target.css('display', 'block');
 
             if ($modalBody.length) {
                 $modalBody.scrollTop(0); // scrollable body variant
@@ -220,7 +223,10 @@
                 .off('mutate.cfw.mutate')
                 .removeAttr('data-cfw-mutate')
                 .CFW_mutationIgnore()
-                .hide();
+                .css('display', 'none');
+
+            this.$element.trigger('focus');
+
             this.backdrop(function() {
                 $selfRef.$body.removeClass('modal-open');
                 $selfRef.resetAdjustments();
@@ -228,8 +234,13 @@
                 $selfRef.$target
                     .CFW_mutateTrigger()
                     .CFW_trigger('afterHide.cfw.modal');
+
+                if ($selfRef.disposeOnHide) {
+                    $selfRef.dispose();
+                } else if ($selfRef.unlinkOnHide) {
+                    $selfRef.unlink();
+                }
             });
-            this.$element.trigger('focus');
         },
 
         enforceFocus : function() {

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -74,6 +74,8 @@
                 hover: false,
                 focus: false
             };
+            this.disposeOnHide = this.settings.dispose;
+            this.unlinkOnHide = this.settings.unlink;
 
             this.$element.attr('data-cfw', this.type);
 
@@ -550,14 +552,17 @@
         },
 
         dispose : function() {
+            var type = this.type;
+            var $element = this.$element;
             var $target = this.$target;
 
-            $(document).one('afterUnlink.cfw.' + this.type, this.$element, function(e) {
-                var $this = $(e.target);
+            $(document).one('afterUnlink.cfw.' + this.type, this.$element, function() {
                 if ($target) {
                     $target.remove();
                 }
-                $this.CFW_trigger('dispose.cfw.' + this.type);
+                $element.CFW_trigger('dispose.cfw.' + type, {
+                    relatedTarget: $target
+                });
             });
             this.unlink();
         },
@@ -735,6 +740,12 @@
             this._hideExt();
 
             this.$element.CFW_trigger('afterHide.cfw.' + this.type);
+
+            if (this.disposeOnHide) {
+                this.dispose();
+            } else if (this.unlinkOnHide) {
+                this.unlink();
+            }
         },
 
         _hideExt : function() {

--- a/site/4.0/widgets/modal.md
+++ b/site/4.0/widgets/modal.md
@@ -1215,11 +1215,17 @@ Event callbacks happen on the target `<div class="modal">` element.
       </tr>
       <tr>
         <td><code>afterUnlink.cfw.modal</code></td>
-        <td>This event is fired when a modal item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+        <td>
+          <p>This event is fired when a modal item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.modal</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
       <tr>
         <td><code>dispose.cfw.modal</code></td>
-        <td>This event is fired immediately before the modal item is removed from the DOM.</td>
+        <td>
+          <p>This event is fired immediately before the modal item is removed from the DOM.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.modal</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/site/4.0/widgets/popover.md
+++ b/site/4.0/widgets/popover.md
@@ -548,11 +548,17 @@ Event callbacks happen on the toggle/trigger element.
       </tr>
       <tr>
         <td><code>afterUnlink.cfw.popover</code></td>
-        <td>This event is fired when a popover item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+        <td>
+          <p>This event is fired on the trigger element when a popover item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.popover</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
       <tr>
         <td><code>dispose.cfw.popover</code></td>
-        <td>This event is fired immediately before the popover item is removed from the DOM.</td>
+        <td>
+          <p>This event is fired immediately before the popover item is removed from the DOM.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.popover</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/site/4.0/widgets/tooltip.md
+++ b/site/4.0/widgets/tooltip.md
@@ -413,11 +413,17 @@ Event callbacks happen on the toggle/trigger element.
       </tr>
       <tr>
         <td><code>afterUnlink.cfw.tooltip</code></td>
-        <td>This event is fired when a tooltip item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</td>
+        <td>
+          <p>This event is fired on the trigger element when a tooltip item has been unlinked from its trigger item and the data-api removed. This event can occur after the <code>afterHide</code> event when invoked from the <code>unlink</code> method, or before if set to automatically unlink.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.tooltip</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
       <tr>
         <td><code>dispose.cfw.tooltip</code></td>
-        <td>This event is fired immediately before the tooltip item is removed from the DOM.</td>
+        <td>
+          <p>This event is fired immediately before the tooltip item is removed from the DOM.</p>
+          <p>This event may need to be listened for using event delegation, since all <code>cfw.tooltip</code> namespaced events will be detached from the trigger element as part of the unlink process.</p>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -870,4 +870,128 @@ $(function() {
             .CFW_Modal()
             .CFW_Modal('show');
     });
+
+    QUnit.test('unlink method should detach events and data', function(assert) {
+        assert.expect(7);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>')
+            .appendTo('#qunit-fixture')
+            .on('custom.foo', $.noop);
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body"></div></div></div></div>').appendTo(document.body);
+
+        $trigger.CFW_Modal();
+
+        assert.ok($trigger.data('cfw.modal'), 'trigger has data');
+        assert.ok($._data($trigger[0], 'events').click, 'trigger has click event');
+        assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger has extra custom.foo event');
+
+        $target.one('afterShow.cfw.modal', function() {
+            $(document).one('afterUnlink.cfw.modal', $target, function() {
+                assert.ok(!$target.hasClass('in'), 'target is hidden');
+                assert.ok(!$trigger.data('cfw.modal'), 'trigger does not have data');
+                assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger still has custom.foo');
+                assert.ok(!$._data($trigger[0], 'events').click, 'trigger does not have any events');
+                done();
+            });
+            $trigger.CFW_Modal('unlink');
+        });
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('unlink option should detach events and data after hide', function(assert) {
+        assert.expect(7);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>')
+            .appendTo('#qunit-fixture')
+            .on('custom.foo', $.noop);
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body"></div></div></div></div>').appendTo(document.body);
+
+        $trigger.CFW_Modal({
+            unlink: true
+        });
+
+        assert.ok($trigger.data('cfw.modal'), 'trigger has data');
+        assert.ok($._data($trigger[0], 'events').click, 'trigger has click event');
+        assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger has extra custom.foo event');
+
+        $target.one('afterShow.cfw.modal', function() {
+            $(document).one('afterUnlink.cfw.modal', $target, function() {
+                assert.ok(!$target.hasClass('in'), 'target is hidden');
+                assert.ok(!$trigger.data('cfw.modal'), 'trigger does not have data');
+                assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger still has custom.foo');
+                assert.ok(!$._data($trigger[0], 'events').click, 'trigger does not have any events');
+                done();
+            });
+            $trigger.CFW_Modal('hide');
+        });
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('dispose method should unlink and remove modal', function(assert) {
+        assert.expect(8);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>')
+            .appendTo('#qunit-fixture')
+            .on('custom.foo', $.noop);
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body"></div></div></div></div>').appendTo(document.body);
+
+        $trigger.CFW_Modal();
+
+        assert.ok($trigger.data('cfw.modal'), 'trigger has data');
+        assert.ok($._data($trigger[0], 'events').click, 'trigger has click event');
+        assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger has extra custom.foo event');
+
+        $target.one('afterShow.cfw.modal', function() {
+            $(document).one('dispose.cfw.modal', $target, function() {
+                assert.ok(!$target.hasClass('in'), 'target is hidden');
+                assert.ok(!$trigger.data('cfw.modal'), 'trigger does not have data');
+                assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger still has custom.foo');
+                assert.ok(!$._data($trigger[0], 'events').click, 'trigger does not have any events');
+                // Slight delay since item removed after the event fires
+                setTimeout(function() {
+                    assert.strictEqual($('.modal').length, 0);
+                }, 0);
+                done();
+            });
+            $trigger.CFW_Modal('dispose');
+        });
+        $trigger.CFW_Modal('show');
+    });
+
+    QUnit.test('dispose option should unlink and remove modal after hide', function(assert) {
+        assert.expect(8);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>')
+            .appendTo('#qunit-fixture')
+            .on('custom.foo', $.noop);
+        var $target = $('<div class="modal" id="modal"><div class="modal-dialog"><div class="modal-content"><div class="modal-body"></div></div></div></div>').appendTo(document.body);
+
+        $trigger.CFW_Modal({
+            dispose: true
+        });
+
+        assert.ok($trigger.data('cfw.modal'), 'trigger has data');
+        assert.ok($._data($trigger[0], 'events').click, 'trigger has click event');
+        assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger has extra custom.foo event');
+
+        $target.one('afterShow.cfw.modal', function() {
+            $(document).one('dispose.cfw.modal', $target, function() {
+                assert.ok(!$target.hasClass('in'), 'target is hidden');
+                assert.ok(!$trigger.data('cfw.modal'), 'trigger does not have data');
+                assert.strictEqual($._data($trigger[0], 'events').custom[0].namespace, 'foo', 'trigger still has custom.foo');
+                assert.ok(!$._data($trigger[0], 'events').click, 'trigger does not have any events');
+                // Slight delay since item removed after the event fires
+                setTimeout(function() {
+                    assert.strictEqual($('.modal').length, 0);
+                }, 0);
+                done();
+            });
+            $trigger.CFW_Modal('hide');
+        });
+        $trigger.CFW_Modal('show');
+    });
 });


### PR DESCRIPTION
Apparently I never hooked in the functionality for the option versions of `unlink` and `dispose` that are available for Tooltips, Popovers, and Modals.   The method calls were available though.

- Updated docs with some additional notes for the options regarding the need for event delegation.
- Removed the use  of jQuery's hide/show methods in `modal.js`.