### PR TITLE
Lists: Resolve multiple issues with borders

### DIFF
--- a/scss/component/_list.scss
+++ b/scss/component/_list.scss
@@ -7,6 +7,7 @@
         flex-direction: column;
         min-width: 0;
         margin-bottom: $list-margin-bottom;
+        border-color: $list-border-color;
         @include list-unstyled();
 
         .list {
@@ -86,12 +87,8 @@
 
     // Lists with borders
     %list-bordered {
-        border-color: $list-border-color;
-
         > .list-item {
-            border-top-color: inherit;
             border-top-width: $list-border-width;
-            border-bottom-color: inherit;
             border-bottom-width: $list-border-width;
         }
 
@@ -141,17 +138,17 @@
     // first and last children.
     @if $enable-list-group {
         .list-group {
+            @include border-radius($list-group-border-radius);
+
             > .list-item {
-                border-right-color: inherit;
                 border-right-width: $list-border-width;
-                border-left-color: inherit;
                 border-left-width: $list-border-width;
 
                 &:first-child {
-                    @include border-top-radius($list-group-border-radius);
+                    @include border-top-radius(inherit);
                 }
                 &:last-child {
-                    @include border-bottom-radius($list-group-border-radius);
+                    @include border-bottom-radius(inherit);
                 }
             }
         }
@@ -192,7 +189,7 @@
 
             > .list-item {
                 &:not(:last-child) {
-                    margin-right: $list-horizontal-padding;
+                    padding-right: $list-horizontal-padding;
                 }
             }
 
@@ -232,21 +229,20 @@
                 > .list-item {
                     padding-right: $list-horizontal-padding;
                     padding-left: $list-horizontal-padding;
-                    margin: 0 0 0 -#{$list-border-width};
+                    margin-top: 0;
+                    margin-left: -$list-border-width;
                     border-top-width: 0;
-                    border-right-color: inherit;
                     border-right-width: $list-border-width;
                     border-bottom-width: 0;
-                    border-left-color: inherit;
                     border-left-width: $list-border-width;
                 }
 
                 > .list-item + .list-item {
                     margin-top: 0;
-                    border-left-width: 0;
 
                     &.active {
                         margin-left: -$list-border-width;
+                        border-top-width: 0;
                         border-left-width: $list-border-width;
                     }
                 }
@@ -283,18 +279,19 @@
                     > .list-item {
                         padding-right: $list-horizontal-padding;
                         padding-left: $list-horizontal-padding;
-                        margin: 0 0 0 -#{$list-border-width};
+                        margin-top: 0;
+                        margin-left: -$list-border-width;
                         border-top-width: $list-border-width;
 
                         &:first-child {
                             margin-left: 0;
                             @include border-top-end-radius(0);
-                            @include border-start-radius($list-group-border-radius);
+                            @include border-start-radius(inherit);
                         }
 
                         &:last-child {
                             @include border-bottom-start-radius(0);
-                            @include border-end-radius($list-group-border-radius);
+                            @include border-end-radius(inherit);
                         }
                     }
 
@@ -366,7 +363,7 @@
         // Override `<button>` background and border.
         background-color: $list-item-bg;
         border: 0 solid;
-        //border-color: inherit;
+        border-color: inherit;
 
         //&::before {
         //    content: none;
@@ -401,17 +398,21 @@
         // Organizationally, this must come after the `:hover` states.
         @if (type-of($list-themes) == "map" and length($list-themes) != 0) {
             @each $theme, $colors in $list-themes {
-                $list-bg:           map-get($colors, "bg");
-                $list-color:        map-get($colors, "color");
-                $list-border:       map-get($colors, "border-color");
-                $list-hover-bg:     map-get($colors, "hover-bg");
-                $list-hover-color:  map-get($colors, "hover-color");
-                $list-hover-border: map-get($colors, "hover-border-color");
+                $list-bg:            map-get($colors, "bg");
+                $list-color:         map-get($colors, "color");
+                $list-border:        null;
+                $list-hover-bg:      map-get($colors, "hover-bg");
+                $list-hover-color:   map-get($colors, "hover-color");
+                $list-hover-border:  null;
+                $list-active-bg:     map-get($colors, "hover-bg");
+                $list-active-color:  map-get($colors, "hover-color");
+                $list-active-border: map-get($colors, "hover-border-color");
 
-                $list-color:       color-if-contrast($list-color, $list-bg);
-                $list-hover-color: color-if-contrast($list-hover-color, $list-hover-bg);
+                $list-color:        color-if-contrast($list-color, $list-bg);
+                $list-hover-color:  color-if-contrast($list-hover-color, $list-hover-bg);
+                $list-active-color: color-if-contrast($list-active-color, $list-active-bg);
 
-                @include list-item-variant(#{$theme}, $list-bg, $list-color, $list-border, $list-hover-bg, $list-hover-color, $list-hover-border);
+                @include list-item-variant(#{$theme}, $list-bg, $list-color, $list-border, $list-hover-bg, $list-hover-color, $list-hover-border, $list-active-bg, $list-active-color, $list-active-border);
             }
         }
     }

--- a/scss/mixins/_lists.scss
+++ b/scss/mixins/_lists.scss
@@ -7,7 +7,7 @@
 }
 
 // List context color
-@mixin list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border) {
+@mixin list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border, $active-bg: $hover-bg, $active-color: $hover-color, $active-border: $hover-border) {
     @if $enable-list-item-action {
         .list-item-action.list-item-#{$state} {
             @include hover-focus() {
@@ -24,9 +24,9 @@
         border-color: $border;
 
         &.active {
-            color: $hover-color;
-            background-color: $hover-bg;
-            border-color: $hover-border;
+            color: $active-color;
+            background-color: $active-bg;
+            border-color: $active-border;
         }
     }
 }

--- a/site/4.1/components/lists.md
+++ b/site/4.1/components/lists.md
@@ -632,7 +632,7 @@ Contextual classes also work with `.list-item-action`. Note the addition of the 
   <a href="#" class="list-item list-item-action list-item-info">Info list item</a>
   <a href="#" class="list-item list-item-action list-item-warning">Warning list item</a>
   <a href="#" class="list-item list-item-action list-item-danger">Danger list item</a>
-  <a href="#" class="list-item list-item-action list-item-list">Light list item</a>
+  <a href="#" class="list-item list-item-action list-item-light">Light list item</a>
   <a href="#" class="list-item list-item-action list-item-dark">Dark list item</a>
 </div>
 {% endcapture %}
@@ -1007,7 +1007,7 @@ List with no left padding or list item markers.
 Create a contextual color variant for a list item.
 
 {% capture highlight %}
-@include list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border);
+@include list-item-variant($state, $bg, $color, $border, $hover-bg, $hover-color, $hover-border, $active-bg, $active-color, $active-border);
 {% endcapture %}
 {% renderHighlight highlight, "sass" %}
 
@@ -1067,7 +1067,7 @@ Create a contextual color variant for a list item.
         <td>string</td>
         <td>none</td>
         <td>
-          Text color for a list item in active, hover, and focus states..
+          Text color for a list item in active, hover, and focus states.
         </td>
       </tr>
       <tr>
@@ -1075,7 +1075,31 @@ Create a contextual color variant for a list item.
         <td>string</td>
         <td>none</td>
         <td>
-          Border color for a list item in active, hover, and focus states..
+          Border color for a list item in active, hover, and focus states.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$active-bg</code></td>
+        <td>string</td>
+        <td><code>$hover-bg</code></td>
+        <td>
+          Background color for a list item in active state.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$active-color</code></td>
+        <td>string</td>
+        <td><code>$hover-color</code></td>
+        <td>
+          Text color for a list item in active states.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$active-border</code></td>
+        <td>string</td>
+        <td><code>$hover-border</code></td>
+        <td>
+          Border color for a list item in active state.
         </td>
       </tr>
     </tbody>

--- a/test/visual/list.html
+++ b/test/visual/list.html
@@ -525,6 +525,12 @@
 </div>
 
 <h2>Color Variants</h2>
+<ul class="list list-spaced list-group bg-dark text-light border-info">
+    <li class="list-item">List item</li>
+    <li class="list-item">List item</li>
+    <li class="list-item">List item</li>
+</ul>
+
 <ul class="list list-spaced list-divided bg-dark text-light border-secondary">
     <li class="list-item">List item</li>
     <li class="list-item">List item</li>


### PR DESCRIPTION
Fixes a bunch of issues with list borders:
- Inherit border-color from the parent list.
- Contextual list items shouldn't override parent list border color.
- Extended `list-item-variant()` mixin to add active state arguments, but backwards-compatible since they inherit from hover state arguments.
- Normalized to use padding over margin in base horizontal mode.
- List group variant now has border radius on parent list to fix background bleed.
- Adjust borders in horizontal mode to help with active items.