### PR TITLE
Extend and update common JS utility routines

### DIFF
--- a/js/affix.js
+++ b/js/affix.js
@@ -88,7 +88,7 @@
         },
 
         checkPosition : function() {
-            if (!this.$element.is(':visible')) { return; }
+            if (!$.CFW_isVisible(this.$element[0])) { return; }
 
             var height       = this.$element.height();
             var offsetTop    = this.settings.top;

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -253,7 +253,10 @@
             }
 
             var $items = $menu.children('li').find('a, .dropdown-item, button, input, textarea, select');
-            $items = $items.filter(':not(.disabled, :disabled):not(:has(input)):not(:has(textarea):not(:has(select)):visible');
+            $items = $items.filter(':not(:has(input)):not(:has(textarea):not(:has(select))');
+            $items = $items.filter(function() {
+                return $.CFW_isFocusable(this);
+            });
             return $items;
         },
 

--- a/js/lazy.js
+++ b/js/lazy.js
@@ -28,7 +28,7 @@
         animate   : false,      // Should the image fade in
         threshold : 0,          // Amount of pixels below viewport to triger show
         container : window,     // Where to watch for events
-        invisible : false,      // Load sources that are not :visible
+        invisible : false,      // Load sources that are not visible
         placeholder: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
     };
 
@@ -74,14 +74,8 @@
             if (checkInitViewport && this.inViewport()) { this.show(); }
         },
 
-        isVisible : function() {
-            // Normalize on using the newer jQuery 3 visibility method
-            var elem = this.$element[0];
-            return Boolean(elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length);
-        },
-
         inViewport : function() {
-            if (!this.settings.invisible && !this.isVisible) {
+            if (!this.settings.invisible && !$.CFW_isVisible(this.$element)) {
                 return false;
             }
             return !this.belowFold() && !this.afterRight() && !this.aboveTop() && !this.beforeLeft();

--- a/js/player.js
+++ b/js/player.js
@@ -1043,7 +1043,7 @@
                         $(this).prop('checked', $selfRef.settings.transcriptScroll);
                     });
                     this.$player.on('click', '[data-cfw-player-script-describe]', function(e) {
-                        if (!$.CFW_isDisabled($(e.target))) {
+                        if (!$.CFW_isDisabled(e.target)) {
                             $selfRef.settings.transcriptDescribe = !$selfRef.settings.transcriptDescribe;
                             $(this).prop('checked', $selfRef.settings.transcriptDescribe);
                             $selfRef.scriptLoad();
@@ -1424,7 +1424,7 @@
                     $selfRef.textDescriptionSet($selfRef.textDescribeCurrent);
                 });
                 this.$player.on('click', '[data-cfw-player-text-describe-visible]', function(e) {
-                    if (!$.CFW_isDisabled($(e.target))) {
+                    if (!$.CFW_isDisabled(e.target)) {
                         $selfRef.settings.textDescribeVisible = !$selfRef.settings.textDescribeVisible;
                         $(this).prop('checked', $selfRef.settings.textDescribeVisible);
                         $selfRef.textDescriptionSet($selfRef.textDescribeCurrent);

--- a/js/slideshow.js
+++ b/js/slideshow.js
@@ -106,7 +106,11 @@
         },
 
         _getTabs : function() {
-            return this.$element.find('[role="tab"]:visible').not('.disabled, :disabled');
+            var $items = this.$element.find('[role="tab"]');
+            $items = $items.filter(function() {
+                return !$.CFW_isDisabled(this) && $.CFW_isVisible(this);
+            });
+            return $items;
         },
 
         _currIndex : function($tabs) {

--- a/js/tab.js
+++ b/js/tab.js
@@ -179,7 +179,10 @@
 
             var $node = $(node);
             var $list = $node.closest('[role="tablist"]');
-            var $items = $list.find('[role="tab"]:visible').not('.disabled').not(':disabled');
+            var $items = $list.find('[role="tab"]');
+            $items = $items.filter(function() {
+                return !$.CFW_isDisabled(this) && $.CFW_isVisible(this);
+            });
             var index = $items.index($items.filter('[aria-selected="true"]'));
 
             var doIncrement = e.which === KEYCODE_RIGHT || e.which === KEYCODE_DOWN;

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -935,63 +935,14 @@
             $.CFW_getNextActiveElement(selectables.toArray(), current, true, true).focus();
         },
 
-        /*
-         * jQuery UI Focusable 1.12.1
-         * http://jqueryui.com
-         *
-         * Copyright jQuery Foundation and other contributors
-         * Released under the MIT license.
-         * http://jquery.org/license
-         */
-        _focusable : function(element, isTabIndexNotNaN) {
-            var map;
-            var mapName;
-            var $img;
-            var focusableIfVisible;
-            var fieldset;
-            var nodeName = element.nodeName.toLowerCase();
-
-            if (nodeName === 'area') {
-                map = element.parentNode;
-                mapName = map.name;
-                if (!element.href || !mapName || map.nodeName.toLowerCase() !== 'map') {
-                    return false;
-                }
-                $img = $('img[usemap="#' + mapName + '"]');
-                return $img.length > 0 && $img.is(':visible');
-            }
-
-            if (/^(input|select|textarea|button|object)$/.test(nodeName)) {
-                focusableIfVisible = !element.disabled;
-
-                if (focusableIfVisible) {
-                    // Form controls within a disabled fieldset are disabled.
-                    // However, controls within the fieldset's legend do not get disabled.
-                    // Since controls generally aren't placed inside legends, we skip
-                    // this portion of the check.
-                    fieldset = $(element).closest('fieldset')[0];
-                    if (fieldset) {
-                        focusableIfVisible = !fieldset.disabled;
-                    }
-                }
-            } else if (nodeName === 'a') {
-                focusableIfVisible = element.href || isTabIndexNotNaN;
-            } else {
-                focusableIfVisible = isTabIndexNotNaN;
-            }
-
-            return focusableIfVisible && $(element).is(':visible');
-        },
-
         _tabItems : function($node) {
             var $selfRef = this;
             if (typeof $node === 'undefined') { $node = $(document); }
-            var items = $node.find('*').filter(function() {
-                var tabIndex = $(this).attr('tabindex');
-                var isTabIndexNaN = isNaN(tabIndex);
+            var items = $.CFW_getFocusable($node[0]);
+            items = items.filter(function() {
                 if ($selfRef.$focusFirst !== null && this === $selfRef.$focusFirst[0]) { return false; }
                 if ($selfRef.$focusLast !== null && this === $selfRef.$focusLast[0]) { return false; }
-                return (isTabIndexNaN || tabIndex >= 0) && $selfRef._focusable(this, !isTabIndexNaN);
+                return true;
             });
             return items;
         }

--- a/js/util.js
+++ b/js/util.js
@@ -464,10 +464,13 @@
                 return true;
             }
         }
+        if (element.classList.contains('disabled')) {
+            return true;
+        }
         if (typeof element.disabled === 'boolean') {
             return element.disabled;
         }
-        return element.classList.contains('disabled') || element.hasAttribute('disabled');
+        return element.hasAttribute('disabled');
     };
 
     $.CFW_isVisible = function(element) {
@@ -488,8 +491,11 @@
         if (element instanceof jQuery) {
             element = element[0];
         }
-        var tabindex = element.getAttribute('tabindex') || '';
-        if (tabindex !== '') {
+        var tabindex = null;
+        if (element.hasAttribute('tabindex')) {
+            tabindex = element.getAttribute('tabindex');
+        }
+        if (tabindex !== null) {
             if (isNaN(tabindex) || tabindex < 0) {
                 return false;
             }
@@ -516,9 +522,9 @@
         var items = element.querySelectorAll(allowed);
         var focusables = [];
 
-        for (var item of items) {
-            if ($.CFW_isFocusable(item)) {
-                focusables.push(item);
+        for (var i = 0; i < items.length; i++) {
+            if ($.CFW_isFocusable(items[i])) {
+                focusables.push(items[i]);
             }
         }
 

--- a/js/util.js
+++ b/js/util.js
@@ -423,6 +423,9 @@
     };
 
     $.CFW_reflow = function(element) {
+        if (element instanceof jQuery) {
+            element = element[0];
+        }
         return element.offsetHeight;
     };
 
@@ -449,7 +452,98 @@
     };
 
     $.CFW_isDisabled = function(element) {
-        return $(element).is('.disabled, :disabled');
+        if (element instanceof jQuery) {
+            element = element[0];
+        }
+        if (!element || element.nodeType !== Node.ELEMENT_NODE) {
+            return true;
+        }
+        if (/^(button|input|select|textarea)$/i.test(element.nodeName)) {
+            var fieldset = $(element).closest('fieldset')[0];
+            if (fieldset && fieldset.disabled) {
+                return true;
+            }
+        }
+        if (typeof element.disabled === 'boolean') {
+            return element.disabled;
+        }
+        return element.classList.contains('disabled') || element.hasAttribute('disabled');
+    };
+
+    $.CFW_isVisible = function(element) {
+        if (element instanceof jQuery) {
+            element = element[0];
+        }
+        if (!$.CFW_isElement(element) || element.getClientRects().length === 0) {
+            return false;
+        }
+        return window.getComputedStyle(element).getPropertyValue('visibility') === 'visible';
+    };
+
+    $.CFW_isFocusable = function(element) {
+        // This is only a cursory check - mostly to be used with `$.CFW_getFocusable()`
+        // Many elements will pass this test if they do not explicitly fail
+        // the conditions below.  For example, passing `<div></div>` through
+        // this method will return true, but the `<div>` is not actually focusable.
+        if (element instanceof jQuery) {
+            element = element[0];
+        }
+        var tabindex = element.getAttribute('tabindex') || '';
+        if (tabindex !== '') {
+            if (isNaN(tabindex) || tabindex < 0) {
+                return false;
+            }
+        }
+        return !$.CFW_isDisabled(element) && $.CFW_isVisible(element);
+    };
+
+    $.CFW_getFocusable = function(element, allowed) {
+        if (typeof allowed === 'undefined') {
+            allowed = [
+                'a',
+                'button',
+                'details',
+                'input',
+                'select',
+                'textarea',
+                '[tabindex]',
+                '[contenteditable="true"]'
+            ].map(function(selector) {
+                return selector + ':not([tabindex^="-"])';
+            }).join(', ');
+        }
+
+        var items = element.querySelectorAll(allowed);
+        var focusables = [];
+
+        for (var item of items) {
+            if ($.CFW_isFocusable(item)) {
+                focusables.push(item);
+            }
+        }
+
+        return focusables;
+    };
+
+    $.CFW_isElement = function(object) {
+        if (!object || typeof object !== 'object') {
+            return false;
+        }
+        if (typeof object.jquery !== 'undefined') {
+            object = object[0];
+        }
+        return typeof object.nodeType !== 'undefined';
+    };
+
+    $.CFW_getElement = function(object) {
+        // Check for jQuery object or a node element
+        if ($.CFW_isElement(object)) {
+            return object.jquery ? object[0] : object;
+        }
+        if (typeof object === 'string' && object.length > 0) {
+            return document.querySelector(object);
+        }
+        return null;
     };
 
     $.CFW_getNextActiveElement = function(list, activeElement, doIncrement, allowLoop, allowStartEnd) {

--- a/js/util.js
+++ b/js/util.js
@@ -480,7 +480,30 @@
         if (!$.CFW_isElement(element) || element.getClientRects().length === 0) {
             return false;
         }
-        return window.getComputedStyle(element).getPropertyValue('visibility') === 'visible';
+        var elementIsVisible = window.getComputedStyle(element).getPropertyValue('visibility') === 'visible';
+
+        // Handle 'details' elements, as content may incorrectly appear visible when closed
+        var detailsClosed = $(element).closest('details:not([open])').get(0);
+        if (typeof detailsClosed !== 'undefined') {
+            detailsClosed = null;
+        }
+        if (!detailsClosed) {
+            return elementIsVisible;
+        }
+        if (detailsClosed !== element) {
+            var summary = $(detailsClosed).closest('summary').get(0);
+            if (typeof summary !== 'undefined') {
+                summary = null;
+            }
+            if (summary && summary.parentNode !== detailsClosed) {
+                return false;
+            }
+            if (summary === null) {
+                return false;
+            }
+        }
+
+        return elementIsVisible;
     };
 
     $.CFW_isFocusable = function(element) {

--- a/js/util.js
+++ b/js/util.js
@@ -482,17 +482,17 @@
         }
         var elementIsVisible = window.getComputedStyle(element).getPropertyValue('visibility') === 'visible';
 
-        // Handle 'details' elements, as content may incorrectly appear visible when closed
+        // Handle 'details' elements, as content may falsie appear visible when closed
         var detailsClosed = $(element).closest('details:not([open])').get(0);
-        if (typeof detailsClosed !== 'undefined') {
+        if (typeof detailsClosed === 'undefined') {
             detailsClosed = null;
         }
         if (!detailsClosed) {
             return elementIsVisible;
         }
         if (detailsClosed !== element) {
-            var summary = $(detailsClosed).closest('summary').get(0);
-            if (typeof summary !== 'undefined') {
+            var summary = $(element).closest('summary').get(0);
+            if (typeof summary === 'undefined') {
                 summary = null;
             }
             if (summary && summary.parentNode !== detailsClosed) {

--- a/js/util/backdrop.js
+++ b/js/util/backdrop.js
@@ -27,7 +27,7 @@
     CFW_Util_Backdrop.prototype = {
         _init : function() {
             // Update rootElement in case of DOM change
-            this.settings.rootElement = this._getElement(this.settings.rootElement);
+            this.settings.rootElement = $.CFW_getElement(this.settings.rootElement);
         },
 
         show : function(callback) {
@@ -78,27 +78,6 @@
             $(this.element).off('mousedown.cfw.backdrop');
             $(this.element).remove();
             this.isAppended = false;
-        },
-
-        _isElement : function(object) {
-            if (!object || typeof object !== 'object') {
-                return false;
-            }
-            if (typeof object.jquery !== 'undefined') {
-                object = object[0];
-            }
-            return typeof object.nodeType !== 'undefined';
-        },
-
-        _getElement : function(object) {
-            // Check for jQuery object or a node element
-            if (this._isElement(object)) {
-                return object.jquery ? object[0] : object;
-            }
-            if (typeof object === 'string' && object.length > 0) {
-                return document.querySelector(object);
-            }
-            return null;
         },
 
         _getBackdrop : function() {

--- a/js/util/scrollbar.js
+++ b/js/util/scrollbar.js
@@ -26,7 +26,7 @@
 
     CFW_Util_Scrollbar.prototype = {
         _init : function() {
-            this.element = this._getElement(this.settings.rootElement);
+            this.element = $.CFW_getElement(this.settings.rootElement);
         },
 
         getContainerWidth : function() {
@@ -155,27 +155,6 @@
 
         _isSticky : function(node) {
             return Boolean(window.getComputedStyle(node).position === 'sticky');
-        },
-
-        _isElement : function(object) {
-            if (!object || typeof object !== 'object') {
-                return false;
-            }
-            if (typeof object.jquery !== 'undefined') {
-                object = object[0];
-            }
-            return typeof object.nodeType !== 'undefined';
-        },
-
-        _getElement : function(object) {
-            // Check for jQuery object or a node element
-            if (this._isElement(object)) {
-                return object.jquery ? object[0] : object;
-            }
-            if (typeof object === 'string' && object.length > 0) {
-                return document.querySelector(object);
-            }
-            return null;
         },
 
         _normalizeData : function(val) {

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -148,14 +148,39 @@ $(function() {
 
         var $div = $('<div id="test"></div>').appendTo($('#qunit-fixture'));
         if (!document.documentElement.attachShadow) {
-            assert.equal(null, $().CFW_findShadowRoot($div[0]));
+            assert.equal($().CFW_findShadowRoot($div[0]), null);
         } else {
-            assert.equal(null, $().CFW_findShadowRoot($div[0]));
+            assert.equal($().CFW_findShadowRoot($div[0]), null);
         }
     });
 
-    QUnit.test('CFW_isDisabled should return true if the element has disabled attribute', function(assert) {
+    QUnit.test('CFW_isDisabled should return false if the element is not defined', function(assert) {
         assert.expect(3);
+        assert.strictEqual($.CFW_isDisabled(null), true);
+        assert.strictEqual($.CFW_isDisabled(undefined), true); // eslint-disable-line no-undefined
+        assert.strictEqual($.CFW_isDisabled(), true);
+    });
+
+    QUnit.test('CFW_isDisabled should return false if the element is not disabled', function(assert) {
+        assert.expect(6);
+        $('<fieldset id="fieldset">' +
+            '<button id="button"></button>' +
+            '<input id="input" type="text">' +
+            '<select id="select"><option>one</option></select>' +
+            '<textarea id="textarea"></textarea>' +
+            '</fieldset>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#fieldset')), false);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#button')), false);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#input')), false);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#select')), false);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#textarea')), false);
+        assert.strictEqual($.CFW_isDisabled($('#input')), false);
+    });
+
+    QUnit.test('CFW_isDisabled should return true if the element has disabled attribute', function(assert) {
+        assert.expect(4);
         $('<button id="test0" disabled="disabled"></button>' +
             '<button id="test1" type="button" disabled="true"></button>' +
             '<button id="test2" type="button" disabled></button>')
@@ -164,6 +189,7 @@ $(function() {
         assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
         assert.strictEqual($.CFW_isDisabled(document.querySelector('#test1')), true);
         assert.strictEqual($.CFW_isDisabled(document.querySelector('#test2')), true);
+        assert.strictEqual($.CFW_isDisabled($('#test0')), true);
     });
 
     QUnit.test('CFW_isDisabled should return true if the element has disabled="false"', function(assert) {
@@ -175,11 +201,255 @@ $(function() {
     });
 
     QUnit.test('CFW_isDisabled should return true if the element has class "disabled', function(assert) {
-        assert.expect(1);
+        assert.expect(2);
         $('<a id="test0" href="#" class="disabled">test</a>')
             .appendTo($('#qunit-fixture'));
 
         assert.strictEqual($.CFW_isDisabled(document.querySelector('#test0')), true);
+        assert.strictEqual($.CFW_isDisabled($('#test0')), true);
+    });
+
+    QUnit.test('CFW_isDisabled should return true for form controls within a disabled fieldset', function(assert) {
+        assert.expect(5);
+        $('<fieldset id="fieldset" disabled>' +
+            '<button id="button"></button>' +
+            '<input id="input" type="text">' +
+            '<select id="select"><option>one</option></select>' +
+            '<textarea id="textarea"></textarea>' +
+            '</fieldset>')
+            .appendTo($('#qunit-fixture'));
+
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#fieldset')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#button')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#input')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#select')), true);
+        assert.strictEqual($.CFW_isDisabled(document.querySelector('#textarea')), true);
+    });
+
+    QUnit.test('CFW_isVisible should return false if the element is not defined', function(assert) {
+        assert.expect(3);
+        assert.strictEqual($.CFW_isVisible(null), false);
+        assert.strictEqual($.CFW_isVisible(undefined), false); // eslint-disable-line no-undefined
+        assert.strictEqual($.CFW_isVisible(), false);
+    });
+
+    QUnit.test('CFW_isVisible should return false if the element is not a DOM element', function(assert) {
+        assert.expect(1);
+        assert.strictEqual($.CFW_isVisible({}), false);
+    });
+
+    QUnit.test('CFW_isVisible should return false if the element is not visible with `display: none;`', function(assert) {
+        assert.expect(2);
+        $('<div id="foo" style="display: none;"></div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), false);
+        assert.strictEqual($.CFW_isVisible($el), false);
+    });
+
+    QUnit.test('CFW_isVisible should return false if the element is not visible with `visibility: hidden;`', function(assert) {
+        assert.expect(2);
+        $('<div id="foo" style="visibility: hidden;"></div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), false);
+        assert.strictEqual($.CFW_isVisible($el), false);
+    });
+
+    QUnit.test('CFW_isVisible should return false if ancestor element is not visible with `display: none;`', function(assert) {
+        assert.expect(2);
+        $('<div style="display: none;"><div><div id="foo"></div></div></div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), false);
+        assert.strictEqual($.CFW_isVisible($el), false);
+    });
+
+    QUnit.test('CFW_isVisible should return false if ancestor element is not visible with `visibility: hidden;`', function(assert) {
+        assert.expect(2);
+        $('<div style="visibility: hidden;"><div><div id="foo"></div></div></div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), false);
+        assert.strictEqual($.CFW_isVisible($el), false);
+    });
+
+    QUnit.test('CFW_isVisible should return true if ancestor element is not visible with `visibility: hidden;`, but is reverted', function(assert) {
+        assert.expect(2);
+        $('<div style="visibility: hidden;"><div style="visibility: visible;"><div id="foo"></div></div></div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), true);
+        assert.strictEqual($.CFW_isVisible($el), true);
+    });
+
+    QUnit.test('CFW_isVisible should return true element is visible', function(assert) {
+        assert.expect(2);
+        $('<div id="foo"</div>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), true);
+        assert.strictEqual($.CFW_isVisible($el), true);
+    });
+
+    QUnit.test('CFW_isVisible should return false element is hidden, but not via display or visibility rules', function(assert) {
+        assert.expect(2);
+        $('<details><div id="foo"</div></details>').appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_isVisible(el), false);
+        assert.strictEqual($.CFW_isVisible($el), false);
+    });
+
+    QUnit.test('CFW_isFocusable should return true for elements with non-negative tabindex', function(assert) {
+        assert.expect(4);
+        $('<div tabindex>content</div>' +
+            '<div tabindex="0">content</div>' +
+            '<div tabindex="10">content</div>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex]')), true);
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="0"]')), true);
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="10"]')), true);
+        assert.strictEqual($.CFW_isFocusable($(fixtureEl).find('[tabindex="0"]')), true);
+    });
+
+    QUnit.test('CFW_isFocusable should return false for elements with negative or non-numeric tabindex', function(assert) {
+        assert.expect(3);
+        $('<div tabindex="false">content</div>' +
+            '<div tabindex="-1">content</div>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="false"]')), false);
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="-1"]')), false);
+        assert.strictEqual($.CFW_isFocusable($(fixtureEl).find('[tabindex="-1"]')), false);
+    });
+
+    QUnit.test('CFW_isFocusable should return false for disabled elements', function(assert) {
+        assert.expect(3);
+        $('<button id="foo" disabled>content</button>' +
+            '<button id="bar" disabled="true">content</button>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('#foo')), false);
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('#bar')), false);
+        assert.strictEqual($.CFW_isFocusable($(fixtureEl).find('#foo')), false);
+    });
+
+    QUnit.test('CFW_isFocusable should return false for invisible elements', function(assert) {
+        assert.expect(3);
+        $('<button id="foo" style="display: none;">content</button>' +
+            '<button id="bar" style="visibility: hidden;">content</button>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('#foo')), false);
+        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('#bar')), false);
+        assert.strictEqual($.CFW_isFocusable($(fixtureEl).find('#foo')), false);
+    });
+
+    QUnit.test('CFW_getFocusable should return a specific allowed subset of elements by default', function(assert) {
+        assert.expect(1);
+        $('<div>content</div>' +
+            '<span>content</span>' +
+            '<a>content</a>' +
+            '<button>content</button>' +
+            '<input>' +
+            '<textarea></textarea>' +
+            '<select></select>' +
+            '<details></details>' +
+            '<span tabindex="0"></span>' +
+            '<span tabindex="-1"></span>' +
+            '<div contenteditable="true"></div>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+        var expectedElements = [
+            fixtureEl.querySelector('a'),
+            fixtureEl.querySelector('button'),
+            fixtureEl.querySelector('input'),
+            fixtureEl.querySelector('textarea'),
+            fixtureEl.querySelector('select'),
+            fixtureEl.querySelector('details'),
+            fixtureEl.querySelector('[tabindex]:not([tabindex^="-"])'),
+            fixtureEl.querySelector('[contenteditable="true"]')
+        ];
+
+        assert.deepEqual($.CFW_getFocusable(fixtureEl), expectedElements);
+    });
+
+
+    QUnit.test('CFW_getFocusable should allow for custom selector', function(assert) {
+        assert.expect(1);
+        $('<div>content</div>' +
+            '<span>content</span>' +
+            '<a>content</a>' +
+            '<button>content</button>' +
+            '<input>' +
+            '<textarea></textarea>' +
+            '<select></select>' +
+            '<details></details>' +
+            '<span tabindex="0"></span>' +
+            '<span tabindex="-1"></span>' +
+            '<div contenteditable="true"></div>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+        var expectedElements = [
+            fixtureEl.querySelector('a'),
+            fixtureEl.querySelector('button')
+        ];
+        var customAllowed = 'a, button';
+
+        assert.deepEqual($.CFW_getFocusable(fixtureEl, customAllowed), expectedElements);
+    });
+
+    QUnit.test('CFW_isElement should detect if the parameter is an argument or not and return Boolean', function(assert) {
+        assert.expect(3);
+        $('<div id="foo" class="test"></div>' +
+            '<div id="bar" class="test"></div>')
+            .appendTo($('#qunit-fixture'));
+        var el = document.querySelector('#foo');
+
+        assert.strictEqual($.CFW_isElement(el), true);
+        assert.strictEqual($.CFW_isElement({}), false);
+        assert.strictEqual($.CFW_isElement(document.querySelectorAll('.test')), false);
+    });
+
+    QUnit.test('CFW_isElement should detect jQuery element', function(assert) {
+        assert.expect(1);
+        $('<div id="foo"></div>').appendTo($('#qunit-fixture'));
+        var el = $('#foo');
+
+        assert.strictEqual($.CFW_isElement(el), true);
+    });
+
+    QUnit.test('CFW_getElement should try to parse element', function(assert) {
+        assert.expect(9);
+        $('<div id="foo" class="test"></div>' +
+            '<div id="bar" class="test"></div>')
+            .appendTo($('#qunit-fixture'));
+        var fixtureEl = document.querySelector('#qunit-fixture');
+        var el = fixtureEl.querySelector('div');
+        var $el = $('#foo');
+
+        assert.strictEqual($.CFW_getElement(el), el);
+        assert.strictEqual($.CFW_getElement('#foo'), el);
+        assert.strictEqual($.CFW_getElement('#null'), null);
+        assert.strictEqual($.CFW_getElement({}), null);
+        assert.strictEqual($.CFW_getElement([]), null);
+        assert.strictEqual($.CFW_getElement(), null);
+        assert.strictEqual($.CFW_getElement(null), null);
+        assert.strictEqual($.CFW_getElement(document.querySelectorAll('.test')), null);
+        assert.strictEqual($.CFW_getElement($el), el);
     });
 
     QUnit.test('CFW_controlEnable should remove disabled class from link', function(assert) {

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -1,6 +1,8 @@
 $(function() {
     'use strict';
 
+    var isIE = /(msie|trident)/i.test(navigator.userAgent);
+
     // Global timer for tests using setTimeout
     var timer = null;
 
@@ -298,25 +300,34 @@ $(function() {
         assert.strictEqual($.CFW_isVisible($el), true);
     });
 
-    QUnit.test('CFW_isVisible should return false element is hidden, but not via display or visibility rules', function(assert) {
-        assert.expect(2);
-        $('<details><div id="foo"</div></details>').appendTo($('#qunit-fixture'));
-        var el = document.querySelector('#foo');
-        var $el = $('#foo');
+    if (!isIE) {
+        QUnit.test('CFW_isVisible should return false if element is hidden, but not via display or visibility rules', function(assert) {
+            assert.expect(2);
+            $('<details><div id="foo"></div></details>').appendTo($('#qunit-fixture'));
+            var el = document.querySelector('#foo');
+            var $el = $('#foo');
 
-        assert.strictEqual($.CFW_isVisible(el), false);
-        assert.strictEqual($.CFW_isVisible($el), false);
-    });
+            assert.strictEqual($.CFW_isVisible(el), false);
+            assert.strictEqual($.CFW_isVisible($el), false);
+        });
+    }
 
     QUnit.test('CFW_isFocusable should return true for elements with non-negative tabindex', function(assert) {
-        assert.expect(4);
+        if (isIE) {
+            assert.expect(3);
+        } else {
+            assert.expect(4);
+        }
         $('<div tabindex>content</div>' +
             '<div tabindex="0">content</div>' +
             '<div tabindex="10">content</div>')
             .appendTo($('#qunit-fixture'));
         var fixtureEl = document.querySelector('#qunit-fixture');
 
-        assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex]')), true);
+        if (!isIE) {
+            // Will fail in IE11 since default value for tabindex is "-32768"
+            assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex]')), true);
+        }
         assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="0"]')), true);
         assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="10"]')), true);
         assert.strictEqual($.CFW_isFocusable($(fixtureEl).find('[tabindex="0"]')), true);

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -301,6 +301,7 @@ $(function() {
     });
 
     if (!isIE) {
+        // IE does not support details or summary elements
         QUnit.test('CFW_isVisible should return false if element is hidden, but not via display or visibility rules', function(assert) {
             assert.expect(2);
             $('<details><div id="foo"></div></details>').appendTo($('#qunit-fixture'));
@@ -309,6 +310,36 @@ $(function() {
 
             assert.strictEqual($.CFW_isVisible(el), false);
             assert.strictEqual($.CFW_isVisible($el), false);
+        });
+
+        QUnit.test('CFW_isVisible should return true if element is a closed details container', function(assert) {
+            assert.expect(2);
+            $('<details id="foo"></details>').appendTo($('#qunit-fixture'));
+            var el = document.querySelector('#foo');
+            var $el = $('#foo');
+
+            assert.strictEqual($.CFW_isVisible(el), true);
+            assert.strictEqual($.CFW_isVisible($el), true);
+        });
+
+        QUnit.test('CFW_isVisible should return true if element is visible inside an open details container', function(assert) {
+            assert.expect(2);
+            $('<details open><div id="foo"></div></details>').appendTo($('#qunit-fixture'));
+            var el = document.querySelector('#foo');
+            var $el = $('#foo');
+
+            assert.strictEqual($.CFW_isVisible(el), true);
+            assert.strictEqual($.CFW_isVisible($el), true);
+        });
+
+        QUnit.test('CFW_isVisible should return true if element is visible summary in a closed details container', function(assert) {
+            assert.expect(2);
+            $('<details><summary id="foo"><div id="bar"></div></summary></details>').appendTo($('#qunit-fixture'));
+            var el1 = document.querySelector('#foo');
+            var el2 = document.querySelector('#bar');
+
+            assert.strictEqual($.CFW_isVisible(el1), true);
+            assert.strictEqual($.CFW_isVisible(el2), true);
         });
     }
 

--- a/test/js/unit/util.js
+++ b/test/js/unit/util.js
@@ -1,6 +1,7 @@
 $(function() {
     'use strict';
 
+    var isEdge = /edge\/\d+/i.test(navigator.userAgent);
     var isIE = /(msie|trident)/i.test(navigator.userAgent);
 
     // Global timer for tests using setTimeout
@@ -344,7 +345,7 @@ $(function() {
     }
 
     QUnit.test('CFW_isFocusable should return true for elements with non-negative tabindex', function(assert) {
-        if (isIE) {
+        if (isIE || isEdge) {
             assert.expect(3);
         } else {
             assert.expect(4);
@@ -355,8 +356,8 @@ $(function() {
             .appendTo($('#qunit-fixture'));
         var fixtureEl = document.querySelector('#qunit-fixture');
 
-        if (!isIE) {
-            // Will fail in IE11 since default value for tabindex is "-32768"
+        if (!isIE && !isEdge) {
+            // Will fail in IE11 and legacy Edge since default value for tabindex is "-32768"
             assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex]')), true);
         }
         assert.strictEqual($.CFW_isFocusable(fixtureEl.querySelector('[tabindex="0"]')), true);


### PR DESCRIPTION
- Improve and consolidate functionality for isDisabled and isVisible checks.
- Added isFocusable and getFocusable helpers.
  - isFocusable is not all inclusive, really meant for a secondary check.
- Added isElement and getElement functions to slowly ease in jQuery reduction.
- Allow some utilities to accept jQuery object or element being passed.

Yes the utility items are a mess.  ES6 would help a ton, but would require significant rework. Not to mention most likely breaking backwards compatibility.  More future plans would include ending IE11 support and remove reliance upon jQuery.
