### PR TITLE
Add offcanvas widget

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -6,11 +6,14 @@ const markdownIt = require('markdown-it');
 const markdownItAttrs = require('markdown-it-attrs');
 const markdownItAnchor = require('markdown-it-anchor');
 const nestingToc = require('eleventy-plugin-nesting-toc');
+const { EleventyRenderPlugin } = require("@11ty/eleventy");
 
 module.exports = function(eleventyConfig) {
     eleventyConfig.setDataDeepMerge(true);
 
     // Plugins
+    eleventyConfig.addPlugin(EleventyRenderPlugin);
+
     eleventyConfig.addPlugin(nestingToc,
         {
             tags: ['.cf-content > h2', '.cf-content > h3', '.cf-content > h4'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,6 +67,7 @@ module.exports = function(grunt) {
             'js/affix.js',
             'js/tooltip.js',
             'js/popover.js',
+            'js/offcanvas.js',
             'js/modal.js',
             'js/accordion.js',
             'js/tab-responsive.js',

--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -69,6 +69,7 @@ const files = [
     'js/affix.js',
     'js/tooltip.js',
     'js/popover.js',
+    'js/offcanvas.js',
     'js/modal.js',
     'js/accordion.js',
     'js/tab-responsive.js',

--- a/js/common.js
+++ b/js/common.js
@@ -14,6 +14,7 @@
         '[data-cfw="tab"]': 'CFW_Tab',
         '[data-cfw="tooltip"]': 'CFW_Tooltip',
         '[data-cfw="popover"]': 'CFW_Popover',
+        '[data-cfw="offcanvas"]': 'CFW_Offcanvas',
         '[data-cfw="modal"]': 'CFW_Modal',
         '[data-cfw="affix"]': 'CFW_Affix',
         '[data-cfw="tabResponsive"]': 'CFW_TabResponsive',

--- a/js/modal.js
+++ b/js/modal.js
@@ -43,9 +43,8 @@
     CFW_Widget_Modal.prototype = {
 
         _init : function() {
-            var rootSelector = this.$element.CFW_getSelectorFromChain('modal', this.settings.rootElement);
-            if (!rootSelector) { return; }
-            this.$rootElement = $(rootSelector);
+            this.$rootElement = $(this.settings.rootElement);
+            if (!this.$rootElement) { return; }
             var selector = this.$element.CFW_getSelectorFromChain('modal', this.settings.target);
             if (!selector) { return; }
             this.$target = $(selector);

--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -1,0 +1,257 @@
+/**
+ * --------------------------------------------------------------------------
+ * Figuration (v4.2.1): offcanvas.js
+ * Licensed under MIT (https://github.com/cast-org/figuration/blob/master/LICENSE)
+ * --------------------------------------------------------------------------
+ */
+/* global CFW_Backdrop, CFW_Focuser, CFW_Scrollbar */
+
+(function($) {
+    'use strict';
+
+    var CFW_Widget_Offcanvas = function(element, options) {
+        this.$rootElement = null;
+        this.$element = $(element);
+        this.$target = null;
+        this._backdrop = null;
+        this._focuser = null;
+        this._scrollbar = null;
+        this.isShown = null;
+        this.fixedContent = '.fixed-top, .fixed-bottom, .is-fixed, .sticky-top';
+        this.stickyContent = '.sticky-top';
+
+        var parsedData = this.$element.CFW_parseData('offcanvas', CFW_Widget_Offcanvas.DEFAULTS);
+        this.settings = $.extend({}, CFW_Widget_Offcanvas.DEFAULTS, parsedData, options);
+
+        this._init();
+    };
+
+    CFW_Widget_Offcanvas.DEFAULTS = {
+        target       : false,   // Target selector
+        animate      : true,    // If offcanvas container should animate
+        backdrop     : true,    // Show backdrop
+        keyboard     : true,    // Close offcanvas on ESC press
+        scroll       : false,   // Allow rootElement to scroll
+        focus        : true,    // Keep focus within the offcanvas element
+        rootElement  : 'body'
+    };
+
+    CFW_Widget_Offcanvas.prototype = {
+        _init : function() {
+            this.$rootElement = $(this.settings.rootElement);
+            if (!this.$rootElement) { return; }
+            var selector = this.$element.CFW_getSelectorFromChain('offcanvas', this.settings.target);
+            if (!selector) { return; }
+            this.$target = $(selector);
+
+            this._backdrop = this._initializeBackdrop();
+            this._focuser = new CFW_Focuser({
+                element: this.$target[0]
+            });
+            this._scrollbar = new CFW_Scrollbar({
+                rootElement: this.settings.rootElement
+            });
+
+            this.$element.attr('data-cfw', 'offcanvas');
+
+            // Check for presence of ids - set if not present
+            var targetID = this.$target.CFW_getID('cfw-offcanvas');
+
+            // Set ARIA attributes on trigger
+            this.$element.attr('aria-controls', targetID);
+
+            // Use '.offcanvas-title' for labelledby
+            var $title = this.$target.find('.offcanvas-title');
+            if ($title.length) {
+                var labelledby = $title.eq(0).CFW_getID('cfw-offcanvas');
+                this.$target.attr('aria-labelledby', labelledby);
+            }
+
+            this.$target.attr('tabindex', -1);
+
+            // Bind click handler
+            this.$element.on('click.cfw.offcanvas', this.toggle.bind(this));
+
+            this.$element.CFW_trigger('init.cfw.offcanvas');
+        },
+
+        toggle : function(e) {
+            if (/a|area/i.test(e.target.tagName)) {
+                e.preventDefault();
+            }
+
+            if ($.CFW_isDisabled(e.target)) {
+                return;
+            }
+
+            // Close any other open offcanvas to avoid conflicts
+            var offcanvasShow = document.querySelector('.offcanvas.in');
+            if (offcanvasShow && offcanvasShow !== this.$target[0]) {
+                $(offcanvasShow).CFW_Offcanvas('hide');
+            }
+
+            if (this.isShown) {
+                this.hide();
+            } else {
+                this.show();
+            }
+        },
+
+        show : function() {
+            var $selfRef = this;
+
+            // Bail if already showing
+            if (this.isShown) { return; }
+
+            // Start open transition
+            if (!this.$element.CFW_trigger('beforeShow.cfw.offcanvas')) {
+                return;
+            }
+
+            this.isShown = true;
+            this._backdrop.show();
+            if (!this.settings.scroll) {
+                this._scrollbar.disable();
+            }
+            this.$rootElement.addClass('offcanvas-open');
+
+            this._escape();
+
+            this.$target
+                .attr('aria-modal', true)
+                .attr('role', 'dialog');
+
+            if (this.settings.animate) {
+                this.$target.addClass('showing');
+            }
+            this.$target.data('cfw.offcanvas', this);
+
+            var complete = function() {
+                $selfRef.$target
+                    .addClass('in')
+                    .removeClass('showing');
+                if (!$selfRef.settings.scroll) {
+                    $selfRef._focuser.activate();
+                }
+                $selfRef.$element.CFW_trigger('afterShow.cfw.offcanvas');
+            };
+
+            this.$target.CFW_transition(null, complete);
+        },
+
+        hide : function() {
+            var $selfRef = this;
+
+            // Bail if not showing
+            if (!this.isShown) { return; }
+
+            // Start close transition
+            if (!this.$element.CFW_trigger('beforeHide.cfw.offcanvas')) {
+                return;
+            }
+
+            this._focuser.deactivate();
+            this.$target
+                .off('.dismiss.cfw.offcanvas')
+                .trigger('blur');
+            this.isShown = false;
+
+            if (this.settings.animate) {
+                this.$target.addClass('hiding');
+            }
+            this._backdrop.hide();
+
+            var complete = function() {
+                $selfRef.$target
+                    .removeClass('in hiding')
+                    .removeAttr('aria-modal role');
+
+                $selfRef.$rootElement.removeClass('offcanvas-open');
+
+                if (!$selfRef.settings.scroll) {
+                    $selfRef._scrollbar.reset();
+                }
+
+                $selfRef.$element.CFW_trigger('afterHide.cfw.offcanvas');
+
+                if ($.CFW_isVisible($selfRef.$element)) {
+                    $selfRef.$element.trigger('focus');
+                }
+            };
+
+            this.$target.CFW_transition(null, complete);
+        },
+
+        dispose : function() {
+            this._backdrop.dispose();
+            this._focuser.deactivate();
+            this._scrollbar.reset();
+
+            this.$target
+                .off('.cfw.offcanvas')
+                .removeData('cfw.offcanvas');
+            this.$element
+                .off('.cfw.offcanvas')
+                .removeData('cfw.offcanvas');
+
+            this.$rootElement = null;
+            this.$element = null;
+            this.$target = null;
+            this._backdrop = null;
+            this._focuser = null;
+            this._scrollbar = null;
+            this.isShown = null;
+            this.settings = null;
+        },
+
+        _initializeBackdrop : function() {
+            var $selfRef = this;
+            return new CFW_Backdrop({
+                className: 'offcanvas-backdrop',
+                isVisible: this.settings.backdrop,
+                isAnimated: this.settings.animate,
+                rootElement: this.$target.parent(),
+                clickCallback: function() {
+                    $selfRef.hide();
+                }
+            });
+        },
+
+        _escape : function() {
+            var $selfRef = this;
+            var KEYCODE_ESC = 27;
+
+            if (this.isShown) {
+                this.$target.on('keydown.dismiss.cfw.offcanvas', function(e) {
+                    if ($selfRef.settings.keyboard && e.which === KEYCODE_ESC) {
+                        $selfRef.hide();
+                    }
+                });
+            }
+        }
+    };
+
+    var Plugin = function(option) {
+        var args = [].splice.call(arguments, 1);
+        return this.each(function() {
+            var $this = $(this);
+            var data = $this.data('cfw.offcanvas');
+            var options = typeof option === 'object' && option;
+
+            if (!data && /unlink|dispose/.test(option)) {
+                return;
+            }
+            if (!data) {
+                $this.data('cfw.offcanvas', data = new CFW_Widget_Offcanvas(this, options));
+            }
+            if (typeof option === 'string') {
+                data[option].apply(data, args);
+            }
+        });
+    };
+
+    $.fn.CFW_Offcanvas = Plugin;
+    $.fn.CFW_Offcanvas.Constructor = CFW_Widget_Offcanvas;
+
+    $.CFW_enableDismissControl('offcanvas', 'hide');
+}(jQuery));

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -369,7 +369,7 @@
             if (this.settings.container) {
                 this._focuser = new CFW_Focuser({
                     element: this.$target[0],
-                    autoFocus: this.isDialog,
+                    autoFocus: false,
                     flowElement: this.$element[0],
                     flowFocus: true
                 });

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -18,6 +18,7 @@
 
 // Components
 @import "mixins/alert";
+@import "mixins/backdrop";
 @import "mixins/buttons";
 @import "mixins/caret";
 @import "mixins/divider";

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -168,6 +168,7 @@ $enable-navbar-text:                        true !default;
 $enable-navbar-divider:                     true !default;
 $enable-navbar-collapse:                    true !default;
 $enable-navbar-toggle:                      true !default;
+$enable-navbar-offcanvas:                   true !default;
 $enable-navbar-light:                       true !default;
 $enable-navbar-dark:                        true !default;
 
@@ -198,6 +199,17 @@ $enable-dropdown-text:                      true !default;
 $enable-dropdown-divider:                   true !default;
 $enable-dropdown-dropup:                    true !default;
 $enable-dropdown-back:                      true !default;
+
+// Offcanvas
+$enable-offcanvas:                          true !default;
+$enable-offcanvas-side-start:               true !default;
+$enable-offcanvas-side-end:                 true !default;
+$enable-offcanvas-side-top:                 true !default;
+$enable-offcanvas-side-bottom:              true !default;
+$enable-offcanvas-header:                   true !default;
+$enable-offcanvas-title:                    true !default;
+$enable-offcanvas-body:                     true !default;
+$enable-offcanvas-footer:                   true !default;
 
 // Modal
 $enable-modal:                              true !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -602,6 +602,7 @@ $transition-collapse-x:     width .3s ease !default;
 // Component transitions
 $btn-transition:            color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 $input-transition:          background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
+$offcanvas-transition:      transform .3s linear !default;
 $modal-transition:          transform .15s linear !default;
 $navbar-toggle-transition:  box-shadow .15s ease-in-out !default;
 $nav-link-transition:       color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out !default;
@@ -1312,6 +1313,43 @@ $popover-arrow-color:           $popover-bg !default;
 $popover-arrow-outer-color:     $popover-border-color !default;
 
 
+// Offcanvas
+// =====
+$offcanvas-bg:                  $component-bg !default;
+$offcanvas-color:               null !default;
+$offcanvas-border-color:        $component-overlay-border-color !default;
+$offcanvas-border-width:        $border-width !default;
+$offcanvas-box-shadow:          map-get($shadows, "d3") !default;
+
+$offcanvas-backdrop-bg:         $dark !default;
+$offcanvas-backdrop-opacity:    .5 !default;
+
+$offcanvas-header-padding-y:    .75rem !default;
+$offcanvas-header-padding-x:    1rem !default;
+$offcanvas-header-bg:           null !default;
+$offcanvas-header-color:        null !default;
+$offcanvas-header-border-color: rgba($uibase-900, .2) !default;
+$offcanvas-header-border-width: 0 !default;
+
+$offcanvas-title-line-height:   $line-height-base !default;
+
+$offcanvas-close-padding-y:     .75rem !default;
+$offcanvas-close-padding-x:     .75rem !default;
+
+$offcanvas-body-padding-y:      .75rem !default;
+$offcanvas-body-padding-x:      1rem !default;
+
+$offcanvas-footer-padding-y:    .75rem !default;
+$offcanvas-footer-padding-x:    1rem !default;
+$offcanvas-footer-bg:           null !default;
+$offcanvas-footer-color:        null !default;
+$offcanvas-footer-border-color: $offcanvas-header-border-color !default;
+$offcanvas-footer-border-width: $offcanvas-header-border-width !default;
+
+$offcanvas-horizontal-width:    rem(400px) !default; // 400px=>25rem !default;
+$offcanvas-vertical-height:     33vh !default;
+
+
 // Modals
 // =====
 // Padding applied to the modal body
@@ -1389,13 +1427,15 @@ $loader-circle-animation-speed:         1s !default;
 
 // Figuration puts modals above popover/tooltip items that could be held open.
 // Tooltips/popovers should also be able to appear over fixed/sticky navbars.
-$zindex-dropdown:          1000 !default;
-$zindex-sticky:            1010 !default;
-$zindex-fixed:             1020 !default;
-$zindex-popover:           1030 !default;
-$zindex-tooltip:           1040 !default;
-$zindex-modal-backdrop:    1050 !default;
-$zindex-modal:             1060 !default;
+$zindex-dropdown:           1000 !default;
+$zindex-sticky:             1010 !default;
+$zindex-fixed:              1020 !default;
+$zindex-offcanvas-backdrop: 1030 !default;
+$zindex-offcanvas:          1035 !default;
+$zindex-popover:            1040 !default;
+$zindex-tooltip:            1050 !default;
+$zindex-modal-backdrop:     1060 !default;
+$zindex-modal:              1065 !default;
 
 
 // Utilities

--- a/scss/component/_modal.scss
+++ b/scss/component/_modal.scss
@@ -1,19 +1,8 @@
-// .modal-open      - body class for killing the scroll
 // .modal           - container to scroll within
 // .modal-dialog    - positioning shell for the actual modal
 // .modal-content   - actual modal w/ bg, border, border-radius, etc
 
 @if $enable-modal {
-    .modal-open {
-        // Kill the scroll on the body
-        overflow: hidden;
-
-        .modal {
-            overflow-x: hidden;
-            overflow-y: auto;
-        }
-    }
-
     // Container that the modal scrolls within
     .modal {
         position: fixed;
@@ -242,19 +231,8 @@
         }
     }
 
-    // Modal background
     .modal-backdrop {
-        position: fixed;
-        top: 0;
-        left: 0;
-        z-index: $zindex-modal-backdrop;
-        width: 100vw;
-        height: 100vh;
-        background-color: $modal-backdrop-bg;
-
-        // Fade for backdrop
-        &.fade { opacity: 0; }
-        &.in { opacity: $modal-backdrop-opacity; }
+        @include backdrop-overlay($zindex-modal-backdrop, $modal-backdrop-bg, $modal-backdrop-opacity);
     }
 
     // Modal rootElement specified

--- a/scss/component/_navbar.scss
+++ b/scss/component/_navbar.scss
@@ -200,6 +200,55 @@
                             display: none;
                         }
                     }
+
+                    @if $enable-navbar-offcanvas and $enable-offcanvas {
+                        .offcanvas {
+                            position: inherit;
+                            bottom: 0;
+                            z-index: auto;
+                            flex-grow: 1;
+                            visibility: visible !important; // stylelint-disable-line declaration-no-important
+                            background-color: transparent;
+                            border-right: 0;
+                            border-left: 0;
+                            @include box-shadow(none);
+                            @include transition(none);
+                            transform: none;
+                        }
+
+                        %navbar-offcanvas-side-vertical-#{$bp} {
+                            height: auto;
+                            border-top: 0;
+                            border-bottom: 0;
+                        }
+
+                        @if $enable-offcanvas-side-top {
+                            .offcanvas-top {
+                                @extend %navbar-offcanvas-side-vertical-#{$bp};
+                            }
+                        }
+
+                        @if $enable-offcanvas-side-bottom {
+                            .offcanvas-bottom {
+                                @extend %navbar-offcanvas-side-vertical-#{$bp};
+                            }
+                        }
+
+                        @if $enable-offcanvas-header {
+                            .offcanvas-header {
+                                display: none;
+                            }
+                        }
+
+                        @if $enable-offcanvas-body {
+                            .offcanvas-body {
+                                display: flex;
+                                flex-grow: 0;
+                                padding: 0;
+                                overflow-y: visible;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/scss/component/_offcanvas.scss
+++ b/scss/component/_offcanvas.scss
@@ -1,0 +1,143 @@
+@if $enable-offcanvas {
+    .offcanvas {
+        position: fixed;
+        bottom: 0;
+        z-index: $zindex-offcanvas;
+        display: flex;
+        flex-direction: column;
+        max-width: 100%;
+        color: $offcanvas-color;
+        visibility: hidden;
+        background-color: $offcanvas-bg;
+        background-clip: padding-box;
+        outline: 0;
+        @include box-shadow($offcanvas-box-shadow);
+
+        &.showing,
+        &.in:not(.hiding) {
+            transform: none;
+        }
+
+        &.showing,
+        &.in.hiding {
+            @include transition($offcanvas-transition);
+        }
+
+        &.showing,
+        &.hiding,
+        &.in {
+            visibility: visible;
+        }
+    }
+
+    .offcanvas-backdrop {
+        @include backdrop-overlay($zindex-offcanvas-backdrop, $offcanvas-backdrop-bg, $offcanvas-backdrop-opacity);
+    }
+
+    // Offcanvas rootElement specified
+    .offcanvas-open:not(body) {
+        .offcanvas {
+            position: absolute;
+        }
+        .offcanvas-backdrop {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+        }
+    }
+
+    @if $enable-offcanvas-header {
+        .offcanvas-header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            padding: $offcanvas-header-padding-y $offcanvas-header-padding-x;
+            color: $offcanvas-header-color;
+            background-color: $offcanvas-header-bg;
+            border-bottom: $offcanvas-header-border-width solid $offcanvas-header-border-color;
+
+            // Close icon
+            .close {
+                // Make sure close appears 'after' the title
+                order: 1;
+                padding: $offcanvas-close-padding-y $offcanvas-close-padding-x;
+                // Left auto margin keeps close pushed to the right side even when no title
+                margin: (-$offcanvas-header-padding-y) (-$offcanvas-header-padding-x) (-$offcanvas-header-padding-y) auto;
+            }
+        }
+    }
+
+    @if $enable-offcanvas-title {
+        .offcanvas-title {
+            margin: 0;
+            line-height: $offcanvas-title-line-height;
+        }
+    }
+
+    @if $enable-offcanvas-body {
+        .offcanvas-body {
+            flex-grow: 1;
+            padding: $offcanvas-body-padding-y $offcanvas-body-padding-x;
+            overflow-y: auto;
+        }
+    }
+
+    @if $enable-offcanvas-footer {
+        .offcanvas-footer {
+            display: flex;
+            align-items: center;
+            justify-content: flex-end; // right align buttons
+            padding: $offcanvas-footer-padding-y $offcanvas-footer-padding-x;
+            color: $offcanvas-footer-color;
+            background-color: $offcanvas-footer-bg;
+            border-top: $offcanvas-footer-border-width solid $offcanvas-footer-border-color;
+
+            // Simulate spaces between footer elements with margins
+            > :not(:first-child) { margin-left: .25rem; }
+            > :not(:last-child) { margin-right: .25rem; }
+        }
+    }
+
+    @if $enable-offcanvas-side-start {
+        .offcanvas-start {
+            top: 0;
+            left: 0;
+            width: $offcanvas-horizontal-width;
+            border-right: $offcanvas-border-width solid $offcanvas-border-color;
+            transform: translateX(-100%);
+        }
+    }
+
+    @if $enable-offcanvas-side-end {
+        .offcanvas-end {
+            top: 0;
+            right: 0;
+            width: $offcanvas-horizontal-width;
+            border-left: $offcanvas-border-width solid $offcanvas-border-color;
+            transform: translateX(100%);
+        }
+    }
+
+    @if $enable-offcanvas-side-top {
+        .offcanvas-top {
+            top: 0;
+            right: 0;
+            left: 0;
+            height: $offcanvas-vertical-height;
+            max-height: 100%;
+            border-bottom: $offcanvas-border-width solid $offcanvas-border-color;
+            transform: translateY(-100%);
+        }
+    }
+
+    @if $enable-offcanvas-side-bottom {
+        .offcanvas-bottom {
+            right: 0;
+            left: 0;
+            height: $offcanvas-vertical-height;
+            max-height: 100%;
+            border-top: $offcanvas-border-width solid $offcanvas-border-color;
+            transform: translateY(100%);
+        }
+    }
+}

--- a/scss/figuration.scss
+++ b/scss/figuration.scss
@@ -51,6 +51,7 @@
 @import "component/loader";
 
 // Components w/ JavaScript
+@import "component/offcanvas";
 @import "component/modal";
 @import "component/tooltip";
 @import "component/popover";

--- a/scss/mixins/_backdrop.scss
+++ b/scss/mixins/_backdrop.scss
@@ -1,0 +1,13 @@
+@mixin backdrop-overlay($backdrop-zindex, $backdrop-bg, $backdrop-opacity) {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: $backdrop-zindex;
+    width: 100vw;
+    height: 100vh;
+    background-color: $backdrop-bg;
+
+    // Fade for backdrop
+    &.fade { opacity: 0; }
+    &.in { opacity: $backdrop-opacity; }
+}

--- a/site/4.2/4.2.11tydata.js
+++ b/site/4.2/4.2.11tydata.js
@@ -102,6 +102,7 @@ module.exports = {
           { "title": "Equalize" },
           { "title": "Lazy" },
           { "title": "Modal" },
+          { "title": "Offcanvas" },
           { "title": "Player" },
           { "title": "Popover" },
           { "title": "Scrollspy" },

--- a/site/4.2/components/navbar.md
+++ b/site/4.2/components/navbar.md
@@ -149,6 +149,77 @@ With the `.navbar-brand` in the collapsing area.
 {% endcapture %}
 {% renderExample example %}
 
+### Offcanvas
+
+Add an offcanvas drawer with the [Offcanvas widget]({{ site.path }}/{{ version.docs }}/widgets/offcanvas/). The offcanvas styles are adjusted when contained within a navbar, and with use of `.navbar-expand-*` classes, you can create flexible and respsonsive navigation.
+
+To create an offcanvas navbar that is always collapsed, simply leave off the `.navbar-expand-*` class from the `.navbar` element.
+
+{% capture example %}
+<nav class="navbar navbar-light bg-light">
+  <div class="container-fluid flex-between">
+    <a class="navbar-brand" href="#">Offcanvas navbar</a>
+    <button class="navbar-toggle" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasNavbar">
+        <span aria-hidden="true">&#8801;</span>
+    </button>
+    <div id="offcanvasNavbar" class="offcanvas offcanvas-end">
+      <div class="offcanvas-header">
+        <h4 class="offcanvas-title h5">Offcanvas navbar example</h4>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="navbar-nav flex-end flex-grow-1 pe-1">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link" href="#" role="button" data-cfw="dropdown">
+              Dropdown
+              <span class="caret" aria-hidden="true"></span>
+            </a>
+            <ul class="dropdown-menu mb-1">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="d-flex" role="search">
+          <input class="form-control me-0_5" type="search" placeholder="Search" aria-label="Search">
+          <button class="btn btn-outline-info" type="submit">Search</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</nav>
+{% endcapture %}
+{% renderExample example %}
+
+To create an offcanvas navbar that expands into a normal navbar at a specific breakpoint like `lg`, use `.navbar-expand-lg`.
+
+For a working example, please check out the [Offcanvas Navbar example]({{ site.path }}/{{ version.docs }}/examples/navbar-offcanvas/).
+
+{% capture highlight %}
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid flex-between">
+    <a class="navbar-brand" href="#">Offcanvas navbar</a>
+    <button class="navbar-toggle" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasNavbar">
+        <span aria-hidden="true">&#8801;</span>
+    </button>
+    <div id="offcanvasNavbar" class="offcanvas offcanvas-end">
+      ...
+    </div>
+  </div>
+</nav>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
 ## Supported Content
 
 Navbars come with built-in support for a handful of sub-components. Mix and match from the following as you need:

--- a/site/4.2/examples/navbar-offcanvas/index.html
+++ b/site/4.2/examples/navbar-offcanvas/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<!-- Required meta tags -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Fixed Top Navbar Example</title>
+
+<!-- Figuration CSS -->
+<link rel="stylesheet" href="{{ site.path }}/assets/{{ version.docs }}/dist/css/figuration.min.css">
+
+<!-- jQuery and Figuration JS -->
+<script src="{{ site.path }}/assets/{{ version.docs }}/js/vendor/jquery.slim.min.js"></script>
+<script src="{{ site.path }}/assets/{{ version.docs }}/js/vendor/popper.min.js"></script>
+<script src="{{ site.path }}/assets/{{ version.docs }}/dist/js/figuration.min.js"></script>
+
+<style>
+body {
+    min-height: 75rem;
+}
+.jumbotron {
+    margin-top: 5rem;
+    margin-bottom: 1rem;
+}
+</style>
+
+</head>
+<body>
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light flex-between fixed-top">
+    <div class="container-fluid flex-between">
+        <a href="#" class="navbar-brand">Offcanvas Navbar</a>
+        <button class="navbar-toggle" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasNavbar">
+            <span aria-hidden="true">&#8801;</span>
+        </button>
+
+        <div class="offcanvas offcanvas-end" id="offcanvasNavbar">
+            <div class="offcanvas-header">
+                <h5 class="offcanvas-title">Offcanvas navbar menu</h5>
+                <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
+            <div class="offcanvas-body">
+                <ul class="navbar-nav flex-end flex-grow-1 pe-1">
+                    <li class="nav-item">
+                        <a href="#" class="nav-link active" aria-current="page">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a href="#" class="nav-link">Link</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link disabled">Disabled</a>
+                    </li>
+                    <li class="nav-item dropdown mb-1 mb-lg-0">
+                        <a class="nav-link" href="#" data-cfw="dropdown">Dropdown<span class="caret ms-0_25" aria-hidden="true"></span></a>
+                        <ul class="dropdown-menu">
+                            <li><a href="#">Action</a></li>
+                            <li><a href="#">Another action</a></li>
+                            <li><a href="#">Something else here</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <form class="d-flex" role="search">
+                    <input class="form-control me-0_5" type="search" placeholder="Search" aria-label="Search">
+                    <button class="btn btn-info" type="submit">Search</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</nav>
+
+<main class="container">
+    <div class="jumbotron">
+        <h1>Offcanvas Navbar</h1>
+        <p class="lead">
+            This example page shows off how a top-aligned navbar and its responsive behaviors.
+            This navbar will remain fixed at the top of your browser's viewport as you scroll.
+        </p>
+        <p>
+            In order to experience the responsive behavior of the navbar, you will have to resize your browser above and below the <code>lg</code> breakpoint.
+        </p>
+        <p>
+            <a href="{{ site.path }}/{{ version.docs }}/components/navbar/" class="btn btn-lg btn-primary">View navbar docs &raquo;</a>
+        </p>
+    </div>
+</main>
+
+</body>
+</html>

--- a/site/4.2/get-started/examples.md
+++ b/site/4.2/get-started/examples.md
@@ -19,15 +19,16 @@ Examples focusing on the use of the standard components.
 
 Examples showing the navbar and how it is responsive, can be positioned, or extended.
 
-- [Navbar Examples]({{ site.path }}/{{ version.docs }}/examples/navbars/index.html) - A large variety of navbar types and examples of the responsive behaviors.
-- [Static Top Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-static-top/index.html) - A basic template of a static top navbar and some additional content.
-- [Fixed Top Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-fixed-top/index.html) - A basic template of a fixed top navbar and some additional content.
-- [Fixed Bottom Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-fixed-bottom/index.html) - A basic template of a fixed bottom navbar and some additional content.
+- [Navbar Examples]({{ site.path }}/{{ version.docs }}/examples/navbars/) - A large variety of navbar types and examples of the responsive behaviors.
+- [Static Top Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-static-top/) - A basic template of a static top navbar and some additional content.
+- [Fixed Top Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-fixed-top/) - A basic template of a fixed top navbar and some additional content.
+- [Fixed Bottom Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-fixed-bottom/) - A basic template of a fixed bottom navbar and some additional content.
+- [Offcanvas Navbar]({{ site.path }}/{{ version.docs }}/examples/navbar-offcanvas/) - An example of a fixed top navbar with a repsonsive offcanvas drawer.
 
 ## Project Concepts
 
 Examples of components and layouts to demonstrate what Figuration can help you create.
 
-- [Blog Example]({{ site.path }}/{{ version.docs }}/examples/blog/index.html) - News style blog layout with header, navigation, footer, content cards, and a sample article.
+- [Blog Example]({{ site.path }}/{{ version.docs }}/examples/blog/) - News style blog layout with header, navigation, footer, content cards, and a sample article.
 
 **More to come!**

--- a/site/4.2/get-started/migration.md
+++ b/site/4.2/get-started/migration.md
@@ -8,6 +8,9 @@ toc: true
 
 ## v4.3.0
 
+### CSS
+- `z-index` values for tooltip, popover, modal-backdrop and modal elements were increased slightly to make space for the new Offcanvas components.
+
 ### Grid
 - Split containers out into their own component with the addition of the `$enable-container` and `$enable-container-responsive` (replaces `$enable-grid-responsive-containers`).
 - Moved container related Sass into `.\scss\component\container.scss`
@@ -40,3 +43,6 @@ toc: true
 #### Modals
 - New 'contained' variant.  Set a modal within a container, instead of blocking the entire page.
 - New `focus` option - to disable the modal's focus trap.  Replaces the need to create an override function.
+
+#### Offcanvas
+- New widget!  Similar to the side-aligned modals, there a few slight differences in functionality, such as the responsive drawer capabilities when contained within a navbar.

--- a/site/4.2/layout/z-index.md
+++ b/site/4.2/layout/z-index.md
@@ -13,13 +13,15 @@ We use a defined set because of the layered components—tooltips, popovers, nav
 Customizing these values is most likely not needed, and we don't recommend adjusting the values.  However, if you change one, you will need to review and possibly update all of the other values.
 
 {% capture highlight %}
-$zindex-dropdown:          1000 !default;
-$zindex-sticky:            1010 !default;
-$zindex-fixed:             1020 !default;
-$zindex-popover:           1030 !default;
-$zindex-tooltip:           1040 !default;
-$zindex-modal-backdrop:    1050 !default;
-$zindex-modal:             1060 !default;
+$zindex-dropdown:           1000 !default;
+$zindex-sticky:             1010 !default;
+$zindex-fixed:              1020 !default;
+$zindex-offcanvas-backdrop: 1030 !default;
+$zindex-offcanvas:          1035 !default;
+$zindex-popover:            1040 !default;
+$zindex-tooltip:            1050 !default;
+$zindex-modal-backdrop:     1060 !default;
+$zindex-modal:              1065 !default;
 {% endcapture %}
 {% renderHighlight highlight, "sass" %}
 

--- a/site/4.2/widgets/alert.md
+++ b/site/4.2/widgets/alert.md
@@ -5,6 +5,8 @@ subtitle: alert.js
 description: Enable dismiss functionality for alert messages.
 group: widgets
 toc: true
+extras:
+  name: alert
 ---
 
 {% capture callout %}
@@ -97,8 +99,8 @@ If the dismiss button is disabled, then the close action will be blocked.
 
 ### Via Data Attributes
 
-{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./" | append: "/partials/js-dismiss.md" -%}
-{% include jsDismiss with name: 'popover' %}
+{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./site/_includes/" | append: "/partials/js-dismiss.md" -%}
+{% renderFile jsDismiss, extras %}
 
 An example can be found in the [JavaScript Intergration section within the Badges component page]({{ site.path }}/{{ version.docs }}/components/badges/#javascript-integration).
 

--- a/site/4.2/widgets/modal.md
+++ b/site/4.2/widgets/modal.md
@@ -5,6 +5,8 @@ subtitle: modal.js
 description: The Modal widget allows you to add dialog style windows to your site or application.
 group: widgets
 toc: true
+extras:
+  name: modal
 ---
 
 ## Important Notes
@@ -1173,13 +1175,15 @@ Contained modals will display the backdrop and modal within a specified element 
 
 Place the modal HTML within the container, apply `position: relative;` to the container, and specify the `rootElement` option on the trigger button to limit the modal to the container.
 
+It may also be useful to add a `z-index` to the container, this will keep the modal from appearing above other items that exist outside the container, such as a navbar.  In the example below a `z-index: 1;` has been added to the `#modalRootElement` container so that the contained modal, and backdrop, do not overlap the site header when the page is scrolled.
+
 While most modal positioning options are supported, the fullscreen variants should not be used within a container.
 
 **Note:** Contained modals do not work well within Internet Explorer and are not supported. Issues could include multiple scrollbars or having to scroll within the container to locate the modal.  Since IE is a low usage browser at this point effort has not been made to fix these issues specific to IE, and will most likely not be attempted in the future.
 
 {% capture example %}
 <!-- Modal will appear within this element, and not the document body -->
-<div id="modalRootElement" class="position-relative border" style="height: 300px;">
+<div id="modalRootElement" class="position-relative border" style="height: 300px; z-index: 1;">
   <!-- Modal -->
   <div id="modalContained" class="modal">
     <div class="modal-dialog">
@@ -1256,8 +1260,8 @@ Activate a modal without writing JavaScript. Set `data-cfw="modal"` on a control
 
 #### Dismiss
 
-{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./" | append: "/partials/js-dismiss.md" -%}
-{% include jsDismiss with name: 'modal' %}
+{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./site/_includes/" | append: "/partials/js-dismiss.md" -%}
+{% renderFile jsDismiss, extras %}
 
 {% capture callout %}
 While both ways to dismiss a modal are supported, keep in mind that dismissing from outside a modal does not match [the WAI-ARIA modal dialog design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal). Do this at your own risk.
@@ -1680,6 +1684,14 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         <td><code>$component-bg</code></td>
         <td>
           Background color for modal content container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$modal-content-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Text color for modal content container.
         </td>
       </tr>
       <tr>

--- a/site/4.2/widgets/offcanvas.md
+++ b/site/4.2/widgets/offcanvas.md
@@ -1,0 +1,790 @@
+---
+layout: doc
+title: Offcanvas
+subtitle: Offcanvas.js
+description: Add hidden dialog sidebars that slide into view from the edge of the page or container.
+group: widgets
+toc: true
+extras:
+  name: offcanvas
+---
+
+## How It Works
+
+Offcanvas is a component to create sidebars that can be toggled using JavaScript to appear from the edges of a viewport or container.
+- Buttons, or anchors, are used to toggle the associated offcanvas element.
+- Offcanvas shares much of the same functionality as modals, but operates slightly differently.
+- By default, offcanvas also uses a backdrop when showing that can be clicked to hide the offcanvas.
+- Only one offcanvas should be shown at a time.
+
+**Heads up!**  You should not use `margin` or `translate` on an `.offcanvas` element as this will interfere with the CSS animations. Instead, use the class as an independent wrapping element.
+
+## Examples
+
+### Offcanvas Components
+
+Below is an offcanvas example that is shown by default (via `.in` on `.offcanvas`). Offcanvas includes support for a header with a close button, an optional body class for some initial `padding` and `overflow` handling. Also available is a completely optional footer container with some available `padding` and end-aligned content.  The offcanvas body will automatically grow to fill the available height.
+
+We suggest that you include offcanvas headers with dismiss actions whenever possible, or provide an explicit dismiss action.
+
+{% capture example %}
+<div class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Content for the offcanvas goes here. You can place just about any component or custom element here.
+  </div>
+  <div class="offcanvas-footer">
+    Offcanvas footer
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example "cf-example-offcanvas p-0 bg-light overflow-hidden" %}
+
+### Live Demo
+
+Use the buttons below to show and hide an offcanvas element via JavaScript that toggles the `.in` class on an element with the `.offcanvas` class.
+
+- `.offcanvas` hides content (default)
+- `.offcanvas.in` shows content
+
+You can use a link with the `href` attribute, or a button with the `data-cfw-offcanvas-target` attribute. In both cases, the `data-cfw="offcanvas"` attribute is required.
+
+{% capture example %}
+<button type="button" class="btn btn-primary" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasData">
+  Button with data-*-target
+</button>
+
+<div id="offcanvasData" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>Some placeholder text. You can include elements here such as, text, images, links, and even more complex components.</p>
+    <div class="dropdown">
+      <button type="button" class="btn btn-secondary" data-cfw="dropdown">
+      Dropdown <span class="caret" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li><a href="#">Action</a></li>
+      <li><a href="#">Another action</a></li>
+      <li><a href="#">Something else here</a></li>
+    </ul>
+    </div>
+  </div>
+  <div class="offcanvas-footer">
+    Offcanvas footer
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
+{% capture example %}
+<a role="button" class="btn btn-primary" data-cfw="offcanvas" href="#offcanvasHref">
+  Link with href
+</a>
+
+<div id="offcanvasHref" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>Some placeholder text. You can include elements here such as, text, images, links, and even more complex components.</p>
+    <div class="dropdown">
+      <button type="button" class="btn btn-secondary" data-cfw="dropdown">
+      Dropdown <span class="caret" aria-hidden="true"></span>
+    </button>
+    <ul class="dropdown-menu">
+      <li><a href="#">Action</a></li>
+      <li><a href="#">Another action</a></li>
+      <li><a href="#">Something else here</a></li>
+    </ul>
+    </div>
+  </div>
+  <div class="offcanvas-footer">
+    Offcanvas footer
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
+### Placement
+
+There is no default placement for an offcanvas components, so you must add one of the following modifier classes;
+
+- `.offcanvas-start` - start edge of the viewport
+- `.offcanvas-end` - end edge of the viewport
+- `.offcanvas-top` - top edge of the viewport
+- `.offcanvas-bottom` - bottom edge  of the viewport
+
+{% capture example %}
+<!-- Toggle buttons -->
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasStart">Offcanvas start</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasEnd">Offcanvas end</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasTop">Offcanvas top</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasBottom">Offcanvas bottom</button>
+
+<!-- Directional examples -->
+<div id="offcanvasStart" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas start</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Offcanvas content
+  </div>
+</div>
+
+<div id="offcanvasEnd" class="offcanvas offcanvas-end">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas end</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Offcanvas content
+  </div>
+</div>
+
+<div id="offcanvasTop" class="offcanvas offcanvas-top">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas top</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Offcanvas content
+  </div>
+</div>
+
+<div id="offcanvasBottom" class="offcanvas offcanvas-bottom">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas bottom</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Offcanvas content
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
+### Backdrop
+
+Scrolling the `<body>` element is disabled when an offcanvas and its backdrop are visible. Use the `scroll` option to toggle `<body>` scrolling and the `backdrop` option to toggle the use of a backdrop.
+
+{% capture example %}
+<!-- Toggle buttons -->
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasBack" data-cfw-offcanvas-backdrop="true" data-cfw-offcanvas-scroll="false">Enable backdrop (default)</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasScroll"  data-cfw-offcanvas-backdrop="false" data-cfw-offcanvas-scroll="true">Disabled backdrop and enable scrolling</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasBackScroll"  data-cfw-offcanvas-backdrop="true" data-cfw-offcanvas-scroll="true">Enable both backdrop and scrolling</button>
+
+<!-- Offcanvas elements -->
+<div id="offcanvasBack" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas with backdrop</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Body scrolling is disabled and you may click on the backdrop to dimiss the offcanvas item.
+  </div>
+</div>
+
+<div id="offcanvasScroll" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas with body scrolling</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    The backdrop has been disabled and the page can be scrolled and interacted with.
+  </div>
+</div>
+
+<div id="offcanvasBackScroll" class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title h5">Offcanvas backdrop and scroll</h4>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    Scrolling is enabled so you can scroll and interact with the page, but clicking on the backdrop will dismiss the offcanvas item.
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
+### Within a Navbar
+
+Offcanvas is supported within the navbar component allowing for flexible navigation options along with support for responsive layouts.
+
+Information and examples can be found in the [Offcavnas section on the Navbar component page]({{ site.path }}/{{ version.docs }}/components/navbar/#offcanvas).
+
+### Contained Offcanvas
+
+Contained offcanvas will display the backdrop and offcanvas within a specified element and not cover the entire page.
+
+Place the offcanvas HTML within the container, apply `position: relative;` to the container, and specify the `rootElement` option on the trigger button to limit the offcanvas to the container.
+
+It may also be useful to add a `z-index` to the container, this will keep the offcanvas from appearing above other items that exist outside the container, such as a navbar.  In the example below a `z-index: 1;` has been added to the `#offcanvasRootElement` container so that the contained offcanvas, and backdrop, do not overlap the site header when the page is scrolled.
+
+{% capture example %}
+<div id="offcanvasRootElement" class="bg-light border overflow-hidden position-relative" style="height: 200px; z-index: 1;">
+  <div id="offcanvasContained" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+      <h4 class="offcanvas-title h5">Contained offcanvas</h4>
+      <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+      Offcanvas content
+    </div>
+    <div class="offcanvas-footer">
+      Offcanvas footer
+    </div>
+  </div>
+
+</div>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasContained" data-cfw-offcanvas-root-element="#offcanvasRootElement">
+  Contained offcanvas
+</button>
+{% endcapture %}
+{% renderExample example %}
+
+## Usage
+
+The offcanvas widget toggles your hidden content on demand, via data attributes or JavaScript. It also generates a `.offcanvas-backdrop` to provide a click area for dismissing shown offcanvas when clicking outside the offcanvas.
+
+### Via Data Attributes
+
+#### Toggle
+
+Activate an offcanvas without writing JavaScript. Set `data-cfw="offcanvas"` on a controller element, like a button, along with a `data-cfw-offcanvas-target="#foo"` or `href="#foo"` to target a specific offcanvas to toggle.
+
+{% capture highlight %}
+<button type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#myOffcanvas">Launch offcanvas</button>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+#### Dismiss
+
+{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./site/_includes/" | append: "/partials/js-dismiss.md" -%}
+{% renderFile jsDismiss, extras %}
+
+{% capture callout %}
+While both ways to dismiss an offcanvas are supported, keep in mind that dismissing from outside an offcanvas does not match [the WAI-ARIA modal dialog design pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal). Do this at your own risk.
+{% endcapture %}
+{% renderCallout callout, "warning" %}
+
+### Via JavaScript
+
+Call an offcanvas with id `myOffcanvas` with a single line of JavaScript:
+
+{% capture highlight %}
+$('#myOffcanvas').CFW_Offcanvas();
+{% endcapture %}
+{% renderHighlight highlight, "js" %}
+
+### Close Triggers
+
+Any an element with a data attribute of `data-cfw-dismiss="offcanvas"` within the offcanvas element will act as a close trigger for the offcanvas.  There can be multiple close triggers, such as a header/titlebar close and a cancel button in the footer.
+
+### With Fixed Position Content
+
+When the scrollbar is removed from the `<body>` when an offcanvas is shown, there can be some shifting of content in fixed position elements.  To help with this issue, when an offcanvas is shown, any elements using the [fixed positioning utility]({{ site.path }}/{{ version.docs }}/utilities/position/) classes, (`.fixed-top` and `.fixed-bottom`), will have additional padding added to their right side.  This padding width should match the width of the scrollbar that becomes hidden.  When the offcanvas is hidden, the `padding-right` CSS value will be reset.
+
+There is also an additional special classname that the offcanvas widget will look for when adjusting padding values.  Simply add the `.is-fixed` class to your element, and it will automatically be handled.
+
+### Options
+
+Options can be passed via data attributes or JavaScript. For data attributes, append the option name to `data-cfw-offcanvas-`, as in `data-cfw-offcanvas-animate=false`.
+
+<div class="table-scroll">
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+        <th style="width: 100px;">Name</th>
+        <th style="width: 50px;">Type</th>
+        <th style="width: 50px;">Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>target</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>The selector of the target offcanvas.</td>
+      </tr>
+      <tr>
+        <td><code>rootElement</code></td>
+        <td>string</td>
+        <td><code>'body'</code></td>
+        <td>The selector of the container to display offcanvas within.</td>
+      </tr>
+      <tr>
+        <td><code>animate</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>If offcanvas targets should fade and slide in.</td>
+      </tr>
+      <tr>
+        <td><code>backdrop</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          <p>Include an offcanvas-backdrop element.</p>
+          <p>The backdrop is the semi-opaque overlay used to visually seperate the offcanvas from the page content.</p>
+         </td>
+      </tr>
+      <tr>
+        <td><code>scroll</code></td>
+        <td>boolean</td>
+        <td><code>false</code></td>
+        <td>Allow rootElement scrolling while offcanvas is open.</td>
+      </tr>
+      <tr>
+        <td><code>keyboard</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>Closes the offcanvas when escape key is pressed.</td>
+      </tr>
+      <tr>
+        <td><code>focus</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>Enforce focus when using keyboard navigation to remain within the offcanvas dialog.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% capture highlight %}
+$('#myOffcanvas').CFW_Offcanvas({
+  animate: false
+});
+{% endcapture %}
+{% renderHighlight highlight, "js" %}
+
+### Methods
+
+Method calls can be made on either the trigger or the target `<div class="offcanvas">` element.
+
+<div class="table-scroll">
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+        <th style="width: 150px;">Method Name</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>toggle</code></td>
+        <td>Toggles an offcanvas dialog to be shown or hidden.</td>
+      </tr>
+      <tr>
+        <td><code>show</code></td>
+        <td>Shows an offcanvas dialog.</td>
+      </tr>
+      <tr>
+        <td><code>hide</code></td>
+        <td>Hides an offcanvas dialog.</td>
+      </tr>
+      <tr>
+        <td><code>dispose</code></td>
+        <td>Removes the event listeners from the trigger and target items.</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% capture highlight %}
+$('#myOffcanvas').CFW_Offcanvas('show');
+{% endcapture %}
+{% renderHighlight highlight, "js" %}
+
+### Events
+
+Event callbacks happen on the toggle/trigger element.
+
+<div class="table-scroll">
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+        <th style="width: 150px;">Event Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>init.cfw.offcanvas</code></td>
+        <td>This event fires after the offcanvas item is initialized.</td>
+      </tr>
+      <tr>
+        <td><code>beforeShow.cfw.offcanvas</code></td>
+        <td>This event is fired immediately when the <code>show</code> method is called.</td>
+      </tr>
+      <tr>
+        <td><code>afterShow.cfw.offcanvas</code></td>
+        <td>This event is fired when an offcanvas dialog has been made visible to the user (will wait for CSS transitions to complete).</td>
+      </tr>
+      <tr>
+        <td><code>beforeHide.cfw.offcanvas</code></td>
+        <td>This event is fired immediately when the <code>hide</code> method is called.</td>
+      </tr>
+      <tr>
+        <td><code>afterHide.cfw.offcanvas</code></td>
+        <td>This event is fired when an offcanvas dialog has been hidden from the user (will wait for CSS transitions to complete).</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+{% capture highlight %}
+$('#myOffcanvas').on('afterHide.cfw.offcanvas', function() {
+  // do something...
+});
+{% endcapture %}
+{% renderHighlight highlight, "js" %}
+
+## Accessibility
+
+### Offcanvas Title
+
+It is recommended that a `.offcanvas-title` item is used, even if visually hidden, within the offcanvas since it will be automatically be found and linked with an `aria-labelledby` on the `.offcanvas` container.  This provides a potential description of the offcanvas to screen-reader users when the offcanvas is shown and focus is automatically moved to the `.offcanvas` container.
+
+### Key Commands
+
+The following key commands are handled when focus is inside the offcanvas:
+
+- <kbd>Esc</kbd> - Close the offcanvas
+- <kbd>Tab</kbd> - Moves focus to next focusable element inside the dialog. When focus is on the last focusable element in the dialog, moves focus to the first focusable element in the dialog.
+- <kbd>Shift + Tab</kbd> - Moves focus to previous focusable element inside the dialog. When focus is on the first focusable element in the dialog, moves focus to the last focusable element in the dialog.
+
+### Enforced Focus
+
+Offcanvas employ a 'focus trap' in an attempt to keep focus with the offcanvas dialog when one is open, as specified by the [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/) recommendations.
+
+If for some reason you need to disable the enforced focus for offcanvas, you can override the behavior by setting the `focus` option to `false`.
+
+## SASS Reference
+
+### Variables
+
+The available [Customization options]({{ site.path }}/{{ version.docs }}/get-started/options/), or Sass variables, that can be customized for the offcanvas component.
+
+<div class="table-scroll">
+  <table class="table table-bordered table-striped">
+    <thead>
+      <tr>
+        <th style="width: 100px;">Name</th>
+        <th style="width: 50px;">Type</th>
+        <th style="width: 50px;">Default</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>$enable-offcanvas</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the offcanvas component classes.
+          Smaller segements of the offcanvas component classes can be disabled with the following <code>$enable-*</code> variables.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-side-start</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the start side aligned offcanvas variant.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-side-end</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the end side aligned offcanvas variant.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-side-top</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the top side aligned offcanvas variant.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-side-bottom</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the bottom side aligned offcanvas variant.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-header</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the offcanvas header class.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-title</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the offcanvas title class.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-body</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the offcanvas body class.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-offcanvas-footer</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the offcanvas footer class.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-bg</code></td>
+        <td>string</td>
+        <td><code>$component-bg</code></td>
+        <td>
+          Background color for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-bg</code></td>
+        <td>string</td>
+        <td><code>$component-bg</code></td>
+        <td>
+          Background color for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Text color for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-border-color</code></td>
+        <td>string</td>
+        <td><code>$component-overlay-border-color</code></td>
+        <td>
+          Border color for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-border-width</code></td>
+        <td>string</td>
+        <td><code>$border-width</code></td>
+        <td>
+          Border width for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-box-shadow</code></td>
+        <td>string</td>
+        <td><code>map-get($shadows, "d3")</code></td>
+        <td>
+          Border width for offcanvas container.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-backdrop-bg</code></td>
+        <td>string</td>
+        <td><code>$dark</code></td>
+        <td>
+          Background color for offcanvas backdrop.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-backdrop-opacity</code></td>
+        <td>string</td>
+        <td><code>.5</code></td>
+        <td>
+          Opacity for offcanvas backdrop.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-padding-y</code></td>
+        <td>string</td>
+        <td><code>.75rem</code></td>
+        <td>
+          Vertical padding for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-padding-x</code></td>
+        <td>string</td>
+        <td><code>1rem</code></td>
+        <td>
+          Horizontal padding for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Text color for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-background-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Background color for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-border-color</code></td>
+        <td>string</td>
+        <td><code>rgba($uibase-900, .2)</code></td>
+        <td>
+          Border color for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-header-border-width</code></td>
+        <td>string</td>
+        <td><code>0</code></td>
+        <td>
+          Border width for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-title-line-height</code></td>
+        <td>string</td>
+        <td><code>$line-height-base</code></td>
+        <td>
+          Line height for offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-close-padding-y</code></td>
+        <td>string</td>
+        <td><code>.75rem</code></td>
+        <td>
+          Vertical padding for close button in offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-close-padding-x</code></td>
+        <td>string</td>
+        <td><code>.75rem</code></td>
+        <td>
+          Horizontal padding for close button in offcanvas header.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-body-padding-y</code></td>
+        <td>string</td>
+        <td><code>.75rem</code></td>
+        <td>
+          Vertical padding for offcanvas body.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-body-padding-x</code></td>
+        <td>string</td>
+        <td><code>1rem</code></td>
+        <td>
+          Horizontal padding for offcanvas body.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-padding-y</code></td>
+        <td>string</td>
+        <td><code>.75rem</code></td>
+        <td>
+          Vertical padding for offcanvas footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-padding-x</code></td>
+        <td>string</td>
+        <td><code>1rem</code></td>
+        <td>
+          Horizontal padding for offcanvas footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Text color for offcanvas footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-background-color</code></td>
+        <td>string</td>
+        <td><code>null</code></td>
+        <td>
+          Background color for offcanvas footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-border-color</code></td>
+        <td>string</td>
+        <td><code>$offcanvas-header-border-color</code></td>
+        <td>
+          Border color for offcanvas footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-footer-border-width</code></td>
+        <td>string</td>
+        <td><code>$offcanvas-header-border-width</code></td>
+        <td>
+          Border width for modal footer.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-horizontal-width</code></td>
+        <td>string</td>
+        <td><code>rem(400px)</code></td>
+        <td>
+          Width for horizontal side aligned offcanvas containers.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-vertical-height</code></td>
+        <td>string</td>
+        <td><code>33vh</code></td>
+        <td>
+          Height for vertical side aligned offcanvas containers.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$offcanvas-transition</code></td>
+        <td>string</td>
+        <td><code>transform .3s linear</code></td>
+        <td>
+          Transition settings for the <code>.offcanvas</code> animations.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+### Mixins
+
+No mixins available.

--- a/site/4.2/widgets/popover.md
+++ b/site/4.2/widgets/popover.md
@@ -5,6 +5,8 @@ subtitle: popover.js
 description: A more robust version of a tooltip, that allows for larger pieces of content or interactive functionality.
 group: widgets
 toc: true
+extras:
+  name: popover
 ---
 
 ## Notices
@@ -255,8 +257,8 @@ If the popover item is already created, you can link to it using <code>data-cfw-
 
 #### Dismiss
 
-{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./" | append: "/partials/js-dismiss.md" -%}
-{% include jsDismiss with name: 'popover' %}
+{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./site/_includes/" | append: "/partials/js-dismiss.md" -%}
+{% renderFile jsDismiss, extras %}
 
 ### Via JavaScript
 

--- a/site/4.2/widgets/tab-responsive.md
+++ b/site/4.2/widgets/tab-responsive.md
@@ -61,7 +61,7 @@ This example uses a breakpoint of 62em/992px.  Larger widths will see the tab st
 
 ## Usage
 
-To set up a responsive tab, all tabs must be under the same resposive tab ancestor, and then one collapse item per tab-pane is needed.
+To set up a responsive tab, all tabs must be under the same responsive tab ancestor, and then one collapse item per tab-pane is needed.
 
 You must provide the necessary CSS to determine how items should appear across breakpoints.  For example, you can hide the collapse triggers on desktops, but show on mobile devices where the tabs are hidden.
 

--- a/site/4.2/widgets/tooltip.md
+++ b/site/4.2/widgets/tooltip.md
@@ -5,6 +5,8 @@ subtitle: tooltip.js
 description: Add stylized tooltips to items for contextual or informational support.
 group: widgets
 toc: true
+extras:
+  name: tooltip
 ---
 
 ## Notices
@@ -171,8 +173,8 @@ If the tooltip item is already created, you can link to it using <code>data-cfw-
 
 #### Dismiss
 
-{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./" | append: "/partials/js-dismiss.md" -%}
-{% include jsDismiss with name: 'tooltip' %}
+{% assign jsDismiss = version.docs | valueIfEmpty: site.version.docs | prepend: "./site/_includes/" | append: "/partials/js-dismiss.md" -%}
+{% renderFile jsDismiss, extras %}
 
 ### Via JavaScript
 

--- a/site/assets/4.2/scss/_example.scss
+++ b/site/assets/4.2/scss/_example.scss
@@ -310,6 +310,14 @@
     overflow: auto;
 }
 
+// Offcanvas
+.cf-example-offcanvas .offcanvas {
+    position: static;
+    height: 200px;
+    visibility: visible;
+    transform: translate(0);
+}
+
 // Border utilities
 .cf-example-border {
     [class^="border"] {

--- a/site/assets/4.2/scss/_topnav.scss
+++ b/site/assets/4.2/scss/_topnav.scss
@@ -9,8 +9,7 @@
         .cf-header {
             position: sticky;
             top: 0;
-            //z-index: $zindex-sticky;
-            z-index: 1045;
+            z-index: $zindex-sticky;
         }
 
         .cf-content {

--- a/test/dev/testing.html
+++ b/test/dev/testing.html
@@ -21,6 +21,7 @@
 <script type="text/javascript" src="../../js/affix.js"></script>
 <script type="text/javascript" src="../../js/tooltip.js"></script>
 <script type="text/javascript" src="../../js/popover.js"></script>
+<script type="text/javascript" src="../../js/offcanvas.js"></script>
 <script type="text/javascript" src="../../js/modal.js"></script>
 <script type="text/javascript" src="../../js/tab-responsive.js"></script>
 <script type="text/javascript" src="../../js/accordion.js"></script>

--- a/test/js/index.html
+++ b/test/js/index.html
@@ -123,6 +123,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/accordion.js"></script>
 <script src="../../js/tab-responsive.js"></script>
@@ -143,6 +144,7 @@
 <script src="unit/equalize.js"></script>
 <script src="unit/lazy.js"></script>
 <script src="unit/modal.js"></script>
+<script src="unit/offcanvas.js"></script>
 <script src="unit/player.js"></script>
 <script src="unit/popover.js"></script>
 <script src="unit/scrollspy.js"></script>
@@ -152,8 +154,8 @@
 <script src="unit/tooltip.js"></script>
 <script src="unit/util.js"></script>
 <script src="unit/util/backdrop.js"></script>
-<script src="unit/util/scrollbar.js"></script>
 <script src="unit/util/focuser.js"></script>
+<script src="unit/util/scrollbar.js"></script>
 
     <div id="qunit-container">
         <div id="qunit"></div>

--- a/test/js/unit/offcanvas.js
+++ b/test/js/unit/offcanvas.js
@@ -1,0 +1,529 @@
+$(function() {
+    'use strict';
+
+    var doc = document.documentElement;
+    var body = document.body;
+
+    QUnit.module('CFW_Offcanvas', {
+        beforeEach: function() {
+            $(window).scrollTop(0);
+        },
+        afterEach: function() {
+            $('.offcanvas, .offcanvas-backdrop').remove();
+            $('#qunit-fixture').empty();
+            var attributes = ['data-cfw-padding-right', 'style'];
+            attributes.forEach(function(attr) {
+                doc.removeAttribute(attr);
+                body.removeAttribute(attr);
+            });
+        }
+    });
+
+    QUnit.test('should be defined on jquery object', function(assert) {
+        assert.expect(1);
+        assert.ok($(document.body).CFW_Offcanvas, 'CFW_Offcanvas method is defined');
+    });
+
+    QUnit.test('should return jquery collection containing the element', function(assert) {
+        assert.expect(2);
+        var $el = $('<div></div>');
+        var $col = $el.CFW_Offcanvas();
+        assert.ok($col instanceof $, 'returns jquery collection');
+        assert.strictEqual($col[0], $el[0], 'collection contains element');
+    });
+
+    QUnit.test('should add "aria-controls" attribute to trigger on init', function(assert) {
+        assert.expect(1);
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        assert.ok($trigger[0].hasAttribute('aria-controls'));
+    });
+
+    QUnit.test('should add "tabindex" attribute to target on init', function(assert) {
+        assert.expect(1);
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        assert.strictEqual($target.attr('tabindex'), '-1');
+    });
+
+    QUnit.test('should add "in" class to target when offcanvas is shown', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                done();
+            });
+
+        $trigger.CFW_Offcanvas();
+        $trigger.trigger('click');
+    });
+
+    QUnit.test('should add aria attributes to target when offcanvas is shown', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual($target.attr('aria-modal'), 'true');
+                assert.strictEqual($target.attr('role'), 'dialog');
+                done();
+            });
+
+        $trigger.CFW_Offcanvas();
+        $trigger.trigger('click');
+    });
+
+    QUnit.test('should show an offcanvas element (no transition)', function(assert) {
+        assert.expect(1);
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').css('transition', 'none').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        $trigger.CFW_Offcanvas('show');
+        assert.ok($target.hasClass('in'), 'has class "in"');
+    });
+
+    QUnit.test('should show an offcanvas element (with transition)', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').css('transition', '.05s').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                done();
+            });
+        $trigger.CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should hide an offcanvas element (no transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').css('transition', 'none').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                $trigger.CFW_Offcanvas('hide');
+            })
+            .one('afterHide.cfw.offcanvas', function() {
+                assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should hide an offcanvas element (with transition)', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').css('transition', '.05s').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                $trigger.CFW_Offcanvas('hide');
+            })
+            .one('afterHide.cfw.offcanvas', function() {
+                assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should hide offcanvas if dismiss control is clicked', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $target = $('<div id="offcanvas" class="offcanvas">' +
+            '<button id="dismiss" data-cfw-dismiss="offcanvas">Dismiss</button>' +
+            '</div>')
+            .appendTo('#qunit-fixture');
+        var $trigger = $('<button id="dismiss" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Trigger</button>')
+            .appendTo('#qunit-fixture')
+            .CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'offcanvas shown');
+                $('#dismiss').trigger('click');
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                assert.notOk($target.hasClass('in'), 'offcanvas hidden');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should hide offcanvas if esc is pressed', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'offcanvas shown');
+                $target.trigger($.Event('keydown', {
+                    which: 27 // Esc
+                }));
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                assert.notOk($target.hasClass('in'), 'offcanvas hidden');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should not hide offcanvas if esc is pressed with `keyboard: false;`', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            keyboard: false
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'offcanvas shown');
+                $target.trigger($.Event('keydown', {
+                    which: 27 // Esc
+                }));
+                setTimeout(function() {
+                    assert.ok($target.hasClass('in'), 'offcanvas still visible');
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should remove aria attributes from target when offcanvas is hidden', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                $trigger.trigger('click');
+            })
+            .one('afterHide.cfw.offcanvas', function() {
+                assert.notOk($target[0].hasAttribute('aria-modal'));
+                assert.notOk($target[0].hasAttribute('role'));
+                done();
+            });
+
+        $trigger.CFW_Offcanvas();
+        $trigger.trigger('click');
+    });
+
+    QUnit.test('`scroll: true` should allow body scroll', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        body.style.overflow = 'scroll';
+        $trigger.CFW_Offcanvas({
+            scroll: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(window.getComputedStyle(body).overflow, 'scroll');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('`scroll: true` should not allow body scroll', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        body.style.overflow = 'scroll';
+        $trigger.CFW_Offcanvas({
+            scroll: false
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(window.getComputedStyle(body).overflow, 'hidden');
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should hide offcanvas if click on backdrop', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            backdrop: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'offcanvas shown');
+                assert.ok($('.offcanvas-backdrop'), 1, 'offcanvas-backdrop created');
+                $('.offcanvas-backdrop').trigger('mousedown');
+
+                setTimeout(function() {
+                    assert.notOk($target.hasClass('in'));
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('`scroll: false` should auto focus on offcanvas element', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            scroll: false
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(document.activeElement, $target[0]);
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('`scroll: false` should trap focus', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        var $other = $('<a id="other" href="#">Other</a>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            scroll: false
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                $other[0].focus();
+
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, $target[0]);
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('`scroll: true` should not auto focus on offcanvas element', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            scroll: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.notEqual(document.activeElement, $target[0]);
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('`scroll: true` should not trap focus', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            scroll: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                $trigger[0].focus();
+
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, $trigger[0]);
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should deactivate focus trap after hide', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        var $other = $('<a id="other" href="#">Other</a>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(document.activeElement, $target[0]);
+                $trigger.CFW_Offcanvas('hide');
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, $trigger[0]);
+                    $other[0].focus();
+
+                    setTimeout(function() {
+                        assert.strictEqual(document.activeElement, $other[0]);
+                        done();
+                    });
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should return focus to trigger on hide', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(document.activeElement, $target[0]);
+                $trigger.CFW_Offcanvas('hide');
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, $trigger[0]);
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should not return focus to trigger on hide if trigger is not visible', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(document.activeElement, $target[0]);
+                $trigger.css('display', 'none');
+                $trigger.CFW_Offcanvas('hide');
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, body);
+                    done();
+                });
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should not fire afterShow event when beforeShow was prevented', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('beforeShow.cfw.offcanvas', function(e) {
+                e.preventDefault();
+                assert.ok(true, 'beforeShow event fired');
+                done();
+            })
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok(false, 'afterShow event fired');
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('should not fire afterHide event when beforeHide was prevented', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas();
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                $(this).CFW_Offcanvas('hide');
+            })
+            .on('beforeHide.cfw.offcanvas', function(e) {
+                e.preventDefault();
+                assert.ok(true, 'beforeHide event fired');
+                done();
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                assert.ok(false, 'afterHide event fired');
+            })
+            .CFW_Offcanvas('show');
+    });
+
+    QUnit.test('does not prevent toggle when using input as trigger', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<input data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas" value="Offcanvas"></input>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+
+        $trigger
+            .one('afterShow.cfw.offcanvas', function() {
+                assert.ok($target.hasClass('in'), 'has class "in"');
+                done();
+            });
+
+        $trigger.CFW_Offcanvas();
+        $trigger.trigger('click');
+    });
+
+    QUnit.test('should not toggle on disabled element trigger', function(assert) {
+        assert.expect(1);
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas" disabled>Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+
+        $trigger.CFW_Offcanvas();
+        $trigger.trigger('click');
+        assert.notOk($target.hasClass('in'), 'has class "in"');
+    });
+
+    QUnit.test('should hide other open offcanvas if open when toggle is called', function(assert) {
+        assert.expect(3);
+        var done = assert.async();
+        var $trigger1 = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas1">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target1 = $('<div id="offcanvas1" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        var $trigger2 = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas2">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target2 = $('<div id="offcanvas2" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger1.CFW_Offcanvas();
+        $trigger2.CFW_Offcanvas();
+
+        $trigger2
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target2.hasClass('in'), 'offcanvas2 shown');
+                done();
+            });
+
+        $trigger1
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.ok($target1.hasClass('in'), 'offcanvas1 shown');
+                $trigger2.trigger('click');
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                assert.notOk($target1.hasClass('in'), 'offcanvas1 hidden');
+            })
+            .CFW_Offcanvas('show');
+    });
+});

--- a/test/visual/dropdown.html
+++ b/test/visual/dropdown.html
@@ -21,6 +21,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>

--- a/test/visual/equalize.html
+++ b/test/visual/equalize.html
@@ -21,6 +21,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -21,6 +21,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>

--- a/test/visual/navbar.html
+++ b/test/visual/navbar.html
@@ -22,6 +22,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>

--- a/test/visual/offcanvas.html
+++ b/test/visual/offcanvas.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>Figuration - Offcanvas</title>
+
+<link type="text/css" rel="stylesheet" href="../../dist/css/figuration.css">
+
+<script src="../../node_modules/jquery/dist/jquery.slim.min.js"></script>
+<script src="../../node_modules/popper.js/dist/umd/popper.min.js"></script>
+<script src="../../js/util/backdrop.js"></script>
+<script src="../../js/util/focuser.js"></script>
+<script src="../../js/util/scrollbar.js"></script>
+<script src="../../js/util.js"></script>
+<script src="../../js/drag.js"></script>
+<script src="../../js/collapse.js"></script>
+<script src="../../js/dropdown.js"></script>
+<script src="../../js/tab.js"></script>
+<script src="../../js/affix.js"></script>
+<script src="../../js/tooltip.js"></script>
+<script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
+<script src="../../js/modal.js"></script>
+<script src="../../js/tab-responsive.js"></script>
+<script src="../../js/accordion.js"></script>
+<script src="../../js/slideshow.js"></script>
+<script src="../../js/scrollspy.js"></script>
+<script src="../../js/alert.js"></script>
+<script src="../../js/lazy.js"></script>
+<script src="../../js/equalize.js"></script>
+<script src="../../js/common.js"></script>
+
+<style>
+body {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+}
+.example-offcanvas .offcanvas {
+    position: static;
+    height: 200px;
+    visibility: visible;
+    transform: translate(0);
+}
+</style>
+
+</head>
+<body>
+
+<div class="container">
+
+<div class="example-offcanvas mt-1 bg-light border overflow-hidden">
+    <div class="offcanvas offcanvas-start">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title">Offcanvas</h5>
+            <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+        <div class="offcanvas-body">
+            Content for the offcanvas goes here. You can place just about any component or custom element here.
+        </div>
+        <div class="offcanvas-footer">
+            Offcanvas footer
+        </div>
+    </div>
+</div>
+
+<hr>
+
+<a class="btn btn-primary" data-cfw="offcanvas" href="#offcanvasEx-0" role="button">
+  Link with href
+</a>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasEx-1">
+  Button with data-*-target
+</button>
+
+<div id="offcanvasEx-0"  class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Offcanvas</h5>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    <div>
+      Some text as placeholder. In real life you can have the elements you have chosen. Like, text, images, lists, etc.
+    </div>
+    <div class="dropdown mt-1">
+      <button class="btn btn-secondary" type="button" data-cfw="dropdown">
+        Dropdown button
+        <span class="caret aria-hidden="true"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">Action</a></li>
+        <li><a class="dropdown-item" href="#">Another action</a></li>
+        <li><a class="dropdown-item" href="#">Something else here</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<div id="offcanvasEx-1"  class="offcanvas offcanvas-start">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">Offcanvas</h5>
+    <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+  </div>
+  <div class="offcanvas-body">
+    <div>
+      Some text as placeholder. In real life you can have the elements you have chosen. Like, text, images, lists, etc.
+    </div>
+    <div class="dropdown mt-1">
+      <button class="btn btn-secondary" type="button" data-cfw="dropdown">
+        Dropdown button
+        <span class="caret aria-hidden="true"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">Action</a></li>
+        <li><a class="dropdown-item" href="#">Another action</a></li>
+        <li><a class="dropdown-item" href="#">Something else here</a></li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<hr>
+
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasDirS">Placement: start</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasDirE">Placement: end</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasDirT">Placement: top</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasDirB">Placement: bottom</button>
+
+<div id="offcanvasDirS" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas start</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+<div id="offcanvasDirE" class="offcanvas offcanvas-end">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas end</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+<div id="offcanvasDirT" class="offcanvas offcanvas-top">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas top</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+<div id="offcanvasDirB" class="offcanvas offcanvas-bottom">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas bottom</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+
+<hr>
+
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasBack" data-cfw-offcanvas-backdrop="true" data-cfw-offcanvas-scroll="false">backdrop: true, scroll false (default)</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasScroll"  data-cfw-offcanvas-backdrop="false" data-cfw-offcanvas-scroll="true">backdrop: false, scroll true</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasBackScroll"  data-cfw-offcanvas-backdrop="true" data-cfw-offcanvas-scroll="true">backdrop: true, scroll true</button>
+
+<div id="offcanvasBack" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas backdrop</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+<div id="offcanvasScroll" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas scroll</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+<div id="offcanvasBackScroll" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas backdrop and scroll</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+
+<hr>
+
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasAnim"  data-cfw-offcanvas-animate="false">animate: false</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasKbd"  data-cfw-offcanvas-keyboard="false">keyboard: false</button>
+<button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasDismiss"  data-cfw-offcanvas-keyboard="false">dismiss button</button>
+
+<div id="offcanvasAnim" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+
+<div id="offcanvasKbd" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+
+<div id="offcanvasDismiss" class="offcanvas offcanvas-start">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas title</h5>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+    <div class="offcanvas-footer">
+        <button type="button" class="btn btn-secondary" data-cfw-dismiss="offcanvas">Close</button>
+    </div>
+</div>
+
+<hr>
+
+<div id="offcanvasEx-2-container" class="mt-1 bg-light border overflow-hidden position-relative" style="height: 200px; z-index: 1;">
+    <div id="offcanvasEx-2" class="offcanvas offcanvas-start">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title">Offcanvas</h5>
+            <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        </div>
+        <div class="offcanvas-body">
+            Content for the offcanvas goes here. You can place just about any component or custom element here.
+        </div>
+        <div class="offcanvas-footer">
+            Offcanvas footer
+        </div>
+    </div>
+    <button class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasEx-2" data-cfw-offcanvas-root-element="#offcanvasEx-2-container">
+        Offcanvas in container
+    </button>
+</div>
+
+<!------------------->
+
+<nav class="navbar navbar-light bg-light fixed-top">
+  <div class="container-fluid flex-between">
+    <a class="navbar-brand" href="#">Offcanvas navbar</a>
+    <button class="navbar-toggle" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasNavbarTop">
+        <span aria-hidden="true">&#8801;</span>
+    </button>
+    <div id="offcanvasNavbarTop" class="offcanvas offcanvas-end">
+      <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas top</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="navbar-nav flex-end flex-grow-1 pe-1">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link" href="#" role="button" data-cfw="dropdown">
+              Dropdown
+              <span class="caret aria-hidden="true"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="d-flex" role="search">
+          <input class="form-control me-0_5" type="search" placeholder="Search" aria-label="Search">
+          <button class="btn btn-outline-success" type="submit">Search</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</nav>
+
+<nav class="navbar navbar-light navbar-expand-lg bg-light fixed-bottom">
+  <div class="container-fluid flex-between">
+    <a class="navbar-brand" href="#">Offcanvas navbar 'lg'</a>
+    <button class="navbar-toggle" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasNavbarBottom">
+        <span aria-hidden="true">&#8801;</span>
+    </button>
+    <div id="offcanvasNavbarBottom" class="offcanvas offcanvas-end">
+      <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Offcanvas bottom</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="navbar-nav flex-end flex-grow-1 pe-1">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">Home</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Link</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link" href="#" role="button" data-cfw="dropdown">
+              Dropdown
+              <span class="caret aria-hidden="true"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="d-flex" role="search">
+          <input class="form-control me-0_5" type="search" placeholder="Search" aria-label="Search">
+          <button class="btn btn-outline-success" type="submit">Search</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</nav>
+
+
+</div>
+
+</body>
+</html>

--- a/test/visual/scrollspy.html
+++ b/test/visual/scrollspy.html
@@ -21,6 +21,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>

--- a/test/visual/tooltip.html
+++ b/test/visual/tooltip.html
@@ -21,6 +21,7 @@
 <script src="../../js/affix.js"></script>
 <script src="../../js/tooltip.js"></script>
 <script src="../../js/popover.js"></script>
+<script src="../../js/offcanvas.js"></script>
 <script src="../../js/modal.js"></script>
 <script src="../../js/tab-responsive.js"></script>
 <script src="../../js/accordion.js"></script>


### PR DESCRIPTION
The breakout of backdrop, focuser, and scrollbar allow us to add this feature without replicating most of the functionality of modals in this "new" component.  Similar to the side-aligned modals, there a few slight differences in functionality, such as the responsive drawer capabilities when contained within a navbar.

Made some alterations and additions to the z-index values to put offcanvas items below tooltips, popover, and modals, but above fixed/sticky items.  The z-index values for tooltips, popovers, modal-backdrop, and modal were all increased slightly.

Also fixed a few other things while forging ahead with this:
-  some doc issues with an included markdown file
- focus issue with Tooltip/Popovers
- rootElement option in Modals
