### PR TITLE
Add `.sticky-bottom` positioning utility class

### DIFF
--- a/js/util/scrollbar.js
+++ b/js/util/scrollbar.js
@@ -9,7 +9,7 @@
     'use strict';
 
     var SELECTOR_CONTENT_FIXED = '.fixed-top, .fixed-bottom, .is-fixed';
-    var SELECTOR_CONTENT_STICKY = '.sticky-top, .is-sticky';
+    var SELECTOR_CONTENT_STICKY = '.sticky-top, .sticky-bottom, .is-sticky';
     var SELECTOR_CONTENT_SHARED = [SELECTOR_CONTENT_FIXED, SELECTOR_CONTENT_STICKY].join(', ');
 
     var CFW_Util_Scrollbar = function(options) {

--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -300,6 +300,8 @@ $enable-utility-position-fixed-top:         true !default;
 $enable-utility-position-fixed-bottom:      true !default;
 $enable-utility-position-sticky-top:        true !default;
 $enable-utility-position-sticky-top-responsive: true !default;
+$enable-utility-position-sticky-bottom:     true !default;
+$enable-utility-position-sticky-bottom-responsive: true !default;
 $enable-utility-position-placement:         true !default;
 $enable-utility-position-translate:         true !default;
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -286,6 +286,7 @@ $utility-flex-breakpoints:          map-keys($grid-breakpoints) !default;
 $utility-float-breakpoints:         map-keys($grid-breakpoints) !default;
 $utility-position-breakpoints:      map-keys($grid-breakpoints) !default;
 $utility-sticky-top-breakpoints:    map-keys($grid-breakpoints) !default;
+$utility-sticky-bottom-breakpoints: map-keys($grid-breakpoints) !default;
 $utility-placement-breakpoints:     "xs" !default;
 $utility-translate-breakpoints:     "xs" !default;
 $utility-screen-reader-breakpoints: map-keys($grid-breakpoints) !default;

--- a/scss/utilities/_position.scss
+++ b/scss/utilities/_position.scss
@@ -59,6 +59,33 @@
         }
     }
 
+    @if $enable-utility-position-sticky-bottom {
+        @supports (position: sticky) {
+            .sticky-bottom {
+                position: sticky;
+                bottom: 0;
+                z-index: $zindex-sticky;
+            }
+
+            @if $enable-utility-position-sticky-bottom-responsive {
+                @each $bp in $utility-sticky-bottom-breakpoints {
+                    // Skip smallest breakpoint for up (equivalent to `.sticky-bottom`)
+                    @if breakpoint-min($bp, $grid-breakpoints) != null {
+                        $bprule: breakpoint-designator($bp);
+
+                        @include media-breakpoint-up($bp) {
+                            .sticky#{$bprule}-bottom {
+                                position: sticky;
+                                bottom: 0;
+                                z-index: $zindex-sticky;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     @if $enable-utility-position-placement {
         @each $bp in $utility-placement-breakpoints {
             $bprule: breakpoint-designator($bp);

--- a/site/4.2/utilities/position.md
+++ b/site/4.2/utilities/position.md
@@ -41,7 +41,7 @@ Position an element at the bottom of the viewport, from edge to edge.
 
 ## Sticky Top
 
-Position an element at the top of the viewport, from edge to edge, but only after you scroll past it.
+Position an element at the top of the viewport, or container, from edge to edge, but only after you scroll past it.
 This sticky utility uses CSS's `position: sticky`, which isn't fully supported in all browsers.  Additional support information can be found at [Can I Use - CSS position:sticky](https://caniuse.com/css-sticky).
 
 **IE11 and IE10 will render `position: sticky` as `position: relative`.** As such, we wrap the styles in a `@supports` query, limiting the stickiness to only browsers that can render it properly.
@@ -51,7 +51,7 @@ This sticky utility uses CSS's `position: sticky`, which isn't fully supported i
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
-## Responsive Sticky Top
+### Responsive Sticky Top
 
 Responsive variations also exist for `.sticky-top` utility.
 
@@ -60,6 +60,27 @@ Responsive variations also exist for `.sticky-top` utility.
 <div class="sticky-md-top">Stick to the top on viewports sized MD (medium) or wider</div>
 <div class="sticky-lg-top">Stick to the top on viewports sized LG (large) or wider</div>
 <div class="sticky-xl-top">Stick to the top on viewports sized XL (extra-large) or wider</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+## Sticky Bottom
+
+Position an element at the bottom of the viewport, or container, from edge to edge, but only until you scroll past it.
+
+{% capture highlight %}
+<div class="sticky-bottom">...</div>
+{% endcapture %}
+{% renderHighlight highlight, "html" %}
+
+### Responsive Sticky Bottom
+
+Responsive variations also exist for `.sticky-bottom` utility.
+
+{% capture highlight %}
+<div class="sticky-sm-bottom">Stick to the bottom on viewports sized SM (small) or wider</div>
+<div class="sticky-md-bottom">Stick to the bottom on viewports sized MD (medium) or wider</div>
+<div class="sticky-lg-bottom">Stick to the bottom on viewports sized LG (large) or wider</div>
+<div class="sticky-xl-bottom">Stick to the bottom on viewports sized XL (extra-large) or wider</div>
 {% endcapture %}
 {% renderHighlight highlight, "html" %}
 
@@ -224,6 +245,23 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$enable-utility-position-sticky-bottom</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the sticky bottom position utility class.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$enable-utility-position-sticky-bottom-responsive</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the additional responsive sticky bottom position utility class.
+          <code>$enable-utility-position-sticky-bottom</code> needs to be <code>true</code> for this setting be be observed.
+        </td>
+      </tr>
+      <tr>
         <td><code>$enable-utility-position-placement</code></td>
         <td>boolean</td>
         <td><code>true</code></td>
@@ -253,6 +291,14 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         <td><code>map-keys($grid-breakpoints)</code></td>
         <td>
           Map of breakpoints that will be used to generate responsive sticky-top utilities.
+        </td>
+      </tr>
+      <tr>
+        <td><code>$utility-sticky-bottom-breakpoints</code></td>
+        <td>string</td>
+        <td><code>map-keys($grid-breakpoints)</code></td>
+        <td>
+          Map of breakpoints that will be used to generate responsive sticky-bottom utilities.
         </td>
       </tr>
       <tr>

--- a/site/4.2/widgets/modal.md
+++ b/site/4.2/widgets/modal.md
@@ -1297,7 +1297,7 @@ Since the scrollbar is removed from the `<body>` when a modal is shown, there ca
 
 The scrollbar handler will attempt to adjust padding values, and margin for sticky elements, to mitigate the content shift.  These values will then be reset when the modal dialog is closed.
 
-Some [positioning utility]({{ site.path }}/{{ version.docs }}/utilities/position/) classes (`.fixed-top`, `.fixed-bottom`, and `.sticky-top`) are automatically handled.  For respsonsive or custom positioned items, there additional `.is-fixed` and `.is-sticky` helper classes can be added to an element to trigger the scrollbar handler to adjust for the shift.  The scrollbar handler will check the computed style on any item with these classes, and only adjust when neccessary.
+Some [positioning utility]({{ site.path }}/{{ version.docs }}/utilities/position/) classes (`.fixed-top`, `.fixed-bottom`, `.sticky-top`, and `.sticky-bottom`) are automatically handled.  For respsonsive or custom positioned items, there additional `.is-fixed` and `.is-sticky` helper classes can be added to an element to trigger the scrollbar handler to adjust for the shift.  The scrollbar handler will check the computed style on any item with these classes, and only adjust when neccessary.
 
 Custom positioned elements using translation to modify their position may not be handled correctly, so a custom solution may be needed.
 

--- a/site/4.2/widgets/offcanvas.md
+++ b/site/4.2/widgets/offcanvas.md
@@ -301,11 +301,16 @@ $('#myOffcanvas').CFW_Offcanvas();
 
 Any an element with a data attribute of `data-cfw-dismiss="offcanvas"` within the offcanvas element will act as a close trigger for the offcanvas.  There can be multiple close triggers, such as a header/titlebar close and a cancel button in the footer.
 
-### With Fixed Position Content
+### With Positioned Content
 
-When the scrollbar is removed from the `<body>` when an offcanvas is shown, there can be some shifting of content in fixed position elements.  To help with this issue, when an offcanvas is shown, any elements using the [fixed positioning utility]({{ site.path }}/{{ version.docs }}/utilities/position/) classes, (`.fixed-top` and `.fixed-bottom`), will have additional padding added to their right side.  This padding width should match the width of the scrollbar that becomes hidden.  When the offcanvas is hidden, the `padding-right` CSS value will be reset.
+Since the scrollbar is removed from the `<body>` when an offcanvas is shown, there can be some shifting of content in fixed or sticky positioned elements.
 
-There is also an additional special classname that the offcanvas widget will look for when adjusting padding values.  Simply add the `.is-fixed` class to your element, and it will automatically be handled.
+The scrollbar handler will attempt to adjust padding values, and margin for sticky elements, to mitigate the content shift.  These values will then be reset when the offcanvas dialog is closed.
+
+Some [positioning utility]({{ site.path }}/{{ version.docs }}/utilities/position/) classes (`.fixed-top`, `.fixed-bottom`, `.sticky-top`, and `.sticky-bottom`) are automatically handled.  For respsonsive or custom positioned items, there additional `.is-fixed` and `.is-sticky` helper classes can be added to an element to trigger the scrollbar handler to adjust for the shift.  The scrollbar handler will check the computed style on any item with these classes, and only adjust when neccessary.
+
+Custom positioned elements using translation to modify their position may not be handled correctly, so a custom solution may be needed.
+
 
 ### Options
 
@@ -773,7 +778,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         <td>string</td>
         <td><code>$offcanvas-header-border-width</code></td>
         <td>
-          Border width for modal footer.
+          Border width for offcanvas footer.
         </td>
       </tr>
       <tr>

--- a/test/visual/modal.html
+++ b/test/visual/modal.html
@@ -63,7 +63,7 @@
 
 <!-- `.sticky top` should not shift since it is not full width -->
 <div class="container sticky-top">
-	<nav class="navbar navbar-dark bg-dark">
+	<nav class="navbar navbar-dark bg-dark text-light">
 		<a class="navbar-brand" href="#">Sticky top</a> - no shift
 	</nav>
 </div>
@@ -703,6 +703,13 @@
   <button type="button" class="btn btn-primary mt-3" data-cfw="modal" data-cfw-modal-target="#modal-root-scroll" data-cfw-modal-root-element="#another-element">
     Show contained side aligned, scrollable modal
   </button>
+</div>
+
+<div class="sticky-bottom bg-dark text-light" style="z-index: 1020; bottom: 3.125rem;">
+    <div class="d-flex  flex-between p-1">
+        <span>Sticky bottom</span>
+        <span>Sticky bottom</span>
+    </div>
 </div>
 
 <p>Vivamus sollicitudin porttitor nisl, sed tempor leo. Maecenas ut rhoncus nisi. Morbi ut bibendum est. Donec tincidunt nec tellus a egestas. Donec id tortor elementum, aliquet magna euismod, commodo felis. Sed a nulla viverra, malesuada nisi a, fringilla velit. Donec justo felis, cursus eu justo ac, vehicula consequat mauris. Duis a interdum lectus, eu dictum nibh. Cras ligula velit, vehicula et luctus a, cursus quis sapien. Aenean a molestie libero. Nam congue ultrices turpis, sed tempus arcu malesuada sit amet. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam eu ligula eleifend, rutrum purus id, pharetra enim. Pellentesque a posuere ex, ac egestas quam. Etiam lobortis massa at elementum consectetur. Nullam tempor orci quis ligula eleifend auctor.</p>


### PR DESCRIPTION
Also adds responsive variants.

Scrollbar JS helper will also handle  `.sticky-bottom` by default.