### PR TITLE
Tooltip/Popover: Improve handling empty content

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -42,6 +42,10 @@
         return $tip;
     };
 
+    CFW_Widget_Popover.prototype._hasContent = function() {
+        return Boolean(this.getTitle() || this.getContent());
+    };
+
     CFW_Widget_Popover.prototype.setContent = function() {
         var $tip = this.$target;
         var $title = $tip.find('.popover-header');
@@ -65,6 +69,9 @@
 
             if (!title && $title) {
                 $title.remove();
+            }
+            if (!content && $content) {
+                $content.remove();
             }
         }
 

--- a/js/popover.js
+++ b/js/popover.js
@@ -67,12 +67,10 @@
                 $content.text(content);
             }
 
-            if (!title && $title) {
-                $title.remove();
-            }
-            if (!content && $content) {
-                $content.remove();
-            }
+            // Header gets hidden by :empty CSS rule
+            // if (!title && $title) {
+            //     $title.remove();
+            // }
         }
 
         // Use '.popover-header' for labelledby

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -153,6 +153,10 @@
             return title;
         },
 
+        _hasContent: function() {
+            return Boolean(this.getTitle());
+        },
+
         setContent : function() {
             var $tip = this.$target;
             var $inner = $tip.find('.tooltip-body');
@@ -321,6 +325,10 @@
         show : function() {
             clearTimeout(this.delayTimer);
             var $selfRef = this;
+
+            if (!this._hasContent() && !this.$target) {
+                return;
+            }
 
             // Bail if transition in progress or already shown
             if (this.inTransition) { return; }

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -173,20 +173,24 @@
         .popover-body {
             padding: $popover-body-padding-y $popover-body-padding-x;
             color: $popover-body-color;
+
+            &:empty {
+                display: none;
+            }
         }
 
         @if $enable-popover-close {
-            .close + .popover-body {
+            .close ~ .popover-header:empty ~ .popover-body {
                 padding-right: add($close-font-size, $popover-control-padding-x);
             }
         }
         @if $enable-popover-drag {
-            .drag + .popover-body {
+            .drag ~ .popover-header:empty ~ .popover-body {
                 padding-right: add($close-font-size, $popover-control-padding-x);
             }
         }
         @if $enable-popover-close and $enable-popover-drag {
-            .close ~ .drag + .popover-body {
+            .close ~ .drag ~ .popover-header:empty ~ .popover-body {
                 padding-right: add($close-font-size * 2, $popover-control-padding-x * 2);
             }
         }

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -174,6 +174,23 @@
             padding: $popover-body-padding-y $popover-body-padding-x;
             color: $popover-body-color;
         }
+
+        @if $enable-popover-close {
+            .close + .popover-body {
+                padding-right: add($close-font-size, $popover-control-padding-x);
+            }
+        }
+        @if $enable-popover-drag {
+            .drag + .popover-body {
+                padding-right: add($close-font-size, $popover-control-padding-x);
+            }
+        }
+        @if $enable-popover-close and $enable-popover-drag {
+            .close ~ .drag + .popover-body {
+                padding-right: add($close-font-size * 2, $popover-control-padding-x * 2);
+            }
+        }
+
     }
 
     // Control buttons

--- a/scss/component/_tooltip.scss
+++ b/scss/component/_tooltip.scss
@@ -141,5 +141,11 @@
         text-align: center;
         background-color: $tooltip-bg;
         @include border-radius($tooltip-border-radius);
+
+        @if $enable-tooltip-close {
+            .close + & {
+                padding-right: add(1.25rem, $tooltip-close-padding-x);
+            }
+        }
     }
 }

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -857,7 +857,13 @@ $(window).ready(function() {
             <h2 id="popover">Popover:</h2>
 
             <div class="mb-1">
-                <div class="card" style="width: 25%;" id="card-popover"></div>
+                <button type="button" class="btn btn-secondary" title="popover title" data-cfw="popover">Title only</button>
+                <button type="button" class="btn btn-secondary" data-cfw-popover-content="popover content" data-cfw="popover">Content only</button>
+                <button type="button" class="btn btn-secondary" data-cfw-popover-content="popover content" data-cfw="popover" data-cfw-popover-drag="true">Content only w/ drag</button>
+            </div>
+
+            <div class="mb-1">
+                <div class="card" style="width: 25%;" id="card-popover"><div class="card-body"></div></div>
                 <button type="button" class="btn btn-info" title="Yay, you clicked me!" data-cfw="popover" data-cfw-popover-content="blah" data-cfw-popover-container="#card-popover">Popover Custom Placement</button>
             </div>
 

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -64,11 +64,11 @@ $(function() {
         $popover.CFW_Popover('show');
 
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
-        assert.strictEqual($('.popover-header').length, 0, 'header was removed');
+        assert.strictEqual($('.popover-header:empty').length, 1, 'header is empty');
         assert.strictEqual($('.popover-body').text(), 'popover content', 'content correctly inserted');
     });
 
-    QUnit.test('should create popover with no body if content option not defined', function(assert) {
+    QUnit.test('should create popover with empty body if content option not defined', function(assert) {
         assert.expect(3);
         var $popover = $('<a href="#" title="popover title">Popover</a>')
             .appendTo('#qunit-fixture')
@@ -78,7 +78,7 @@ $(function() {
 
         assert.notEqual($('.popover').length, 0, 'popover was inserted');
         assert.strictEqual($('.popover-header').text(), 'popover title', 'title correctly inserted');
-        assert.strictEqual($('.popover-body').length, 0, 'body was removed');
+        assert.strictEqual($('.popover-body:empty').length, 1, 'body is empty');
     });
 
     QUnit.test('should get title and content from options', function(assert) {

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -68,6 +68,19 @@ $(function() {
         assert.strictEqual($('.popover-body').text(), 'popover content', 'content correctly inserted');
     });
 
+    QUnit.test('should create popover with no body if content option not defined', function(assert) {
+        assert.expect(3);
+        var $popover = $('<a href="#" title="popover title">Popover</a>')
+            .appendTo('#qunit-fixture')
+            .CFW_Popover();
+
+        $popover.CFW_Popover('show');
+
+        assert.notEqual($('.popover').length, 0, 'popover was inserted');
+        assert.strictEqual($('.popover-header').text(), 'popover title', 'title correctly inserted');
+        assert.strictEqual($('.popover-body').length, 0, 'body was removed');
+    });
+
     QUnit.test('should get title and content from options', function(assert) {
         assert.expect(4);
         var $popover = $('<a href="#">Popover</a>')
@@ -149,6 +162,19 @@ $(function() {
 
         $popover.CFW_Popover('hide');
         assert.strictEqual($('.popover').length, 0, 'popover was removed');
+    });
+
+    QUnit.test('should not show dynamic popover without title or content provided', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $popover = $('<a href="#" title="" data-cfw-popover-content="">Popover</a>')
+            .appendTo('#qunit-fixture');
+        $popover.CFW_Popover('show');
+
+        setTimeout(function() {
+            assert.strictEqual($('.popover').length, 0, 'popover not created');
+            done();
+        });
     });
 
     QUnit.test('should respect custom template', function(assert) {

--- a/test/js/unit/tooltip.js
+++ b/test/js/unit/tooltip.js
@@ -622,6 +622,19 @@ $(function() {
         assert.strictEqual($('.tooltip').length, 0, 'tooltip removed from dom');
     });
 
+    QUnit.test('should not show dynamic tooltip without title provided', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $tooltip = $('<a href="#" title="">Popover</a>')
+            .appendTo('#qunit-fixture');
+        $tooltip.CFW_Tooltip('show');
+
+        setTimeout(function() {
+            assert.strictEqual($('.tooltip').length, 0, 'tooltip not created');
+            done();
+        });
+    });
+
     QUnit.test('should position tip on top if viewport has enough space and placement is "auto top"', function(assert) {
         assert.expect(2);
         var styles = '<style>' +


### PR DESCRIPTION
- Don't display dynamic widget if all content pieces are empty.
- ~~Remove container where content has not been provided.~~
- Add padding to `.popover-body` to help with text wrapping due to `float` on `.close` and `.drag` controls - when the header/title is empty.