### PR TITLE
Lighten the hover background-color for component base and default `.btn`

### DIFF
--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -488,7 +488,7 @@ $responsive-font-size-scale-factor: (
 $component-bg:                  $white !default;
 $component-border-color:        $border-color !default;
 
-$component-hover-bg:            $uibase-100 !default;
+$component-hover-bg:            $uibase-50 !default;
 
 $component-action-color:        $uibase-700 !default;
 $component-action-hover-color:  $uibase-800 !default;
@@ -753,7 +753,7 @@ $btn-default-bg:                    $white !default;
 $btn-default-color:                 color-if-contrast($uibase-500, $btn-default-bg) !default;
 $btn-default-border-color:          $uibase-300 !default;
 $btn-default-focus-box-shadow-color: $component-active-bg !default;
-$btn-default-hover-bg:              $uibase-100 !default;
+$btn-default-hover-bg:              $uibase-50 !default;
 $btn-default-hover-color:           color-if-contrast($uibase-600, $btn-default-hover-bg) !default;
 $btn-default-hover-border-color:    $uibase-400 !default;
 $btn-default-active-bg:             $uibase-200 !default;

--- a/site/4.1/content/buttons.md
+++ b/site/4.1/content/buttons.md
@@ -660,7 +660,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$btn-default-hover-bg</code></td>
         <td>string</td>
-        <td><code>$uibase-100</code></td>
+        <td><code>$uibase-50</code></td>
         <td>
           Default button background color for hover state.
         </td>


### PR DESCRIPTION
Ease the the component and button hover background-color down a bit so it is not so 'harsh'.