### PR TITLE
Utilities-Spacing: Reorder generated spacing rules so single sides co…

### DIFF
--- a/scss/utilities/_spacing.scss
+++ b/scss/utilities/_spacing.scss
@@ -13,6 +13,8 @@
                         .#{$abbrev}#{$bprule}-#{$size} {
                             #{$prop}: $length !important;
                         }
+                    }
+                    @each $size, $length in $spacers-map {
                         .#{$abbrev}t#{$bprule}-#{$size},
                         .#{$abbrev}y#{$bprule}-#{$size} {
                             #{$prop}-top: $length !important;
@@ -42,6 +44,10 @@
                         .m#{$bprule}-#{$spacers-margin-negative-prepend}#{$size} {
                             margin: ($length * -1) !important;
                         }
+                    }
+                }
+                @each $size, $length in $spacers-margin-negative {
+                    @if not($length == 0) {
                         .mt#{$bprule}-#{$spacers-margin-negative-prepend}#{$size},
                         .my#{$bprule}-#{$spacers-margin-negative-prepend}#{$size} {
                             margin-top: ($length * -1) !important;


### PR DESCRIPTION
…me after all sides

Align with assumed behavior that `p-1 pb-0` will remove bottom padding, but `1rem` padding on all other sides.