### PR TITLE
Modal/Offcanvs: Add `manual` option

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -35,6 +35,7 @@
         dispose      : false,   // If on hide to unlink, then remove modal from DOM
         backdrop     : true,    // Show backdrop, or 'static' for no close on click
         keyboard     : true,    // Close modal on ESC press
+        manual       : false,   // If modal should trigger manually (programatically)
         show         : false,   // Show modal afer initialize
         focus        : true,    // Keep focus within the modal dialog
         rootElement  : 'body'
@@ -84,7 +85,9 @@
             });
 
             // Bind click handler
-            this.$element.on('click.cfw.modal', this.toggle.bind(this));
+            if (!this.settings.manual) {
+                this.$element.on('click.cfw.modal', this.toggle.bind(this));
+            }
 
             this.$target.data('cfw.modal', this);
 
@@ -256,7 +259,9 @@
                 .CFW_mutationIgnore()
                 .css('display', 'none');
 
-            this.$element.trigger('focus');
+            if (!this.settings.manual) {
+                this.$element.trigger('focus');
+            }
 
             this.backdrop(function() {
                 $selfRef.$rootElement.removeClass('modal-open');

--- a/js/offcanvas.js
+++ b/js/offcanvas.js
@@ -33,6 +33,7 @@
         keyboard     : true,    // Close offcanvas on ESC press
         scroll       : false,   // Allow rootElement to scroll
         focus        : true,    // Keep focus within the offcanvas element
+        manual       : false,   // If offcanvas should trigger manually (programatically)
         rootElement  : 'body'
     };
 
@@ -70,7 +71,11 @@
             this.$target.attr('tabindex', -1);
 
             // Bind click handler
-            this.$element.on('click.cfw.offcanvas', this.toggle.bind(this));
+            if (!this.settings.manual) {
+                this.$element.on('click.cfw.offcanvas', this.toggle.bind(this));
+            }
+
+            this.$target.data('cfw.offcanvas', this);
 
             this.$element.CFW_trigger('init.cfw.offcanvas');
         },
@@ -138,6 +143,8 @@
                 $selfRef.$element.CFW_trigger('afterShow.cfw.offcanvas');
             };
 
+            this.$target.data('cfw.offcanvas', this);
+
             this.$target.CFW_transition(null, complete);
         },
 
@@ -175,7 +182,7 @@
 
                 $selfRef.$element.CFW_trigger('afterHide.cfw.offcanvas');
 
-                if ($.CFW_isVisible($selfRef.$element)) {
+                if ($.CFW_isVisible($selfRef.$element) && !$selfRef.settings.manual) {
                     $selfRef.$element.trigger('focus');
                 }
             };

--- a/site/4.2/widgets/modal.md
+++ b/site/4.2/widgets/modal.md
@@ -1373,6 +1373,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td><code>false</code></td>
         <td>Shows the modal when initialized.</td>
       </tr>
+      <tr>
+        <td><code>manual</code></td>
+        <td>boolean</td>
+        <td><code>false</code></td>
+        <td>If the modal should be triggered manually through method calls, not from clicking the trigger element.  Closing a manual modal will not autoamatically return focus to the trigger item when the modal is hidden.</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/site/4.2/widgets/offcanvas.md
+++ b/site/4.2/widgets/offcanvas.md
@@ -367,6 +367,12 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
         <td><code>true</code></td>
         <td>Enforce focus when using keyboard navigation to remain within the offcanvas dialog.</td>
       </tr>
+      <tr>
+        <td><code>manual</code></td>
+        <td>boolean</td>
+        <td><code>false</code></td>
+        <td>If the offcanvas should be triggered manually through method calls, not from clicking the trigger element.  Closing a manual offcanvas will not autoamatically return focus to the trigger item when the offcanvas is hidden.</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/test/js/unit/modal.js
+++ b/test/js/unit/modal.js
@@ -790,4 +790,77 @@ $(function() {
         });
         $trigger.CFW_Modal('show');
     });
+
+    QUnit.test('manual=true option should not add click toggle to trigger', function(assert) {
+        assert.expect(1);
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"><button class="close" data-cfw-dismiss="modal"></button></div>').appendTo(document.body);
+
+        $trigger
+            .CFW_Modal({
+                manual: true
+            })
+            .trigger('focus')
+            .trigger('click');
+
+        assert.notOk($target.hasClass('in'), 'modal visible');
+    });
+
+
+    QUnit.test('manual=true should still enforce focus by default', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"><button class="close" data-cfw-dismiss="modal"></button></div>').appendTo(document.body);
+        var $close = $('.close');
+
+        $target.one('afterShow.cfw.modal', function() {
+            setTimeout(function() {
+                $target.one('focusin', function() {
+                    setTimeout(function() {
+                        assert.strictEqual(document.activeElement, $close[0], 'focused moved inside modal');
+                        done();
+                    });
+                });
+                assert.strictEqual(document.activeElement, $target[0], 'modal is focused');
+                $trigger.trigger('focusin');
+            });
+        });
+
+        $trigger
+            .CFW_Modal({
+                manual: true
+            })
+            .CFW_Modal('show');
+    });
+
+    QUnit.test('manual=true should not return focus to trigger on close', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+
+        var $trigger = $('<button type="button" class="btn" data-cfw="modal" data-cfw-modal-target="#modal">Modal</button>').appendTo('#qunit-fixture');
+        var $target = $('<div class="modal" id="modal"><button class="close" data-cfw-dismiss="modal"></button></div>').appendTo(document.body);
+        var $close = $('.close');
+
+        $target.one('afterShow.cfw.modal', function() {
+            setTimeout(function() {
+                assert.strictEqual(document.activeElement, $target[0], 'modal is focused');
+                $close.trigger('click');
+            });
+        });
+        $target.one('afterHide.cfw.modal', function() {
+            setTimeout(function() {
+                assert.notEqual(document.activeElement, $trigger[0], 'trigger is not focused');
+                done();
+            });
+        });
+
+        $trigger
+            .CFW_Modal({
+                manual: true
+            })
+            .CFW_Modal('show');
+    });
 });

--- a/test/js/unit/offcanvas.js
+++ b/test/js/unit/offcanvas.js
@@ -550,4 +550,62 @@ $(function() {
             })
             .CFW_Offcanvas('show');
     });
+
+    QUnit.test('`manual: true` should not add click toggle to trigger', function(assert) {
+        assert.expect(1);
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger
+            .CFW_Offcanvas({
+                manual: true
+            })
+            .trigger('focus')
+            .trigger('click');
+
+        assert.ok(!$target.hasClass('in'), 'does not have class "in"');
+    });
+
+    QUnit.test('`manual: true` should still auto focus on offcanvas element', function(assert) {
+        assert.expect(1);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            manual: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                assert.strictEqual(document.activeElement, $target[0]);
+                done();
+            })
+            .CFW_Offcanvas('show');
+    });
+
+
+    QUnit.test('`manual: true` should not return focus to trigger on close', function(assert) {
+        assert.expect(2);
+        var done = assert.async();
+        var $trigger = $('<button data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvas">Offcanvas</button>').appendTo('#qunit-fixture');
+        var $target = $('<div id="offcanvas" class="offcanvas"></div>').appendTo('#qunit-fixture');
+        $trigger.CFW_Offcanvas({
+            manual: true
+        });
+
+        $trigger
+            .on('afterShow.cfw.offcanvas', function() {
+                setTimeout(function() {
+                    assert.strictEqual(document.activeElement, $target[0], 'offcanvas is focused');
+                    $trigger.CFW_Offcanvas('hide');
+                });
+            })
+            .on('afterHide.cfw.offcanvas', function() {
+                setTimeout(function() {
+                    assert.notEqual(document.activeElement, $trigger[0], 'trigger is not focused');
+                    done();
+                });
+            });
+
+        $trigger.CFW_Offcanvas('show');
+    });
 });

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -538,12 +538,14 @@
 </div>
 
 <!-- Modal chained example -->
-<button type="button" class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalChained1">Modal chained example</button>
+<p>
+    <button type="button" class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalChained1">Modal chained example</button>
+</p>
 <div class="modal" id="modalChained1">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <div class="modal-title">First chained modal</div>
+        <h4 class="modal-title">First chained modal</h4>
         <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       </div>
       <div class="modal-body">
@@ -559,7 +561,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <div class="modal-title">Second chained modal</div>
+        <h4 class="modal-title">Second chained modal</h4>
         <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
       </div>
       <div class="modal-body">
@@ -567,6 +569,28 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" onclick="$('#modalChained2').CFW_Modal('chain', '#modalChained1');">Open First chained modal</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Manual modal example -->
+<p>
+    <button type="button" class="btn btn-primary" data-cfw="modal" data-cfw-modal-target="#modalManual" data-cfw-modal-manual="true">Manual modal</button>
+    <button type="button" class="btn btn-link" onclick="$('#modalManual').CFW_Modal('show'); return false;">show</button>
+</p>
+<div class="modal" id="modalManual">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Manual modal</h4>
+        <button type="button" class="close" data-cfw-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      </div>
+      <div class="modal-body">
+        This is a modal body.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" onclick="$('#modalManual').CFW_Modal('hide'); return false;">Hide</button>
       </div>
     </div>
   </div>

--- a/test/visual/offcanvas.html
+++ b/test/visual/offcanvas.html
@@ -248,6 +248,22 @@ body {
 
 <hr>
 
+<button id="offcanvasManualBtn" class="btn btn-primary" type="button" data-cfw="offcanvas" data-cfw-offcanvas-target="#offcanvasManual"  data-cfw-offcanvas-manual="true" data-cfw-offcanvas-backdrop="false">manual: true</button>
+<button class="btn btn-link" type="button" onclick="$('#offcanvasManualBtn').CFW_Offcanvas('show'); return false;">show</button>
+<button class="btn btn-link" type="button" onclick="$('#offcanvasManualBtn').CFW_Offcanvas('hide'); return false;">hide</button>
+
+<div id="offcanvasManual" class="offcanvas offcanvas-end">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title">Manual offcanvas</h5>
+        <button type="button" class="close" data-cfw-dismiss="offcanvas" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    </div>
+    <div class="offcanvas-body">
+        Offcanvas content
+    </div>
+</div>
+
+<hr>
+
 <div id="offcanvasEx-2-container" class="mt-1 bg-light border overflow-hidden position-relative" style="height: 200px; z-index: 1;">
     <div id="offcanvasEx-2" class="offcanvas offcanvas-start">
         <div class="offcanvas-header">


### PR DESCRIPTION
Add `manual` option to both Modal and Offcanvas widgets. What this does:
- trigger element does not get toggle click handler attached
- focus is moved into dialog on show where appropriate
- focus is not moved to trigger on close of the dialog

Does not prevent you from adding your own click handler to the trigger item to show the dialog.