### PR TITLE
Tab: Allow use of  `<button>`s

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -29,8 +29,10 @@
             var $selfRef = this;
 
             // Find nav and target elements
-            this.$navElm = this.$element.closest('ul, ol, nav');
-            this.$navElm.attr('role', 'tablist');
+            this.$navElm = this.$element.closest('ul, ol, nav, .nav, .list');
+            if (this.$navElm.length && this.$navElm[0].nodeName.toLowerCase() !== 'nav') {
+                this.$navElm.attr('role', 'tablist');
+            }
 
             var $selector = $(this.settings.target);
             if (!$selector.length) {
@@ -179,7 +181,7 @@
 
             var $node = $(node);
             var $list = $node.closest('[role="tablist"]');
-            var $items = $list.find('[role="tab"]:visible').not('.disabled');
+            var $items = $list.find('[role="tab"]:visible').not('.disabled').not(':disabled');
             var index = $items.index($items.filter('[aria-selected="true"]'));
 
             if ((e.which === KEYCODE_UP || e.which === KEYCODE_LEFT) && index > 0) { index--; } // up & left

--- a/scss/component/_nav.scss
+++ b/scss/component/_nav.scss
@@ -17,6 +17,8 @@
         font-weight: $nav-link-font-weight;
         color: $nav-link-color;
         text-decoration: $nav-link-decoration;
+        background: none;
+        border: 0;
         @include transition($nav-link-transition);
 
         @include hover-focus() {
@@ -26,7 +28,8 @@
 
         // Disabled state lightens text and removes hover/focus effects
         // By default it also influences `.nav-tab` and `.nav-pills`
-        &.disabled {
+        &.disabled,
+        &:disabled {
             color: $nav-link-disabled-color;
             text-decoration: none;
             pointer-events: none;
@@ -45,7 +48,6 @@
             .nav-link {
                 // Make the list-items overlay the bottom border
                 margin-bottom: -$nav-tabs-border-width;
-                background: none;
                 border: $nav-tabs-border-width solid transparent;
                 @include border-radius($border-radius $border-radius 0 0);
 
@@ -54,7 +56,8 @@
                     border-color: $nav-tabs-hover-border-color $nav-tabs-hover-border-color $nav-tabs-border-color;
                 }
 
-                &.disabled {
+                &.disabled,
+                &:disabled {
                     color: $nav-link-disabled-color;
                     background-color: transparent;
                     border-color: transparent;
@@ -86,8 +89,6 @@
             flex-flow: row wrap;
 
             .nav-link {
-                background: none;
-                border: 0;
                 @include border-radius($nav-pills-border-radius);
 
                 @include hover-focus() {
@@ -95,7 +96,8 @@
                     background-color: $nav-pills-hover-bg;
                 }
 
-                &.disabled {
+                &.disabled,
+                &:disabled {
                     color: $nav-link-disabled-color;
                     background-color: transparent;
                     border-color: transparent;

--- a/site/4.1/widgets/tab.md
+++ b/site/4.1/widgets/tab.md
@@ -17,6 +17,13 @@ For accessibility reasons, do not mix use of the [Tab widget]({{ site.path }}/{{
 {% endcapture %}
 {% renderCallout, callout, "warning" %}
 
+As a best practice, we recommend using `<button>` elements for the tabs, as these are controls that trigger a dynamic change, rather than links that navigate to a new page or location.
+
+However, if you choose to use the historical method using anchors, be sure to abide by the recommendations for disabled links.
+
+{%- assign calloutAnchors = version.docs | valueIfEmpty: site.version.docs | prepend: "./" | append: "/partials/callout-warning-disabling-anchors.md" -%}
+{% include calloutAnchors %}
+
 ## Examples
 
 ### Tabs
@@ -25,10 +32,10 @@ The tab widget works with [tab]({{ site.path }}/{{ version.docs }}/components/na
 
 <div class="cf-example">
   <ul class="nav nav-tabs">
-    <li class="nav-item"><a href="#tab1" class="nav-link" data-cfw="tab">Tab 1</a></li>
-    <li class="nav-item"><a href="#tab2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
-    <li class="nav-item"><a href="#tab3" class="nav-link" data-cfw="tab">Tab 3</a></li>
-    <li class="nav-item"><a href="#tab4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Tab 4</a></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab1">Tab 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#tab2">Tab 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab3">Tab 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab4" disabled>Tab 4</button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="tab1">
@@ -48,10 +55,10 @@ The tab widget works with [tab]({{ site.path }}/{{ version.docs }}/components/na
 
 {% capture highlight %}
 <ul class="nav nav-tabs">
-  <li class="nav-item"><a href="#tab1" class="nav-link" data-cfw="tab">Tab 1</a></li>
-  <li class="nav-item"><a href="#tab2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
-  <li class="nav-item"><a href="#tab3" class="nav-link" data-cfw="tab">Tab 3</a></li>
-  <li class="nav-item"><a href="#tab4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Tab 4</a></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab1">Tab 1</button></li>
+  <li class="nav-item"><button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#tab2">Tab 2</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab3">Tab 3</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab4" disabled>Tab 4</button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="tab1">...</div>
@@ -68,10 +75,10 @@ The tab widget also works with [pill]({{ site.path }}/{{ version.docs }}/compone
 
 <div class="cf-example">
   <ul class="nav nav-pills">
-    <li class="nav-item"><a href="#pill1" class="nav-link" data-cfw="tab">Tab 1</a></li>
-    <li class="nav-item"><a href="#pill2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
-    <li class="nav-item"><a href="#pill3" class="nav-link" data-cfw="tab">Tab 3</a></li>
-    <li class="nav-item"><a href="#pill4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Tab 4</a></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill1">Pill 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#pill2">Pill 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill3">Pill 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill4" disabled>Pill 4</button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="pill1">
@@ -90,11 +97,11 @@ The tab widget also works with [pill]({{ site.path }}/{{ version.docs }}/compone
 </div>
 
 {% capture highlight %}
-<ul class="nav nav-tabs">
-  <li class="nav-item"><a href="#pill1" class="nav-link" data-cfw="tab">Pill 1</a></li>
-  <li class="nav-item"><a href="#pill2" class="nav-link active" data-cfw="tab">Pill 2</a></li>
-  <li class="nav-item"><a href="#pill3" class="nav-link" data-cfw="tab">Pill 3</a></li>
-  <li class="nav-item"><a href="#pill4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Pill 4</a></li>
+<ul class="nav nav-pills">
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill1">Pill 1</button></li>
+  <li class="nav-item"><button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#pill2">Pill 2</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill3">Pill 3</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pill4" disabled>Pill 4</button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="pill1">...</div>
@@ -105,19 +112,66 @@ The tab widget also works with [pill]({{ site.path }}/{{ version.docs }}/compone
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
+And with vertical pills.
+
+<div class="cf-example">
+  <div class="d-flex align-items-start">
+    <ul class="nav nav-pills flex-column me-1">
+      <li class="nav-item"><button type="button" class="nav-link text-nowrap" data-cfw="tab" data-cfw-tab-target="#pillV1">Vertical Pill 1</button></li>
+      <li class="nav-item"><button type="button" class="nav-link text-nowrap active" data-cfw="tab" data-cfw-tab-target="#pillV2">Vertical Pill 2</button></li>
+      <li class="nav-item"><button type="button" class="nav-link text-nowrap" data-cfw="tab" data-cfw-tab-target="#pillV3">Vertical Pill 3</button></li>
+      <li class="nav-item"><button type="button" class="nav-link text-nowrap" data-cfw="tab" data-cfw-tab-target="#pillV4" disabled>Vertical Pill 4</button></li>
+    </ul>
+    <div class="tab-content">
+      <div class="tab-pane" id="pillV1">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar ligula ac sapien auctor viverra. Aliquam elit tortor, consequat at ultrices sit amet, vehicula eu leo. In fermentum lacus purus, ac dictum orci placerat ut. Integer magna lacus, adipiscing sed justo ut, sollicitudin rhoncus libero. Pellentesque accumsan pretium sem eu euismod? Nunc id facilisis sem? Quisque quis laoreet mi.</p>
+      </div>
+      <div class="tab-pane" id="pillV2">
+        <p>Phasellus at nisl et arcu tincidunt sagittis et nec nunc. Fusce ultrices venenatis felis, in faucibus mauris egestas nec. Etiam malesuada dictum nisi, at pulvinar orci. Aenean venenatis metus in pharetra aliquam. Mauris ac odio tortor! Maecenas eget orci in ipsum ullamcorper malesuada. Nunc interdum lobortis velit sed accumsan.</p>
+      </div>
+      <div class="tab-pane" id="pillV3">
+        <p> Praesent laoreet augue sed mauris vulputate, ut commodo justo malesuada. Pellentesque adipiscing; lorem vel convallis dignissim, leo est condimentum sapien, nec viverra dui risus at metus! Phasellus tellus magna, hendrerit eget tempor quis, fringilla id sem.</p>
+      </div>
+      <div class="tab-pane" id="pillV4">
+        <p>Duis pharetra suscipit felis, id congue purus tempus sed. Nunc porttitor nec arcu at interdum. Nulla placerat odio luctus malesuada dapibus. Suspendisse et auctor metus. Suspendisse fringilla commodo cursus. Suspendisse sodales vitae enim ut commodo. Nunc ut nibh quis tellus varius fermentum at et nibh. Nulla nisl leo, hendrerit ut rutrum faucibus, ullamcorper ut lectus. Donec tristique justo justo, nec imperdiet leo porttitor non. Donec vehicula purus dapibus hendrerit ornare.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% capture highlight %}
+<div class="d-flex align-items-start">
+  <ul class="nav nav-pills me-1">
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pillV1">Vertical Pill 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#pillV2">Vertical Pill 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pillV3">Vertical Pill 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#pillV4" disabled>Vertical Pill 4</button></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane" id="pillV1">...</div>
+    <div class="tab-pane" id="pillV2">...</div>
+    <div class="tab-pane" id="pillV3">...</div>
+    <div class="tab-pane" id="pillV4">...</div>
+  </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
 ### List
 
-The tab widget even work with the [`.list` component]({{ site.path }}/{{ version.docs }}/components/lists/).
+The tab widget even works with the [`.list` component]({{ site.path }}/{{ version.docs }}/components/lists/).
 
 <div class="cf-example">
   <div class="row">
     <div class="col-md-4">
-      <nav class="list list-spaced list-ruled">
-        <a href="#list1" data-cfw="tab" class="list-item list-item-action">List Item 1</a>
-        <a href="#list2" data-cfw="tab" class="list-item list-item-action active">List Item 2</a>
-        <a href="#list3" data-cfw="tab" class="list-item list-item-action">List Item 3</a>
-        <a href="#list4" data-cfw="tab" class="list-item list-item-action disabled" tabindex="-1" aria-disabled="true">List Item 4</a>
-        </nav>
+      <nav>
+        <div class="list list-spaced list-ruled">
+          <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list1">List Item 1</button>
+          <button type="button" class="list-item list-item-action active" data-cfw="tab" data-cfw-tab-target="#list2">List Item 2</button>
+          <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list3">List Item 3</button>
+          <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list4" disabled>List Item 4</button>
+        </div>
+      </nav>
     </div>
     <div class="col-md-8">
       <div class="tab-content">
@@ -141,11 +195,13 @@ The tab widget even work with the [`.list` component]({{ site.path }}/{{ version
 {% capture highlight %}
 <div class="row">
   <div class="col-md-4">
-    <nav class="list list-spaced list-ruled">
-      <a href="#list1" class="list-item list-item-action">List Item 1</a>
-      <a href="#list2" class="list-item list-item-action active">List Item 2</a>
-      <a href="#list3" class="list-item list-item-action">List Item 3</a>
-      <a href="#list4" class="list-item list-item-action disabled" tabindex="-1" aria-disabled="true">List Item 4</a>
+    <nav>
+      <div class="list list-spaced list-ruled">
+        <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list1">List Item 1</button>
+        <button type="button" class="list-item list-item-action active" data-cfw="tab" data-cfw-tab-target="#list2">List Item 2</button>
+        <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list3">List Item 3</button>
+        <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#list4" disabled>List Item 4</button>
+      </div>
     </nav>
   </div>
   <div class="col-md-8">
@@ -156,6 +212,49 @@ The tab widget even work with the [`.list` component]({{ site.path }}/{{ version
       <div class="tab-pane" id="list4">...</div>
     </div>
   </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Anchors
+
+For reference, this is a 'historical' example, using anchors, as shown in earlier iterations of Figuration. As previously mentioned, we recommend using `<button>` elements for the tabs, as seen in the examples above. Regardless, this alternative may be helpful for some situations.
+
+<div class="cf-example">
+  <ul class="nav nav-tabs">
+    <li class="nav-item"><a href="#tabOld1" class="nav-link" data-cfw="tab">Tab 1</a></li>
+    <li class="nav-item"><a href="#tabOld2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
+    <li class="nav-item"><a href="#tabOld3" class="nav-link" data-cfw="tab">Tab 3</a></li>
+    <li class="nav-item"><a href="#tabOld4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Tab 4</a></li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane" id="tabOld1">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar ligula ac sapien auctor viverra. Aliquam elit tortor, consequat at ultrices sit amet, vehicula eu leo. In fermentum lacus purus, ac dictum orci placerat ut. Integer magna lacus, adipiscing sed justo ut, sollicitudin rhoncus libero. Pellentesque accumsan pretium sem eu euismod? Nunc id facilisis sem? Quisque quis laoreet mi.</p>
+    </div>
+    <div class="tab-pane" id="tabOld2">
+      <p>Phasellus at nisl et arcu tincidunt sagittis et nec nunc. Fusce ultrices venenatis felis, in faucibus mauris egestas nec. Etiam malesuada dictum nisi, at pulvinar orci. Aenean venenatis metus in pharetra aliquam. Mauris ac odio tortor! Maecenas eget orci in ipsum ullamcorper malesuada. Nunc interdum lobortis velit sed accumsan.</p>
+    </div>
+    <div class="tab-pane" id="tabOld3">
+      <p> Praesent laoreet augue sed mauris vulputate, ut commodo justo malesuada. Pellentesque adipiscing; lorem vel convallis dignissim, leo est condimentum sapien, nec viverra dui risus at metus! Phasellus tellus magna, hendrerit eget tempor quis, fringilla id sem.</p>
+    </div>
+    <div class="tab-pane" id="tabOld4">
+      <p>Duis pharetra suscipit felis, id congue purus tempus sed. Nunc porttitor nec arcu at interdum. Nulla placerat odio luctus malesuada dapibus. Suspendisse et auctor metus. Suspendisse fringilla commodo cursus. Suspendisse sodales vitae enim ut commodo. Nunc ut nibh quis tellus varius fermentum at et nibh. Nulla nisl leo, hendrerit ut rutrum faucibus, ullamcorper ut lectus. Donec tristique justo justo, nec imperdiet leo porttitor non. Donec vehicula purus dapibus hendrerit ornare.</p>
+    </div>
+  </div>
+</div>
+
+{% capture highlight %}
+<ul class="nav nav-tabs">
+  <li class="nav-item"><a href="#tabOld1" class="nav-link" data-cfw="tab">Tab 1</a></li>
+  <li class="nav-item"><a href="#tabOld2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
+  <li class="nav-item"><a href="#tabOld3" class="nav-link" data-cfw="tab">Tab 3</a></li>
+  <li class="nav-item"><a href="#tabOld4" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Tab 4</a></li>
+</ul>
+<div class="tab-content">
+  <div class="tab-pane" id="tabOld1">...</div>
+  <div class="tab-pane" id="tabOld2">...</div>
+  <div class="tab-pane" id="tabOld3">...</div>
+  <div class="tab-pane" id="tabOld4">...</div>
 </div>
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
@@ -349,3 +448,7 @@ Dynamic tabbed interfaces, as described in the [<abbr title="Web Accessibility I
 All of these requirements are automatically added by the Tab widget, and will update automatically as the user interacts with the tabbed interface.
 
 The `aria-current` attribute is not necessary on dynamic tabbed interfaces since our JavaScript handles the selected state by adding `aria-selected="true"` on the active tab.
+
+### Using a Nav Element
+
+If you are using `<nav>`, the `role="tablist"` will not be automatically added to it, as this would override the `<nav>`'s native role as a navigation landmark. Instead, switch to an alternative element (such as `<div>`) and wrap the `<nav>` around that.  Refer to the [tab widget using a list example](#list) for a better look.

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -1195,52 +1195,109 @@ $(window).ready(function() {
 
             <h2 id="tab">Tab:</h2>
 
-            <div class="bs-example bs-example-tabs">
-                <ul id="myTab" class="nav nav-tabs">
-                    <li class="nav-item"><a href="#tabpanel1" class="nav-link" data-cfw="tab">Tab 1</a></li>
-                    <li class="nav-item"><a href="#tabpanel2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
-                    <li class="nav-item"><a href="#tabpanel3" class="nav-link" data-cfw="tab">Tab 3</a></li>
-                    <li class="nav-item"><a href="#tabpanel4" class="nav-link disabled" data-cfw="tab">Tab 4</a></li>
-                    <li class="nav-item"><a href="#" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tabpanel5" data-cfw-tab-animate="false">Tab 5</a></li>
-                </ul>
-                <div class="tab-content">
-                    <div class="tab-pane" id="tabpanel1">
-                        <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
-                        <p>This <button type="button"  class="btn" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
-                    </div>
-                    <div class="tab-pane" id="tabpanel2">
-                        <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
-                    </div>
-                    <div class="tab-pane" id="tabpanel3">
-                        <div class="active bg-warning">active</div>
-                        <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
-                        <div class="row" data-cfw="equalize" data-cfw-equalize-target=".card">
-                            <div class="col-4">
-                                <div class="card">
-                                    Card
-                                </div>
+            <ul id="myTab" class="nav nav-tabs">
+                <li class="nav-item"><a href="#tabpanel1" class="nav-link" data-cfw="tab">Tab 1</a></li>
+                <li class="nav-item"><a href="#tabpanel2" class="nav-link active" data-cfw="tab">Tab 2</a></li>
+                <li class="nav-item"><a href="#tabpanel3" class="nav-link" data-cfw="tab">Tab 3</a></li>
+                <li class="nav-item"><a href="#tabpanel4" class="nav-link disabled" data-cfw="tab">Tab 4</a></li>
+                <li class="nav-item"><a href="#" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tabpanel5" data-cfw-tab-animate="false">Tab 5</a></li>
+            </ul>
+            <div class="tab-content">
+                <div class="tab-pane" id="tabpanel1">
+                    <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+                    <p>This <button type="button"  class="btn" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel2">
+                    <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel3">
+                    <div class="active bg-warning">active</div>
+                    <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+                    <div class="row" data-cfw="equalize" data-cfw-equalize-target=".card">
+                        <div class="col-4">
+                            <div class="card">
+                                Card
                             </div>
-                            <div class="col-4">
-                                <div class="card">
-                                    Card<br>Card<br>Card<br>
-                                </div>
+                        </div>
+                        <div class="col-4">
+                            <div class="card">
+                                Card<br>Card<br>Card<br>
                             </div>
-                            <div class="col-4">
-                                <div class="card">
-                                    Card
-                                </div>
+                        </div>
+                        <div class="col-4">
+                            <div class="card">
+                                Card
                             </div>
                         </div>
                     </div>
-                    <div class="tab-pane" id="tabpanel4">
-                        <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel4">
+                    <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel5">
+                    <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+                    <div class="row">
+                        <div class="col-4">
+                            <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.1/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid">
+                        </div>
                     </div>
-                    <div class="tab-pane" id="tabpanel5">
-                        <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
-                        <div class="row">
-                            <div class="col-4">
-                                <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.1/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid">
+                </div>
+            </div>
+
+            <h3>Alternate Tab</h3>
+            <div id="myTabButtons" class="nav nav-tabs">
+                <button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tabpanel1b">Tab 1</button>
+                <button type="button" class="nav-link active" data-cfw="tab" data-cfw-tab-target="#tabpanel2b">Tab 2</button>
+                <button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tabpanel3b">Tab 3</button>
+                <button type="button" class="nav-link disabled" data-cfw="tab" data-cfw-tab-target="#tabpanel4b">Tab 4</button>
+                <button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tabpanel5b" data-cfw-tab-animate="false">Tab 5</button>
+            </div>
+            <!--
+            <div id="myTabButtons" class="list list-horizontal">
+                <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#tabpanel1b">Tab 1</button>
+                <button type="button" class="list-item list-item-action active" data-cfw="tab" data-cfw-tab-target="#tabpanel2b">Tab 2</button>
+                <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#tabpanel3b">Tab 3</button>
+                <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#tabpanel4b" disabled>Tab 4</button>
+                <button type="button" class="list-item list-item-action" data-cfw="tab" data-cfw-tab-target="#tabpanel5b" data-cfw-tab-animate="false">Tab 5</button>
+            </div>
+            -->
+            <div class="tab-content">
+                <div class="tab-pane" id="tabpanel1b">
+                    <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+                    <p>This <button type="button"  class="btn" data-cfw="popover" title="A Title" data-cfw-popover-content="And here's some amazing content. It's very engaging. right?" data-cfw-popover-placement="forward">button</button> should trigger a popover on click.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel2b">
+                    <p>Food truck fixie locavore, accusamus mcsweeney's marfa nulla single-origin coffee squid. Exercitation +1 labore velit, blog sartorial PBR leggings next level wes anderson artisan four loko farm-to-table craft beer twee. Qui photo booth letterpress, commodo enim craft beer mlkshk aliquip jean shorts ullamco ad vinyl cillum PBR. Homo nostrud organic, assumenda labore aesthetic magna delectus mollit. Keytar helvetica VHS salvia yr, vero magna velit sapiente labore stumptown. Vegan fanny pack odio cillum wes anderson 8-bit, sustainable jean shorts beard ut DIY ethical culpa terry richardson biodiesel. Art party scenester stumptown, tumblr butcher vero sint qui sapiente accusamus tattooed echo park.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel3b">
+                    <div class="active bg-warning">active</div>
+                    <p>Etsy mixtape wayfarers, ethical wes anderson tofu before they sold out mcsweeney's organic lomo retro fanny pack lo-fi farm-to-table readymade. Messenger bag gentrify pitchfork tattooed craft beer, iphone skateboard locavore carles etsy salvia banksy hoodie helvetica. DIY synth PBR banksy irony. Leggings gentrify squid 8-bit cred pitchfork. Williamsburg banh mi whatever gluten-free, carles pitchfork biodiesel fixie etsy retro mlkshk vice blog. Scenester cred you probably haven't heard of them, vinyl craft beer blog stumptown. Pitchfork sustainable tofu synth chambray yr.</p>
+                    <div class="row" data-cfw="equalize" data-cfw-equalize-target=".card">
+                        <div class="col-4">
+                            <div class="card">
+                                Card
                             </div>
+                        </div>
+                        <div class="col-4">
+                            <div class="card">
+                                Card<br>Card<br>Card<br>
+                            </div>
+                        </div>
+                        <div class="col-4">
+                            <div class="card">
+                                Card
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="tab-pane" id="tabpanel4b">
+                    <p>Trust fund seitan letterpress, keytar raw denim keffiyeh etsy art party before they sold out master cleanse gluten-free squid scenester freegan cosby sweater. Fanny pack portland seitan DIY, art party locavore wolf cliche high life echo park Austin. Cred vinyl keffiyeh DIY salvia PBR, banh mi before they sold out farm-to-table VHS viral locavore cosby sweater. Lomo wolf viral, mustache readymade thundercats keffiyeh craft beer marfa ethical. Wolf salvia freegan, sartorial keffiyeh echo park vegan.</p>
+                </div>
+                <div class="tab-pane" id="tabpanel5b">
+                    <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
+                    <div class="row">
+                        <div class="col-4">
+                            <img src="" data-cfw="lazy" data-cfw-lazy-src="../../site/assets/4.1/img/test.gif" alt="test pattern" style="border: 1px solid blue;" class="img-fluid">
                         </div>
                     </div>
                 </div>

--- a/test/js/unit/tab.js
+++ b/test/js/unit/tab.js
@@ -38,18 +38,95 @@ $(function() {
         assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
     });
 
-    QUnit.test('should activate element by pill id', function(assert) {
+    QUnit.test('should activate element by tab id using buttons', function(assert) {
         assert.expect(2);
-        var pillsHTML = '<ul class="pills">' +
+        var tabsHTML = '<ul class="tabs">' +
+            '<li><button type="button" data-cfw-tab-target="#home">Home</button></li>' +
+            '<li><button type="button" data-cfw-tab-target="#profile">Profile</button></li>' +
+            '</ul>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+
+        $(tabsHTML).find('li:last button').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'profile');
+
+        $(tabsHTML).find('li:first button').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
+    });
+
+    QUnit.test('should activate element by tab id in ordered list', function(assert) {
+        assert.expect(2);
+        var pillsHTML = '<ol class="pills">' +
             '<li><a href="#home">Home</a></li>' +
             '<li><a href="#profile">Profile</a></li>' +
-            '</ul>';
+            '</ol>';
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
 
         $(pillsHTML).find('li:last a').CFW_Tab('show');
         assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'profile');
 
         $(pillsHTML).find('li:first a').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
+    });
+
+    QUnit.test('should activate element by tab id in nav', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<nav>' +
+            '<button type="button" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw-tab-target="#profile">Profile</button>' +
+            '</nav>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        $(tabsHTML).find('button:last').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'profile');
+
+        $(tabsHTML).find('button:first').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
+    });
+
+    QUnit.test('should not appy role="tablist" to parent nav', function(assert) {
+        assert.expect(3);
+        var tabsHTML = '<nav>' +
+            '<button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw="tab" data-cfw-tab-target="#profile">Profile</button>' +
+            '</nav>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        assert.strictEqual($('#qunit-fixture').find('nav').length, 1, 'parent <nav> exists');
+        assert.strictEqual($('#qunit-fixture').find('nav[role="tablist"]').length, 0, 'parent <nav> does not have role="tablist"');
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        assert.strictEqual($('#qunit-fixture').find('nav[role="tablist"]').length, 0, 'parent <nav> does not have role="tablist" after invoking');
+    });
+
+    QUnit.test('should activate element by tab id in .nav', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<div class="nav">' +
+            '<button type="button" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw-tab-target="#profile">Profile</button>' +
+            '</div>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        $(tabsHTML).find('button:last').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'profile');
+
+        $(tabsHTML).find('button:first').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
+    });
+
+    QUnit.test('should activate element by tab id in .list', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<div class="list">' +
+            '<button type="button" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw-tab-target="#profile">Profile</button>' +
+            '</div>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+
+        $(tabsHTML).find('button:last').CFW_Tab('show');
+        assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'profile');
+
+        $(tabsHTML).find('button:first').CFW_Tab('show');
         assert.strictEqual($('#qunit-fixture').find('.active').attr('id'), 'home');
     });
 
@@ -182,6 +259,62 @@ $(function() {
         $last.CFW_Tab('show');
     });
 
+    QUnit.test('should appy role="tablist" to parent <ul>', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<ul>' +
+            '<li><button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button></li>' +
+            '<li><button type="button" data-cfw="tab" ata-cfw-tab-target="#profile">Profile</button></li>' +
+            '</ul>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        assert.strictEqual($('#qunit-fixture').find('ul[role="tablist"]').length, 0, 'parent <ul> does not have role="tablist"');
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        assert.strictEqual($('#qunit-fixture').find('ul[role="tablist"]').length, 1, 'parent <ul> has role="tablist" after invoking');
+    });
+
+    QUnit.test('should appy role="tablist" to parent <ol>', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<ol>' +
+            '<li><button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button></li>' +
+            '<li><button type="button" data-cfw="tab" ata-cfw-tab-target="#profile">Profile</button></li>' +
+            '</ol>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        assert.strictEqual($('#qunit-fixture').find('ol[role="tablist"]').length, 0, 'parent <ol> does not have role="tablist"');
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        assert.strictEqual($('#qunit-fixture').find('ol[role="tablist"]').length, 1, 'parent <ol> has role="tablist" after invoking');
+    });
+
+    QUnit.test('should appy role="tablist" to parent .nav', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<div class="nav">' +
+            '<button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw="tab" ata-cfw-tab-target="#profile">Profile</button>' +
+            '</div>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        assert.strictEqual($('#qunit-fixture').find('.nav[role="tablist"]').length, 0, 'parent .nav does not have role="tablist"');
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        assert.strictEqual($('#qunit-fixture').find('.nav[role="tablist"]').length, 1, 'parent .nav has role="tablist" after invoking');
+    });
+
+    QUnit.test('should appy role="tablist" to parent .list', function(assert) {
+        assert.expect(2);
+        var tabsHTML = '<div class="list">' +
+            '<button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button>' +
+            '<button type="button" data-cfw="tab" ata-cfw-tab-target="#profile">Profile</button>' +
+            '</div>';
+        $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
+        $(tabsHTML).appendTo('#qunit-fixture');
+
+        assert.strictEqual($('#qunit-fixture').find('.list[role="tablist"]').length, 0, 'parent .list does not have role="tablist"');
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        assert.strictEqual($('#qunit-fixture').find('.list[role="tablist"]').length, 1, 'parent .list has role="tablist" after invoking');
+    });
+
     QUnit.test('parent list items should get role="presentation"', function(assert) {
         assert.expect(2);
         var tabsHTML = '<ul class="tabs">' +
@@ -252,8 +385,8 @@ $(function() {
         assert.expect(0);
 
         var tabsHTML = '<ul class="tabs">' +
-            '<li><a href="#home" data-cfw="tab">Home</a></li>' +
-            '<li><a href="#profile" data-cfw="tab" disabled>Profile</a></li>' +
+            '<li><button type="button" data-cfw="tab" data-cfw-tab-target="#home">Home</button></li>' +
+            '<li><button type="button" data-cfw="tab" data-cfw-tab-target="#profile" disabled>Profile</button></li>' +
             '</ul>';
         $('<ul><li id="home"></li><li id="profile"></li></ul>').appendTo('#qunit-fixture');
         $(tabsHTML).appendTo('#qunit-fixture');

--- a/test/visual/nav.html
+++ b/test/visual/nav.html
@@ -50,6 +50,15 @@
         <a class="nav-link disabled" href="#">Disabled</a>
     </nav>
 
+    <h2>Button</h2>
+
+    <div class="nav">
+        <button class="nav-link active" type="button">Active</button>
+        <button class="nav-link" type="button">Link</button>
+        <button class="nav-link" type="button">Another link</button>
+        <button class="nav-link" type="button" disabled>Disabled</button>
+    </div>
+
     <h2>Vertical List</h2>
 
     <ul class="nav nav-vertical">


### PR DESCRIPTION
- Moved button reset in `.nav. to base `.nav-link`
- Expand valid parent to include `.nav` and `.list`
- Don't apply `role="tablist"` to `<nav>` parent
- Added a few more unit tests
- Removed unused wrapper from dev testing file
- Updated docs