### PR TITLE
Modal: Remove outdated `adjustBackdrop()` method

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -352,14 +352,7 @@
 
         // these following methods are used to handle overflowing modals
         handleUpdate : function() {
-            if (this.settings.backdrop) { this.adjustBackdrop(); }
             this.adjustDialog();
-        },
-
-        adjustBackdrop : function() {
-            this.$backdrop
-                .css('height', 0)
-                .css('height', this.$target[0].scrollHeight);
         },
 
         adjustDialog : function() {


### PR DESCRIPTION
Not needed since backdrop CSS handles this without need for dynamic sizing