### PR TITLE
Slideshow: Allow use of button controls 

### DIFF
--- a/js/alert.js
+++ b/js/alert.js
@@ -50,7 +50,7 @@
                 return;
             }
 
-            if ($(e.currentTarget).not('.disabled, :disabled').length) {
+            if (!$.CFW_isDisabled(e.currentTarget)) {
                 this.close();
             }
         },

--- a/js/drag.js
+++ b/js/drag.js
@@ -69,7 +69,7 @@
             }
 
             // check for disabled element
-            if (this.$element.is('.disabled, :disabled')) { return; }
+            if ($.CFW_isDisabled(this.$element)) { return; }
 
             this._dragStartOff(e);
             this.dragging = true;

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -352,7 +352,7 @@
             }
 
             // Ignore disabled items
-            if (this.$element.is('.disabled, :disabled')) {
+            if ($.CFW_isDisabled(this.$element)) {
                 return;
             }
 
@@ -595,7 +595,7 @@
                 e.stopPropagation();
             }
 
-            if (this.$element.is('.disabled, :disabled')) {
+            if ($.CFW_isDisabled(this.$element)) {
                 return;
             }
 
@@ -613,7 +613,7 @@
         show : function() {
             var $selfRef = this;
 
-            if (this.$element.is('.disabled, :disabled') || this.$target.hasClass('open')) {
+            if ($.CFW_isDisabled(this.$element) || this.$target.hasClass('open')) {
                 return;
             }
 
@@ -648,7 +648,7 @@
         },
 
         hide : function() {
-            if (this.$element.is('.disabled, :disabled') || !this.$target.hasClass('open')) {
+            if ($.CFW_isDisabled(this.$element) || !this.$target.hasClass('open')) {
                 return;
             }
 

--- a/js/player.js
+++ b/js/player.js
@@ -585,7 +585,7 @@
             var $muteElm = this.$player.find('[data-cfw-player="mute"]');
 
             if (!this.support.mute) {
-                this._controlDisable($muteElm);
+                $.CFW_controlDisable($muteElm);
             } else if (this.media.muted) {
                 $muteElm.addClass('active');
             } else {
@@ -623,7 +623,7 @@
             var $volElm = this.$player.find('[data-cfw-player="volume"]');
 
             if (!this.support.mute) {
-                this._controlDisable($volElm);
+                $.CFW_controlDisable($volElm);
                 return;
             }
             var $inputElm = $volElm.find('input[type="range"]').eq(0);
@@ -833,7 +833,7 @@
             }
 
             if (this.trackValid.length <= 0) {
-                this._controlDisable($captionElm);
+                $.CFW_controlDisable($captionElm);
                 return;
             }
 
@@ -977,7 +977,7 @@
             }
 
             if (this.trackValid.length <= 0) {
-                this._controlDisable($tsElm);
+                $.CFW_controlDisable($tsElm);
                 return;
             }
 
@@ -1042,7 +1042,7 @@
                         $(this).prop('checked', $selfRef.settings.transcriptScroll);
                     });
                     this.$player.on('click', '[data-cfw-player-script-describe]', function(e) {
-                        if (!$selfRef._controlIsDisabled($(e.target))) {
+                        if (!$.CFW_isDisabled($(e.target))) {
                             $selfRef.settings.transcriptDescribe = !$selfRef.settings.transcriptDescribe;
                             $(this).prop('checked', $selfRef.settings.transcriptDescribe);
                             $selfRef.scriptLoad();
@@ -1169,9 +1169,9 @@
             }
             var $descControl = this.$player.find('[data-cfw-player-script-describe]');
             if (!descAvailable) {
-                this._controlDisable($descControl);
+                $.CFW_controlDisable($descControl);
             } else {
-                this._controlEnable($descControl);
+                $.CFW_controlEnable($descControl);
             }
 
             // Test again for text-based description
@@ -1183,9 +1183,9 @@
             }
             var $textDescControl = this.$player.find('[data-cfw-player="textdescription"]');
             if (!textDescAvailable) {
-                this._controlDisable($textDescControl);
+                $.CFW_controlDisable($textDescControl);
             } else {
-                this._controlEnable($textDescControl);
+                $.CFW_controlEnable($textDescControl);
             }
 
             var scriptLoad2 = function(forced) {
@@ -1371,7 +1371,7 @@
             }
 
             if (this.trackDescription.length <= 0) {
-                this._controlDisable($tdElm);
+                $.CFW_controlDisable($tdElm);
                 return;
             }
 
@@ -1423,7 +1423,7 @@
                     $selfRef.textDescriptionSet($selfRef.textDescribeCurrent);
                 });
                 this.$player.on('click', '[data-cfw-player-text-describe-visible]', function(e) {
-                    if (!$selfRef._controlIsDisabled($(e.target))) {
+                    if (!$.CFW_isDisabled($(e.target))) {
                         $selfRef.settings.textDescribeVisible = !$selfRef.settings.textDescribeVisible;
                         $(this).prop('checked', $selfRef.settings.textDescribeVisible);
                         $selfRef.textDescriptionSet($selfRef.textDescribeCurrent);
@@ -1699,29 +1699,6 @@
                     $selfRef.$focus.trigger('focus');
                 }
             }, 10);
-        },
-
-        _controlEnable : function($control) {
-            $control
-                .removeClass('disabled')
-                .removeAttr('disabled')
-                .closest('label')
-                .removeClass('disabled');
-        },
-
-        _controlDisable : function($control) {
-            if ($control.is('button, input')) {
-                $control.prop('disabled', true);
-                $control
-                    .closest('label')
-                    .addClass('disabled');
-            } else {
-                $control.addClass('disabled');
-            }
-        },
-
-        _controlIsDisabled : function($control) {
-            return $control.is('.disabled, :disabled');
         },
 
         _cuechangeEnable : function(trackID, namespace, callback) {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -43,13 +43,13 @@
             // Bind nav
             this.$navPrev.on('click.cfw.slideshow', function(e) {
                 e.preventDefault();
-                if ($(e.target).not('.disabled, :disabled')) {
+                if (!$.CFW_isDisabled(e.target)) {
                     $selfRef.prev();
                 }
             });
             this.$navNext.on('click.cfw.slideshow', function(e) {
                 e.preventDefault();
-                if ($(e.target).not('.disabled, :disabled')) {
+                if (!$.CFW_isDisabled(e.target)) {
                     $selfRef.next();
                 }
             });
@@ -97,22 +97,22 @@
         },
 
         update : function() {
-            this.$navPrev.removeClass('disabled');
-            this.$navNext.removeClass('disabled');
+            $.CFW_controlEnable(this.$navPrev);
+            $.CFW_controlEnable(this.$navNext);
 
             var $tabs = this._getTabs();
             var currIndex = this._currIndex($tabs);
             if (currIndex <= 0 && !this.settings.loop) {
-                this.$navPrev.addClass('disabled');
+                $.CFW_controlDisable(this.$navPrev);
             }
             if (currIndex >= $tabs.length - 1 && !this.settings.loop) {
-                this.$navNext.addClass('disabled');
+                $.CFW_controlDisable(this.$navNext);
             }
             this.$element.CFW_trigger('update.cfw.slideshow');
         },
 
         _getTabs : function() {
-            return this.$element.find('[role="tab"]:visible').not('.disabled');
+            return this.$element.find('[role="tab"]:visible').not('.disabled, :disabled');
         },
 
         _currIndex : function($tabs) {

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -54,16 +54,14 @@
                 }
             });
 
-            // If loop, replace keydown handler
-            if (this.settings.loop) {
-                $tabs
-                    .off('keydown.cfw.tab')
-                    .add(this.$navPrev)
-                    .add(this.$navNext)
-                    .on('keydown.cfw.slideshow', function(e) {
-                        $selfRef._actionsKeydown(e);
-                    });
-            }
+            // Replace keydown handler to handle loop
+            $tabs
+                .off('keydown.cfw.tab')
+                .add(this.$navPrev)
+                .add(this.$navNext)
+                .on('keydown.cfw.slideshow', function(e) {
+                    $selfRef._actionsKeydown(e);
+                });
 
             this.update();
 
@@ -73,26 +71,32 @@
         prev : function() {
             var $tabs = this._getTabs();
             var currIndex = this._currIndex($tabs);
+            var newIndex = -1;
             if (currIndex > 0) {
-                this.$element.CFW_trigger('prev.cfw.slideshow');
-                $tabs.eq(currIndex - 1).CFW_Tab('show');
+                newIndex = currIndex - 1;
             }
             if (this.settings.loop && currIndex === 0) {
+                newIndex = $tabs.length - 1;
+            }
+            if (newIndex > -1) {
                 this.$element.CFW_trigger('prev.cfw.slideshow');
-                $tabs.eq($tabs.length - 1).CFW_Tab('show');
+                $tabs.eq(newIndex).CFW_Tab('show');
             }
         },
 
         next : function() {
             var $tabs = this._getTabs();
             var currIndex = this._currIndex($tabs);
+            var newIndex = -1;
             if (currIndex < $tabs.length - 1) {
-                this.$element.CFW_trigger('next.cfw.slideshow');
-                $tabs.eq(currIndex + 1).CFW_Tab('show');
+                newIndex = currIndex + 1;
             }
             if (this.settings.loop && currIndex === ($tabs.length - 1)) {
-                this.$element.CFW_trigger('prev.cfw.slideshow');
-                $tabs.eq(0).CFW_Tab('show');
+                newIndex = 0;
+            }
+            if (newIndex > -1) {
+                this.$element.CFW_trigger('next.cfw.slideshow');
+                $tabs.eq(newIndex).CFW_Tab('show');
             }
         },
 
@@ -129,31 +133,19 @@
 
             if (!REGEX_KEYS.test(e.which)) { return; }
 
-            e.stopPropagation();
             e.preventDefault();
 
-            var $tabs = this._getTabs();
-            var index = this._currIndex($tabs);
-
             if (e.which === KEYCODE_UP || e.which === KEYCODE_LEFT) {
-                if (index > 0) {
-                    index--;
-                } else if (index === 0) {
-                    index = $tabs.length - 1;
-                }
+                this.prev();
             }
             if (e.which === KEYCODE_DOWN || e.which === KEYCODE_RIGHT) {
-                if (index < $tabs.length - 1) {
-                    index++;
-                } else if (index === $tabs.length - 1) {
-                    index = 0;
-                }
+                this.next();
             }
-            /* eslint-disable-next-line no-bitwise */
-            if (!~index) { index = 0; }  // force first item
-
-            var nextTab = $tabs.eq(index);
-            nextTab.CFW_Tab('show').trigger('focus');
+            if (e.currentTarget !== this.$navPrev[0] && e.currentTarget !== this.$navNext[0]) {
+                var $tabs = this._getTabs();
+                var currIndex = this._currIndex($tabs);
+                $tabs.eq(currIndex).trigger('focus');
+            }
         },
 
         dispose : function() {

--- a/js/tab.js
+++ b/js/tab.js
@@ -29,7 +29,7 @@
             var $selfRef = this;
 
             // Find nav and target elements
-            this.$navElm = this.$element.closest('ul, ol, nav, .nav, .list');
+            this.$navElm = this.$element.closest('ul, ol, nav, .nav, .list, .btn-group, .is-tablist');
             if (this.$navElm.length && this.$navElm[0].nodeName.toLowerCase() !== 'nav') {
                 this.$navElm.attr('role', 'tablist');
             }
@@ -114,9 +114,7 @@
                 e.preventDefault();
             }
 
-            if (this.$element.hasClass('active') ||
-                this.$element.hasClass('disabled') ||
-                this.$element[0].hasAttribute('disabled')) {
+            if ($.CFW_isDisabled(this.$element) || this.$element.hasClass('active')) {
                 return;
             }
 

--- a/js/util.js
+++ b/js/util.js
@@ -429,6 +429,7 @@
     $.CFW_controlEnable = function(element) {
         $(element)
             .removeClass('disabled')
+            .removeAttr('tabindex')
             .removeAttr('disabled')
             .closest('label')
             .removeClass('disabled');
@@ -443,7 +444,7 @@
                 .closest('label')
                 .addClass('disabled');
         } else {
-            $control.addClass('disabled');
+            $control.addClass('disabled').attr('tabindex', -1);
         }
     };
 

--- a/js/util.js
+++ b/js/util.js
@@ -425,4 +425,29 @@
     $.CFW_reflow = function(element) {
         return element.offsetHeight;
     };
+
+    $.CFW_controlEnable = function(element) {
+        $(element)
+            .removeClass('disabled')
+            .removeAttr('disabled')
+            .closest('label')
+            .removeClass('disabled');
+    };
+
+    $.CFW_controlDisable = function(element) {
+        var $control = $(element);
+
+        if ($control.length && /button|fieldset|input|optgroup|option|select|textarea/i.test($control[0].tagName)) {
+            $control.prop('disabled', true);
+            $control
+                .closest('label')
+                .addClass('disabled');
+        } else {
+            $control.addClass('disabled');
+        }
+    };
+
+    $.CFW_isDisabled = function(element) {
+        return $(element).is('.disabled, :disabled');
+    };
 }(jQuery));

--- a/site/4.1/widgets/slideshow.md
+++ b/site/4.1/widgets/slideshow.md
@@ -85,14 +85,14 @@ The slideshow works well with [tab navigation]({{ site.path }}/{{ version.docs }
 The slideshow also works with [pill navigation]({{ site.path }}/{{ version.docs }}/components/navs/#pills).
 
 <div class="cf-example">
-  <nav class="nav nav-pills" data-cfw="slideshow">
+  <div class="nav nav-pills" data-cfw="slideshow">
     <a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
     <a href="#pill-slide0" class="nav-link" data-cfw="tab">Slide 1</a>
     <a href="#pill-slide1" class="nav-link" data-cfw="tab">Slide 2</a>
     <a href="#pill-slide2" class="nav-link" data-cfw="tab">Slide 3</a>
     <a href="#pill-slide3" class="nav-link" data-cfw="tab">Slide 4</a>
     <a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
-  </nav>
+  </div>
   <div class="tab-content">
     <div class="tab-pane" id="pill-slide0">
       <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</p>
@@ -110,14 +110,14 @@ The slideshow also works with [pill navigation]({{ site.path }}/{{ version.docs 
 </div>
 
 {% capture highlight %}
-<nav class="nav nav-pills" data-cfw="slideshow">
-   <a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
+<div class="nav nav-pills" data-cfw="slideshow">
+  <a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
   <a href="#pill-slide0" class="nav-link" data-cfw="tab">Slide 1</a>
   <a href="#pill-slide1" class="nav-link" data-cfw="tab">Slide 2</a>
   <a href="#pill-slide2" class="nav-link" data-cfw="tab">Slide 3</a>
   <a href="#pill-slide3" class="nav-link" data-cfw="tab">Slide 4</a>
   <a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
-</nav>
+</div>
 <div class="tab-content">
   <div class="tab-pane" id="pill-slide0">
     ...
@@ -166,7 +166,7 @@ You can even use the [pagination componenent]({{ site.path }}/{{ version.docs }}
 
 {% capture highlight %}
 <ul class="pagination pagination-group" data-cfw="slideshow">
-   <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
+  <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
   <li class="page-item"><a href="#page-slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
   <li class="page-item"><a href="#page-slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
   <li class="page-item"><a href="#page-slide2" class="page-link" data-cfw="tab">Slide 3</a></li>

--- a/site/4.1/widgets/slideshow.md
+++ b/site/4.1/widgets/slideshow.md
@@ -23,6 +23,8 @@ Sideshow requires the following:
 
 A simple widget that extends on the [Tab widget]({{ site.path }}/{{ version.docs }}/widgets/tab/) to add previous and next navigation items that update their disabled state based on the currently active tab/slide.
 
+In accordance with the best practice recommendation with tabs, we recommend using `<button>` elements for the tabs within a slideshow, as these are controls that trigger a dynamic change, rather than links that navigate to a new page or location.
+
 ## Examples
 
 ### Using Tabs
@@ -31,12 +33,12 @@ The slideshow works well with [tab navigation]({{ site.path }}/{{ version.docs }
 
 <div class="cf-example">
   <ul class="nav nav-tabs" data-cfw="slideshow">
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-    <li class="nav-item"><a href="#tab-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-    <li class="nav-item"><a href="#tab-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
-    <li class="nav-item"><a href="#tab-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-    <li class="nav-item"><a href="#tab-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide0">Slide 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide1">Slide 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide2">Slide 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide3">Slide 4</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="tab-slide0">
@@ -56,12 +58,12 @@ The slideshow works well with [tab navigation]({{ site.path }}/{{ version.docs }
 
 {% capture highlight %}
 <ul class="nav nav-tabs" data-cfw="slideshow">
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-  <li class="nav-item"><a href="#tab-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-  <li class="nav-item"><a href="#tab-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
-  <li class="nav-item"><a href="#tab-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-  <li class="nav-item"><a href="#tab-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide0">Slide 1</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide1">Slide 2</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide2">Slide 3</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#tab-slide3">Slide 4</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="tab-slide0">
@@ -86,12 +88,12 @@ The slideshow also works with [pill navigation]({{ site.path }}/{{ version.docs 
 
 <div class="cf-example">
   <div class="nav nav-pills" data-cfw="slideshow">
-    <a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
-    <a href="#pill-slide0" class="nav-link" data-cfw="tab">Slide 1</a>
-    <a href="#pill-slide1" class="nav-link" data-cfw="tab">Slide 2</a>
-    <a href="#pill-slide2" class="nav-link" data-cfw="tab">Slide 3</a>
-    <a href="#pill-slide3" class="nav-link" data-cfw="tab">Slide 4</a>
-    <a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
+    <button type="button" class="nav-item nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button>
+    <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide0">Slide 1</button>
+    <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide1">Slide 2</button>
+    <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide2">Slide 3</button>
+    <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide3">Slide 4</button>
+    <button type="button" class="nav-item nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button>
   </div>
   <div class="tab-content">
     <div class="tab-pane" id="pill-slide0">
@@ -111,12 +113,12 @@ The slideshow also works with [pill navigation]({{ site.path }}/{{ version.docs 
 
 {% capture highlight %}
 <div class="nav nav-pills" data-cfw="slideshow">
-  <a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a>
-  <a href="#pill-slide0" class="nav-link" data-cfw="tab">Slide 1</a>
-  <a href="#pill-slide1" class="nav-link" data-cfw="tab">Slide 2</a>
-  <a href="#pill-slide2" class="nav-link" data-cfw="tab">Slide 3</a>
-  <a href="#pill-slide3" class="nav-link" data-cfw="tab">Slide 4</a>
-  <a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a>
+  <button type="button" class="nav-item nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button>
+  <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide0">Slide 1</button>
+  <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide1">Slide 2</button>
+  <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide2">Slide 3</button>
+  <button type="button" class="nav-item nav-link" data-cfw="tab" data-cfw-tab-target="#pill-slide3">Slide 4</button>
+  <button type="button" class="nav-item nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button>
 </div>
 <div class="tab-content">
   <div class="tab-pane" id="pill-slide0">
@@ -141,12 +143,12 @@ You can even use the [pagination componenent]({{ site.path }}/{{ version.docs }}
 
 <div class="cf-example">
   <ul class="pagination pagination-group" data-cfw="slideshow">
-    <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-    <li class="page-item"><a href="#page-slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
-    <li class="page-item"><a href="#page-slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
-    <li class="page-item"><a href="#page-slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
-    <li class="page-item"><a href="#page-slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
-    <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide0">Slide 1</button></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide1">Slide 2</button></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide2">Slide 3</button></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide3">Slide 4</button></li>
+    <li class="page-item"><button type="button" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="page-slide0">
@@ -166,12 +168,12 @@ You can even use the [pagination componenent]({{ site.path }}/{{ version.docs }}
 
 {% capture highlight %}
 <ul class="pagination pagination-group" data-cfw="slideshow">
-  <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-  <li class="page-item"><a href="#page-slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
-  <li class="page-item"><a href="#page-slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
-  <li class="page-item"><a href="#page-slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
-  <li class="page-item"><a href="#page-slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
-  <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide0">Slide 1</button></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide1">Slide 2</button></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide2">Slide 3</button></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw="tab" data-cfw-tab-target="#page-slide3">Slide 4</button></li>
+  <li class="page-item"><button type="button" class="page-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="page-slide0">
@@ -196,12 +198,12 @@ If there is a tab that is disabled, the previous and next navigation items will 
 
 <div class="cf-example">
   <ul class="nav nav-tabs" data-cfw="slideshow">
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-    <li class="nav-item"><a href="#ex-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-    <li class="nav-item"><a href="#ex-slide1" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Slide 2</a></li>
-    <li class="nav-item"><a href="#ex-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-    <li class="nav-item"><a href="#ex-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide0">Slide 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide1">Slide 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide2" disabled>Slide 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide3">Slide 4</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="ex-slide0">
@@ -221,12 +223,12 @@ If there is a tab that is disabled, the previous and next navigation items will 
 
 {% capture highlight %}
 <ul class="nav nav-tabs" data-cfw="slideshow">
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-  <li class="nav-item"><a href="#ex-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-  <li class="nav-item"><a href="#ex-slide1" class="nav-link disabled" data-cfw="tab" tabindex="-1" aria-disabled="true">Slide 2</a></li>
-  <li class="nav-item"><a href="#ex-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-  <li class="nav-item"><a href="#ex-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide0">Slide 1</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide1">Slide 2</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide2" disabled>Slide 3</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#ex-slide3">Slide 4</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="ex-slide0">
@@ -251,12 +253,12 @@ By default the previous or next navigation controls become disabled when the fir
 
 <div class="cf-example">
   <ul class="nav nav-tabs" data-cfw="slideshow" data-cfw-slideshow-loop="true">
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-    <li class="nav-item"><a href="#loop-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-    <li class="nav-item"><a href="#loop-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
-    <li class="nav-item"><a href="#loop-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-    <li class="nav-item"><a href="#loop-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide0">Slide 1</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide1">Slide 2</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide2">Slide 3</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide3">Slide 4</button></li>
+    <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
   </ul>
   <div class="tab-content">
     <div class="tab-pane" id="loop-slide0">
@@ -276,12 +278,12 @@ By default the previous or next navigation controls become disabled when the fir
 
 {% capture highlight %}
 <ul class="nav nav-tabs" data-cfw="slideshow" data-cfw-slideshow-loop="true">
-    <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></a></li>
-  <li class="nav-item"><a href="#loop-slide0" class="nav-link" data-cfw="tab">Slide 1</a></li>
-  <li class="nav-item"><a href="#loop-slide1" class="nav-link" data-cfw="tab">Slide 2</a></li>
-  <li class="nav-item"><a href="#loop-slide2" class="nav-link" data-cfw="tab">Slide 3</a></li>
-  <li class="nav-item"><a href="#loop-slide3" class="nav-link" data-cfw="tab">Slide 4</a></li>
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></a></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="prev" title="Previous Slide" aria-label="Previous Slide"><span aria-hidden="true">&laquo;</span></button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide0">Slide 1</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide1">Slide 2</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide2">Slide 3</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#loop-slide3">Slide 4</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw-slideshow-nav="next" title="Next Slide" aria-label="Next Slide"><span aria-hidden="true">&raquo;</span></button></li>
 </ul>
 <div class="tab-content">
   <div class="tab-pane" id="loop-slide0">
@@ -295,6 +297,93 @@ By default the previous or next navigation controls become disabled when the fir
   </div>
   <div class="tab-pane" id="loop-slide3">
     ...
+  </div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Customized
+
+Here is a slideshow using a customized layout, an `.is-tablist` wrapping container, and some Font Awesome icons.
+
+<div class="cf-example">
+  <div class="position-relative">
+    <div class="is-tablist" data-cfw="slideshow" data-cfw-slideshow-loop="true">
+      <div class="position-absolute top-0 start-0">
+        <button type="button" class="btn btn-link btn-icon" data-cfw-slideshow-nav="prev">
+          <span class="fas fa-fw fa-chevron-left" aria-hidden="true"></span>
+          <span class="sr-only">Previous Slide</span>
+        </button>
+      </div>
+      <div class="position-absolute top-0 start-50 translate-middle-x pt-0_25">
+        <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom1">
+          <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+          <span class="sr-only">Slide 1</span>
+        </button>
+        <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom2">
+          <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+          <span class="sr-only">Slide 2</span>
+        </button>
+        <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom3">
+          <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+          <span class="sr-only">Slide 3</span>
+        </button>
+      </div>
+      <div class="position-absolute top-0 end-0">
+        <button type="button" class="btn btn-link btn-icon" data-cfw-slideshow-nav="next">
+          <span class="fas fa-fw fa-chevron-right" aria-hidden="true"></span>
+          <span class="sr-only">Next Slide</span>
+        </button>
+      </div>
+    </div>
+    <div class="tab-content pt-2 px-2">
+      <div class="tab-pane" id="custom1">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar ligula ac sapien auctor viverra. Aliquam elit tortor, consequat at ultrices sit amet, vehicula eu leo. In fermentum lacus purus, ac dictum orci placerat ut. Integer magna lacus, adipiscing sed justo ut, sollicitudin rhoncus libero. Pellentesque accumsan pretium sem eu euismod? Nunc id facilisis sem? Quisque quis laoreet mi.</p>
+      </div>
+      <div class="tab-pane" id="custom2">
+        <p>Phasellus at nisl et arcu tincidunt sagittis et nec nunc. Fusce ultrices venenatis felis, in faucibus mauris egestas nec. Etiam malesuada dictum nisi, at pulvinar orci. Aenean venenatis metus in pharetra aliquam. Mauris ac odio tortor! Maecenas eget orci in ipsum ullamcorper malesuada. Nunc interdum lobortis velit sed accumsan.</p>
+      </div>
+      <div class="tab-pane" id="custom3">
+        <p> Praesent laoreet augue sed mauris vulputate, ut commodo justo malesuada. Pellentesque adipiscing; lorem vel convallis dignissim, leo est condimentum sapien, nec viverra dui risus at metus! Phasellus tellus magna, hendrerit eget tempor quis, fringilla id sem.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% capture highlight %}
+<div class="position-relative">
+  <div class="is-tablist" data-cfw="slideshow" data-cfw-slideshow-loop="true">
+    <div class="position-absolute top-0 start-0">
+      <button type="button" class="btn btn-link btn-icon" data-cfw-slideshow-nav="prev">
+        <span class="fas fa-fw fa-chevron-left" aria-hidden="true"></span>
+        <span class="sr-only">Previous Slide</span>
+      </button>
+    </div>
+    <div class="position-absolute top-0 start-50 translate-middle-x pt-0_25">
+      <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom1">
+        <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+        <span class="sr-only">Slide 1</span>
+      </button>
+      <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom2">
+        <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+        <span class="sr-only">Slide 2</span>
+      </button>
+      <button type="button" class="btn btn-link btn-icon btn-small" data-cfw="tab" data-cfw-tab-target="#custom3">
+        <span class="fas fa-fw fa-circle" aria-hidden="true"></span>
+        <span class="sr-only">Slide 3</span>
+      </button>
+    </div>
+    <div class="position-absolute top-0 end-0">
+      <button type="button" class="btn btn-link btn-icon" data-cfw-slideshow-nav="next">
+        <span class="fas fa-fw fa-chevron-right" aria-hidden="true"></span>
+        <span class="sr-only">Next Slide</span>
+      </button>
+    </div>
+  </div>
+  <div class="tab-content pt-2 px-2">
+    <div class="tab-pane" id="custom1">...</div>
+    <div class="tab-pane" id="custom2">...</div>
+    <div class="tab-pane" id="custom3">...</div>
   </div>
 </div>
 {% endcapture %}

--- a/site/4.1/widgets/tab.md
+++ b/site/4.1/widgets/tab.md
@@ -26,6 +26,8 @@ However, if you choose to use the historical method using anchors, be sure to ab
 
 ## Examples
 
+The tab widget can be used with the following semantic structures: `ul`, `ol`, and `nav`. In order to support more use-cases, the following classes will also allowed for tabs when used on the wrapping container: `.nav`, `.list`, and `.btn-group`. For even more flexibility, the custom class `.is-tablist` is also available.
+
 ### Tabs
 
 The tab widget works with [tab]({{ site.path }}/{{ version.docs }}/components/navs/#tabs) style navigation.
@@ -216,6 +218,83 @@ The tab widget even works with the [`.list` component]({{ site.path }}/{{ versio
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
+### Button Group
+
+Control tab panels using a [button group]({{ site.path }}/{{ version.docs }}/components/button-group/).
+
+<div class="cf-example">
+  <div class="btn-group mb-0_5">
+    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup1">Button 1</button>
+    <button type="button" class="btn active" data-cfw="tab" data-cfw-tab-target="#btngroup2">Button 2</button>
+    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup3" disabled>Button 3</button>
+    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup4">Button 4</button>
+  </div>
+  <div class="tab-content">
+    <div class="tab-pane" id="btngroup1">
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar ligula ac sapien auctor viverra. Aliquam elit tortor, consequat at ultrices sit amet, vehicula eu leo. In fermentum lacus purus, ac dictum orci placerat ut. Integer magna lacus, adipiscing sed justo ut, sollicitudin rhoncus libero. Pellentesque accumsan pretium sem eu euismod? Nunc id facilisis sem? Quisque quis laoreet mi.</p>
+    </div>
+    <div class="tab-pane" id="btngroup2">
+      <p>Phasellus at nisl et arcu tincidunt sagittis et nec nunc. Fusce ultrices venenatis felis, in faucibus mauris egestas nec. Etiam malesuada dictum nisi, at pulvinar orci. Aenean venenatis metus in pharetra aliquam. Mauris ac odio tortor! Maecenas eget orci in ipsum ullamcorper malesuada. Nunc interdum lobortis velit sed accumsan.</p>
+    </div>
+    <div class="tab-pane" id="btngroup3">
+      <p> Praesent laoreet augue sed mauris vulputate, ut commodo justo malesuada. Pellentesque adipiscing; lorem vel convallis dignissim, leo est condimentum sapien, nec viverra dui risus at metus! Phasellus tellus magna, hendrerit eget tempor quis, fringilla id sem.</p>
+    </div>
+    <div class="tab-pane" id="btngroup4">
+      <p>Duis pharetra suscipit felis, id congue purus tempus sed. Nunc porttitor nec arcu at interdum. Nulla placerat odio luctus malesuada dapibus. Suspendisse et auctor metus. Suspendisse fringilla commodo cursus. Suspendisse sodales vitae enim ut commodo. Nunc ut nibh quis tellus varius fermentum at et nibh. Nulla nisl leo, hendrerit ut rutrum faucibus, ullamcorper ut lectus. Donec tristique justo justo, nec imperdiet leo porttitor non. Donec vehicula purus dapibus hendrerit ornare.</p>
+    </div>
+  </div>
+</div>
+
+{% capture highlight %}
+<div class="btn-group mb-0_5">
+  <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup1">Button 1</button>
+  <button type="button" class="btn active" data-cfw="tab" data-cfw-tab-target="#btngroup2">Button 2</button>
+  <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup3" disabled>Button 3</button>
+  <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#btngroup4">Button 4</button>
+</div>
+<div class="tab-content">
+  <div class="tab-pane" id="btngroup1">...</div>
+  <div class="tab-pane" id="btngroup2">...</div>
+  <div class="tab-pane" id="btngroup3">...</div>
+  <div class="tab-pane" id="btngroup4">...</div>
+</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Customized
+
+Here is a tab example using a customized layout, an `.is-tablist` wrapping container, and some Font Awesome icons.
+
+<div class="cf-example">
+  <div class="position-relative">
+    <div class="is-tablist position-absolute top-0 start-50 translate-middle-x">
+      <button type="button" class="btn btn-link fs-2xlarge p-0" data-cfw="tab" data-cfw-tab-target="#custom1">
+        <span class="fas fa-fw fa-dice-one" aria-hidden="true"></span>
+        <span class="sr-only">Tab 1</span>
+      </button>
+      <button type="button" class="btn btn-link fs-2xlarge p-0" data-cfw="tab" data-cfw-tab-target="#custom2">
+        <span class="fas fa-fw fa-dice-two" aria-hidden="true"></span>
+        <span class="sr-only">Tab 2</span>
+      </button>
+      <button type="button" class="btn btn-link fs-2xlarge p-0" data-cfw="tab" data-cfw-tab-target="#custom3">
+        <span class="fas fa-fw fa-dice-three" aria-hidden="true"></span>
+        <span class="sr-only">Tab 3</span>
+      </button>
+    </div>
+    <div class="tab-content pt-2 px-2">
+      <div class="tab-pane" id="custom1">
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur pulvinar ligula ac sapien auctor viverra. Aliquam elit tortor, consequat at ultrices sit amet, vehicula eu leo. In fermentum lacus purus, ac dictum orci placerat ut. Integer magna lacus, adipiscing sed justo ut, sollicitudin rhoncus libero. Pellentesque accumsan pretium sem eu euismod? Nunc id facilisis sem? Quisque quis laoreet mi.</p>
+      </div>
+      <div class="tab-pane" id="custom2">
+        <p>Phasellus at nisl et arcu tincidunt sagittis et nec nunc. Fusce ultrices venenatis felis, in faucibus mauris egestas nec. Etiam malesuada dictum nisi, at pulvinar orci. Aenean venenatis metus in pharetra aliquam. Mauris ac odio tortor! Maecenas eget orci in ipsum ullamcorper malesuada. Nunc interdum lobortis velit sed accumsan.</p>
+      </div>
+      <div class="tab-pane" id="custom3">
+        <p> Praesent laoreet augue sed mauris vulputate, ut commodo justo malesuada. Pellentesque adipiscing; lorem vel convallis dignissim, leo est condimentum sapien, nec viverra dui risus at metus! Phasellus tellus magna, hendrerit eget tempor quis, fringilla id sem.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
 ### Anchors
 
 For reference, this is a 'historical' example, using anchors, as shown in earlier iterations of Figuration. As previously mentioned, we recommend using `<button>` elements for the tabs, as seen in the examples above. Regardless, this alternative may be helpful for some situations.
@@ -274,8 +353,8 @@ To set a default active tab, add the class `.active` to the trigger item.
 <ul class="nav nav-tabs">
   <li class="nav-item"><a href="#home" class="nav-link active" data-cfw="tab">Home</a></li>
   <li class="nav-item"><a href="#profile" class="nav-link" data-cfw="tab">Profile</a></li>
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw="tab" data-cfw-tab-target="#messages">Messages</a></li>
-  <li class="nav-item"><a href="#" class="nav-link" data-cfw="tab" data-cfw-tab-target="#settings">Settings</a></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#messages">Messages</button></li>
+  <li class="nav-item"><button type="button" class="nav-link" data-cfw="tab" data-cfw-tab-target="#settings">Settings</button></li>
 </ul>
 
 <!-- Tab panes -->
@@ -293,10 +372,10 @@ To set a default active tab, add the class `.active` to the trigger item.
 You can activate individual tabs in several ways:
 
 {% capture highlight %}
-$('#myTab a[href="#profile"]').CFW_Tab('show'); // Select tab by name
-$('#myTab a:first').CFW_Tab('show');            // Select first tab
-$('#myTab a:last').CFW_Tab('show');             // Select last tab
-$('#myTab a:nth-child(3)').CFW_Tab('show')      // Select third tab
+$('#myTab a[href="#profile"]').CFW_Tab('show');  // Select tab by href
+$('#myTab button:first').CFW_Tab('show');        // Select first tab
+$('#myTab button:last').CFW_Tab('show');         // Select last tab
+$('#myTab button:nth-child(3)').CFW_Tab('show'); // Select third tab
 {% endcapture %}
 {% renderHighlight highlight, "js" %}
 

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -450,7 +450,7 @@ $(window).ready(function() {
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" aria-label="Previous">&laquo;</a></li>
                         <li class="page-item"><a href="#slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
                         <li class="page-item"><a href="#slide1" class="page-link" data-cfw="tab">Slide 2</a></li>
-                        <li class="page-item"><a href="#slide2" class="page-link" data-cfw="tab">Slide 3</a></li>
+                        <li class="page-item"><a href="#slide2" class="page-link disabled" data-cfw="tab">Slide 3</a></li>
                         <li class="page-item"><a href="#slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" aria-label="Next">&raquo;</a></li>
                     </ul>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -397,7 +397,7 @@ $(window).ready(function() {
             <h2 id="slideshow">Slideshow:</h2>
 
             <h3>Buttons</h3>
-            <div data-cfw="slideshow">
+            <div data-cfw="slideshow" data-cfw-slideshow-loop="true">
                 <div class="btn-group" role="region" aria-label="Slideshow navigation">
                     <button type="button" class="btn" data-cfw-slideshow-nav="prev" aria-label="Previous">&laquo;</button>
                     <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#slideB0">Slide 1</button>

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -396,17 +396,39 @@ $(window).ready(function() {
 
             <h2 id="slideshow">Slideshow:</h2>
 
+            <h3>Buttons</h3>
+            <div data-cfw="slideshow">
+                <div class="btn-group" role="region" aria-label="Slideshow navigation">
+                    <button type="button" class="btn" data-cfw-slideshow-nav="prev" aria-label="Previous">&laquo;</button>
+                    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#slideB0">Slide 1</button>
+                    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#slideB1">Slide 2</button>
+                    <button type="button" class="btn" data-cfw="tab" data-cfw-tab-target="#slideB2">Slide 3</button>
+                    <button type="button" class="btn" data-cfw-slideshow-nav="next" aria-label="Next">&raquo;</button>
+                </div>
+                <div class="tab-content">
+                    <div class="tab-pane" id="slideB0">
+                        <p>Slide one</p>
+                    </div>
+                    <div class="tab-pane" id="slideB1">
+                        <p>Slide two</p>
+                    </div>
+                    <div class="tab-pane" id="slideB2">
+                        <p>slide three</p>
+                    </div>
+                </div>
+            </div>
+
             <h3>Loop enabled</h3>
             <div data-cfw="slideshow" data-cfw-slideshow-loop="true">
-                <nav aria-label="Page navigation">
-                    <ul id="slidetest" class="pagination pagination-group">
+                <section aria-label="Slideshow navigation">
+                    <ul id="slidetestL" class="pagination pagination-group">
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" aria-label="Previous">&laquo;</a></li>
                         <li class="page-item"><a href="#slideL0" class="page-link" data-cfw="tab">Slide 1</a></li>
                         <li class="page-item"><a href="#slideL1" class="page-link" data-cfw="tab">Slide 2</a></li>
                         <li class="page-item"><a href="#slideL2" class="page-link" data-cfw="tab">Slide 3</a></li>
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" aria-label="Next">&raquo;</a></li>
                     </ul>
-                </nav>
+                </section>
                 <div class="tab-content">
                     <div class="tab-pane" id="slideL0">
                         <p>Slide one</p>
@@ -423,7 +445,7 @@ $(window).ready(function() {
             <h3>Regular</h3>
             <p>Demo using pagination componenent, should also work for tab/pill navigation.</p>
             <div data-cfw="slideshow">
-                <nav aria-label="Page navigation">
+                <section aria-label="Slideshow navigation">
                     <ul id="slidetest" class="pagination pagination-group">
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="prev" aria-label="Previous">&laquo;</a></li>
                         <li class="page-item"><a href="#slide0" class="page-link" data-cfw="tab">Slide 1</a></li>
@@ -432,7 +454,7 @@ $(window).ready(function() {
                         <li class="page-item"><a href="#slide3" class="page-link" data-cfw="tab">Slide 4</a></li>
                         <li class="page-item"><a href="#" class="page-link" data-cfw-slideshow-nav="next" aria-label="Next">&raquo;</a></li>
                     </ul>
-                </nav>
+                </section>
                 <a href="#" data-cfw-slideshow-nav="prev" title="Previous">&laquo;</a>
                 <a href="#" data-cfw-slideshow-nav="next" title="Next">&raquo;</a>
                 <!--

--- a/test/js/unit/alert.js
+++ b/test/js/unit/alert.js
@@ -26,7 +26,7 @@ $(function() {
     QUnit.test('should fade element out on clicking .close (no transition)', function(assert) {
         assert.expect(1);
         var alertHTML = '<div class="alert alert-danger">' +
-            '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', 'none').appendTo($('#qunit-fixture'));
@@ -41,7 +41,7 @@ $(function() {
         assert.expect(1);
         var done = assert.async();
         var alertHTML = '<div class="alert alert-danger">' +
-            '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', '.05s').appendTo($('#qunit-fixture'));
@@ -59,7 +59,7 @@ $(function() {
     QUnit.test('should remove element when clicking .close (no transition)', function(assert) {
         assert.expect(2);
         var alertHTML = '<div class="alert alert-danger">' +
-            '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture');
@@ -75,7 +75,7 @@ $(function() {
         assert.expect(2);
         var done = assert.async();
         var alertHTML = '<div class="alert alert-danger">' +
-            '<a class="close" href="#" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', '.05s').appendTo('#qunit-fixture');
@@ -106,10 +106,11 @@ $(function() {
             .CFW_Alert('close');
     });
 
-    QUnit.test('should remove target element when clicking .close (no transition)', function(assert) {
-        assert.expect(2);
+    QUnit.test('should remove target element when clicking .close button (no transition)', function(assert) {
+        assert.expect(3);
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'no element in dom');
         var alertHTML = '<div id="test">' +
-            '<a class="close" href="#test" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" data-cfw-alert-target="#test" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture');
@@ -121,11 +122,12 @@ $(function() {
         assert.strictEqual($('#qunit-fixture').find('#test').length, 0, 'element removed from dom');
     });
 
-    QUnit.test('should remove target element when clicking .close (with transition)', function(assert) {
-        assert.expect(2);
+    QUnit.test('should remove target element when clicking .close button (with transition)', function(assert) {
+        assert.expect(3);
         var done = assert.async();
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'no element in dom');
         var alertHTML = '<div id="test">' +
-            '<a class="close" href="#test" data-cfw-dismiss="alert">&times;</a>' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" data-cfw-alert-target="#test" aria-label="Close"><span aria-hidden="true">&times;</span></button>' +
             '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
             '</div>';
         var $alert = $(alertHTML).css('transition', '.05s').appendTo('#qunit-fixture');
@@ -139,5 +141,53 @@ $(function() {
         $close
             .CFW_Alert()
             .trigger('click');
+    });
+
+    QUnit.test('should remove target element when clicking .close link (no transition)', function(assert) {
+        assert.expect(3);
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'no element in dom');
+        var alertHTML = '<div id="test">' +
+            '<a class="close" href="#test" data-cfw-dismiss="alert">&times;</a>' +
+            '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
+            '</div>';
+        var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture');
+        var $close = $alert.find('.close');
+        assert.notEqual($('#qunit-fixture').find('#test').length, 0, 'element added to dom');
+        $close
+            .CFW_Alert()
+            .trigger('click');
+        assert.strictEqual($('#qunit-fixture').find('#test').length, 0, 'element removed from dom');
+    });
+
+    QUnit.test('should not remove element close link has disabled class', function(assert) {
+        assert.expect(3);
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'no element in dom');
+        var alertHTML = '<div class="alert alert-danger">' +
+            '<a class="close disabled" href="#" data-cfw-dismiss="alert">&times;</a>' +
+            '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
+            '</div>';
+        var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture');
+        var $close = $alert.find('.close');
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 1, 'element added to dom');
+        $close
+            .CFW_Alert()
+            .trigger('click');
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 1, 'element not removed from dom');
+    });
+
+    QUnit.test('should not remove element close button has disabled attribute', function(assert) {
+        assert.expect(3);
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 0, 'no element in dom');
+        var alertHTML = '<div class="alert alert-danger">' +
+            '<button type="button" class="close" data-cfw-dismiss="alert" aria-label="Close" disabled><span aria-hidden="true">&times;</span></button>' +
+            '<p><strong>Danger!</strong> There is definitaly some error now.</p>' +
+            '</div>';
+        var $alert = $(alertHTML).css('transition', 'none').appendTo('#qunit-fixture');
+        var $close = $alert.find('.close');
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 1, 'element added to dom');
+        $close
+            .CFW_Alert()
+            .trigger('click');
+        assert.strictEqual($('#qunit-fixture').find('.alert').length, 1, 'element not removed from dom');
     });
 });

--- a/test/js/unit/slideshow.js
+++ b/test/js/unit/slideshow.js
@@ -23,7 +23,7 @@ $(function() {
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
 
-    QUnit.test('should move to next tab when next control clicked', function(assert) {
+    QUnit.test('should activate next tab when next control clicked', function(assert) {
         assert.expect(2);
 
         var $slideshow = $('<div class="nav">' +
@@ -44,7 +44,7 @@ $(function() {
         assert.strictEqual($tabs.filter('.active').attr('id'), 'tab1');
     });
 
-    QUnit.test('should move to next tab when next control clicked, skipping disabled tabs', function(assert) {
+    QUnit.test('should activate next tab when next control clicked, skipping disabled tabs', function(assert) {
         assert.expect(2);
 
         var $slideshow = $('<div class="nav">' +
@@ -65,7 +65,82 @@ $(function() {
         assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
     });
 
-    QUnit.test('should move to previous tab when previous control clicked', function(assert) {
+    QUnit.test('should trigger next event when next control clicked', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        /* var $tabs = */ $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $slideshow.on('next.cfw.slideshow', function() {
+            assert.ok(true);
+            done();
+        });
+        $('#slideNext').trigger('click');
+    });
+
+    QUnit.test('should move focus to next tab item for down/right keypress on tab', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        /* var $tabs = */ $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab0').trigger($.Event('keydown', {
+            which: 40 // Down
+        }));
+        assert.strictEqual(document.activeElement, document.querySelector('#tab1'));
+        $('#tab1').trigger($.Event('keydown', {
+            which: 39 // Right
+        }));
+        assert.strictEqual(document.activeElement, document.querySelector('#tab2'));
+    });
+
+    QUnit.test('should not move focus to next tab item for down/right keypress on next control', function(assert) {
+        assert.expect(3);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab1').CFW_Tab('show');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab1');
+        $('#slideNext').trigger('focus').trigger($.Event('keydown', {
+            which: 37 // Left
+        }));
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+        assert.strictEqual(document.activeElement, document.querySelector('#slideNext'));
+    });
+
+    QUnit.test('should activate previous tab when previous control clicked', function(assert) {
         assert.expect(2);
 
         var $slideshow = $('<div class="nav">' +
@@ -87,7 +162,7 @@ $(function() {
         assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
     });
 
-    QUnit.test('should move to previous tab when previous control clicked', function(assert) {
+    QUnit.test('should activate previous tab when previous control clicked, skipping disabled tabs', function(assert) {
         assert.expect(2);
 
         var $slideshow = $('<div class="nav">' +
@@ -107,6 +182,84 @@ $(function() {
         assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
         $('#slidePrev').trigger('click');
         assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+    });
+
+    QUnit.test('should trigger prev event when previous control clicked', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        /* var $tabs = */ $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $slideshow.on('prev.cfw.slideshow', function() {
+            assert.ok(true);
+            done();
+        });
+        $('#tab2').CFW_Tab('show');
+        $('#slidePrev').trigger('click');
+    });
+
+    QUnit.test('should move focus to previous tab item for up/left keypress on tab', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        /* var $tabs = */ $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab2').CFW_Tab('show');
+        $('#tab2').trigger($.Event('keydown', {
+            which: 38 // Up
+        }));
+        assert.strictEqual(document.activeElement, document.querySelector('#tab1'));
+        $('#tab1').trigger($.Event('keydown', {
+            which: 37 // Left
+        }));
+        assert.strictEqual(document.activeElement, document.querySelector('#tab0'));
+    });
+
+    QUnit.test('should not move focus to previous tab item for keypress on previous control', function(assert) {
+        assert.expect(3);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab2').CFW_Tab('show');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
+        $('#slidePrev').trigger('focus');
+        $('#slidePrev').trigger($.Event('keydown', {
+            which: 37 // Left
+        }));
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab1');
+        assert.strictEqual(document.activeElement, document.querySelector('#slidePrev'));
     });
 
     QUnit.test('should apply disabled attribute to previous button when first tab is active', function(assert) {

--- a/test/js/unit/slideshow.js
+++ b/test/js/unit/slideshow.js
@@ -22,4 +22,236 @@ $(function() {
         assert.ok($col instanceof $, 'returns jquery collection');
         assert.strictEqual($col[0], $el[0], 'collection contains element');
     });
+
+    QUnit.test('should move to next tab when next control clicked', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+        $('#slideNext').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab1');
+    });
+
+    QUnit.test('should move to next tab when next control clicked, skipping disabled tabs', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1" disabled>1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+        $('#slideNext').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
+    });
+
+    QUnit.test('should move to previous tab when previous control clicked', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+        $('#tab1').CFW_Tab('show');
+
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab1');
+        $('#slidePrev').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+    });
+
+    QUnit.test('should move to previous tab when previous control clicked', function(assert) {
+        assert.expect(2);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1" disabled>1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+        $('#tab2').CFW_Tab('show');
+
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
+        $('#slidePrev').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+    });
+
+    QUnit.test('should apply disabled attribute to previous button when first tab is active', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        assert.strictEqual($('#slidePrev').is(':disabled'), true);
+    });
+
+    QUnit.test('should apply disabled class to previous link when first tab is active', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<a id="slidePrev" role="button" href="#" data-cfw-slideshow-nav="prev">Previous</a>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<a id="slideNext" role="button" href="#" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        assert.strictEqual($('#slidePrev').hasClass('disabled'), true);
+    });
+
+    QUnit.test('should not disable previous control when first tab is active when loop=true', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow({
+            loop: true
+        });
+
+        assert.strictEqual($('#slidePrev').is(':disabled'), false);
+    });
+
+    QUnit.test('should apply disabled attribute to next button when last tab is active', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab2').CFW_Tab('show');
+        assert.strictEqual($('#slideNext').is(':disabled'), true);
+    });
+
+    QUnit.test('should apply disabled class to next link when last tab is active', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<a id="slidePrev" role="button" href="#" data-cfw-slideshow-nav="prev">Previous</a>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<a id="slideNext" role="button" href="#" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow();
+
+        $('#tab2').CFW_Tab('show');
+        assert.strictEqual($('#slideNext').hasClass('disabled'), true);
+    });
+
+    QUnit.test('should not disable next control when last tab is active when loop=true', function(assert) {
+        assert.expect(1);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow({
+            loop: true
+        });
+
+        $('#tab2').CFW_Tab('show');
+        assert.strictEqual($('#slideNext').is(':disabled'), false);
+    });
+
+    QUnit.test('should allow looping when loop=true', function(assert) {
+        assert.expect(3);
+
+        var $slideshow = $('<div class="nav">' +
+            '<button id="slidePrev" type="button" data-cfw-slideshow-nav="prev">Previous</button>' +
+            '<button id="tab0" type="button" data-cfw="tab" data-cfw-tab-target="#panel0">0</button>' +
+            '<button id="tab1" type="button" data-cfw="tab" data-cfw-tab-target="#panel1">1</button>' +
+            '<button id="tab2" type="button" data-cfw="tab" data-cfw-tab-target="#panel2">2</button>' +
+            '<button id="slideNext" type="button" data-cfw-slideshow-nav="next">Next</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        $('<ul><li id="panel0"></li><li id="panel1"></li><li id="panel2"></li></ul>').appendTo('#qunit-fixture');
+
+        var $tabs = $('#qunit-fixture').find('[data-cfw="tab"]').CFW_Tab();
+        $slideshow.CFW_Slideshow({
+            loop: true
+        });
+
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+        $('#slidePrev').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab2');
+        $('#slideNext').trigger('click');
+        assert.strictEqual($tabs.filter('.active').attr('id'), 'tab0');
+    });
 });

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -111,4 +111,32 @@ $(function() {
             assert.equal(null, $().CFW_findShadowRoot($div[0]));
         }
     });
+
+    QUnit.test('CFW_isDisabled should return true if the element has disabled attribute', function(assert) {
+        assert.expect(3);
+        $('<button id="test0" disabled="disabled"></button>' +
+            '<button id="test1" type="button" disabled="true"></button>' +
+            '<button id="test2" type="button" disabled></button>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#test1')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#test2')), true);
+    });
+
+    QUnit.test('CFW_isDisabled should return true if the element has disabled="false"', function(assert) {
+        assert.expect(1);
+        $('<button id="test0" type="button" disabled="false"></button>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
+    });
+
+    QUnit.test('CFW_isDisabled should return true if the element has class "disabled', function(assert) {
+        assert.expect(1);
+        $('<a id="test0" href="#" class="disabled">test</a>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
+    });
 });

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -139,4 +139,123 @@ $(function() {
 
         assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
     });
+
+    QUnit.test('CFW_controlEnable should remove disabled class from link', function(assert) {
+        assert.expect(2);
+        $('<a id="test0" href="#" class="disabled">test</a>')
+            .appendTo($('#qunit-fixture'));
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), true);
+        $.CFW_controlEnable(document.querySelector('#test0'));
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), false);
+    });
+
+    QUnit.test('CFW_controlEnable should remove tabindex attribute from link', function(assert) {
+        assert.expect(2);
+        $('<a id="test0" href="#" class="disabled" tabindex="-1">test</a>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual(document.querySelector('#test0').getAttribute('tabindex'), '-1');
+        $.CFW_controlEnable(document.querySelector('#test0'));
+        assert.strictEqual(document.querySelector('#test0').hasAttribute('tabindex'), false);
+    });
+
+    QUnit.test('CFW_controlEnable should remove disabled attribute from controls', function(assert) {
+        assert.expect(7);
+        $('<button id="test0" type="button" disabled>test</button>' +
+           '<fieldset id="test1" disabled></fieldset>' +
+           '<input id="test2" disabled></input>' +
+           '<optgroup id="test3" disabled></optgroup>' +
+           '<option id="test4" disabled></option>' +
+           '<select id="test5" disabled></select>' +
+           '<textarea id="test6" disabled></textarea>')
+            .appendTo($('#qunit-fixture'));
+
+        $.CFW_controlEnable(document.querySelector('#test0'));
+        $.CFW_controlEnable(document.querySelector('#test1'));
+        $.CFW_controlEnable(document.querySelector('#test2'));
+        $.CFW_controlEnable(document.querySelector('#test3'));
+        $.CFW_controlEnable(document.querySelector('#test4'));
+        $.CFW_controlEnable(document.querySelector('#test5'));
+        $.CFW_controlEnable(document.querySelector('#test6'));
+
+        assert.strictEqual(document.querySelector('#test0').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test1').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test2').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test3').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test4').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test5').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test6').hasAttribute('disabled'), false);
+    });
+
+    QUnit.test('CFW_controlEnable should remove disabled class from label wrapping a control', function(assert) {
+        assert.expect(2);
+        $('<label id="test0" class="disabled">' +
+            '<button id="test1" type="button" disabled>test</button>' +
+            '</label>')
+            .appendTo($('#qunit-fixture'));
+
+        $.CFW_controlEnable(document.querySelector('#test1'));
+
+        assert.strictEqual(document.querySelector('#test1').hasAttribute('disabled'), false);
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), false);
+    });
+
+    QUnit.test('CFW_controlDisable should add disabled class to link', function(assert) {
+        assert.expect(2);
+        $('<a id="test0" href="#">test</a>')
+            .appendTo($('#qunit-fixture'));
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), false);
+        $.CFW_controlDisable(document.querySelector('#test0'));
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), true);
+    });
+
+    QUnit.test('CFW_controlDisable should add tabindex=-1 to link', function(assert) {
+        assert.expect(2);
+        $('<a id="test0" href="#">test</a>')
+            .appendTo($('#qunit-fixture'));
+        assert.strictEqual(document.querySelector('#test0').hasAttribute('tabindex'), false);
+        $.CFW_controlDisable(document.querySelector('#test0'));
+        assert.strictEqual(document.querySelector('#test0').getAttribute('tabindex'), '-1');
+    });
+
+    QUnit.test('CFW_controlDisable should add disabled attribute to controls', function(assert) {
+        assert.expect(7);
+        $('<button id="test0" type="button">test</button>' +
+           '<fieldset id="test1"></fieldset>' +
+           '<input id="test2"></input>' +
+           '<optgroup id="test3"></optgroup>' +
+           '<option id="test4"></option>' +
+           '<select id="test5"></select>' +
+           '<textarea id="test6"></textarea>')
+            .appendTo($('#qunit-fixture'));
+
+        $.CFW_controlDisable(document.querySelector('#test0'));
+        $.CFW_controlDisable(document.querySelector('#test1'));
+        $.CFW_controlDisable(document.querySelector('#test2'));
+        $.CFW_controlDisable(document.querySelector('#test3'));
+        $.CFW_controlDisable(document.querySelector('#test4'));
+        $.CFW_controlDisable(document.querySelector('#test5'));
+        $.CFW_controlDisable(document.querySelector('#test6'));
+
+        assert.strictEqual(document.querySelector('#test0').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test1').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test2').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test3').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test4').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test5').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test6').hasAttribute('disabled'), true);
+    });
+
+    QUnit.test('CFW_controlDisable should add disabled class to label wrapping a control', function(assert) {
+        assert.expect(2);
+        $('<label id="test0">' +
+            '<button id="test1" type="button">test</button>' +
+            '</label>')
+            .appendTo($('#qunit-fixture'));
+
+        $.CFW_controlDisable(document.querySelector('#test1'));
+
+        assert.strictEqual(document.querySelector('#test1').hasAttribute('disabled'), true);
+        assert.strictEqual(document.querySelector('#test0').classList.contains('disabled'), true);
+    });
 });


### PR DESCRIPTION
- Slidehow:
  - Handle use of buttons for controls
  - Revised keyboard handling and will now be available on all related slideshow controls, such as prev/next controls
- Utilities:
  - Make common CFW_isDisabled()
  - Move controlEnable()/controlDisable() functions from player to common utils
  - CFW_controlDisable() 
    - removes `tabindex` and `disabled` attributes
    - removes `.disabled` class from element and closest ancestor `label`
  - CFW_controlEnable
    - handles `disabled` attribute only for valid elements - `button`, `fieldset`, `input`, `optgroup`, `option`, `select`, `textarea`.
    -  will add `.disabled` class and `tabindex=-1` to elements were `disabled` attribute does not apply.
    - will add `.disabled` class to closest ancestor `label` element.
- Unit tests:
  - Finally added some for slideshow
  - Add ones for new common utils
  - Sneaking in some alert related ones
- Many doc updates for tabs and slideshow