### PR TITLE
Tooltip/Popover: Normalize fade

### DIFF
--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -17,6 +17,7 @@
         target          : false,            // Target selector
         placement       : 'top',            // Where to locate tooltip (top/bottom/reverse(left))/forward(right)/auto)
         trigger         : 'hover focus',    // How tooltip is triggered (click/hover/focus/manual)
+        display         : 'block',          // Value for display CSS rule
         animate         : true,             // Should the tooltip fade in and out
         delay : {
             show        : 0,                // Delay for showing tooltip (milliseconda)
@@ -348,6 +349,7 @@
             this.bindTip(false);
             this.setContent();
 
+            this.$target.css('display', this.settings.display);
             if (this.settings.animate) { this.$target.addClass('fade'); }
 
             this.locateTip();
@@ -692,6 +694,7 @@
                 .removeAttr('data-cfw-mutate')
                 .CFW_mutationIgnore();
             this.$target
+                .css('display', 'none')
                 .off('.cfw.' + this.type)
                 .off('mutate.cfw.mutate')
                 .removeClass('in')

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -20,7 +20,7 @@
 
         // Showing
         &.in {
-            display: block;
+            opacity: 1;
         }
     }
 

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -2,7 +2,7 @@
     .tooltip {
         position: absolute;
         z-index: $zindex-tooltip;
-        display: block;
+        display: none;
         margin: $tooltip-margin;
         // Our parent element can be arbitrary since tooltips are by default inserted as a sibling of their target element.
         // So reset our font and text properties to avoid inheriting weird values.

--- a/site/4.0/widgets/popover.md
+++ b/site/4.0/widgets/popover.md
@@ -287,6 +287,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>The selector of the target popover.</td>
       </tr>
       <tr>
+        <td><code>display</code></td>
+        <td>string</td>
+        <td><code>block</code></td>
+        <td>Value of CSS <code>display</code> rule when popover is visible.</td>
+      </tr>
+      <tr>
         <td><code>animate</code></td>
         <td>boolean</td>
         <td><code>true</code></td>

--- a/site/4.0/widgets/tooltip.md
+++ b/site/4.0/widgets/tooltip.md
@@ -181,6 +181,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td>The selector of the target tooltip.</td>
       </tr>
       <tr>
+        <td><code>display</code></td>
+        <td>string</td>
+        <td><code>block</code></td>
+        <td>Value of CSS <code>display</code> rule when tooltip is visible.</td>
+      </tr>
+      <tr>
         <td><code>animate</code></td>
         <td>boolean</td>
         <td><code>true</code></td>

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -1062,4 +1062,22 @@ $(function() {
         $el.CFW_Tooltip('hide');
         assert.ok(!showingTooltip(), 'tooltip is hidden');
     });
+
+    QUnit.test('should allow custom display value when shown', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $trigger = $('<a href="#" title="Another tooltip"></a>')
+            .appendTo('#qunit-fixture')
+            .CFW_Tooltip({
+                display: 'flex'
+            });
+
+        $trigger
+            .on('afterShow.cfw.tooltip', function() {
+                assert.strictEqual($('.tooltip').css('display'), 'flex');
+                done();
+            })
+            .CFW_Tooltip('show');
+    });
 });


### PR DESCRIPTION
- Fixes broken popover animation
- Adds option to pass custom `display` rule