### PR TITLE
Forms: Add `.form-check-reverse` modifier

### DIFF
--- a/scss/_settings-options.scss
+++ b/scss/_settings-options.scss
@@ -72,6 +72,7 @@ $enable-form-text:                          true !default;
 $enable-form-check:                         true !default;
 $enable-form-check-checkradio:              true !default;
 $enable-form-check-switch:                  true !default;
+$enable-form-check-reverse:                 true !default;
 $enable-form-file:                          true !default;
 $enable-form-file-sizing:                   true !default;
 $enable-form-range:                         true !default;

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -820,6 +820,8 @@ $input-placeholder-color:       #999 !default;
 
 $input-static-color:            $body-color !default;
 
+$input-checkradio-size:         .875rem !default;
+
 $form-label-font-weight:        $font-weight-normal !default;
 
 $form-text-margin-top:          .25rem !default;

--- a/scss/core/_reboot.scss
+++ b/scss/core/_reboot.scss
@@ -413,10 +413,15 @@ button,
     border-style: none;
 }
 
+// 1. Add the correct box sizing in IE 10-
+// 2. Opinionated normalize of dimensions across browsers
+// 3. Remove the padding in IE 10-
 input[type="radio"],
 input[type="checkbox"] {
-    box-sizing: border-box; // 1. Add the correct box sizing in IE 10-
-    padding: 0; // 2. Remove the padding in IE 10-
+    box-sizing: border-box; // 1
+    width: $input-checkradio-size; // 2
+    height: $input-checkradio-size; // 2
+    padding: 0; // 3
 }
 
 textarea {

--- a/scss/forms/_form-check.scss
+++ b/scss/forms/_form-check.scss
@@ -30,6 +30,23 @@
             }
         }
 
+        @if $enable-form-check-reverse {
+            .form-check-reverse {
+                &.form-check {
+                    padding-right: $form-check-gutter;
+                    padding-left: 0;
+                    text-align: right;
+
+                    > input {
+                        float: right;
+                        margin-top: subtract(if(unit($line-height-base) == "", $line-height-base * .5em, $line-height-base * .5), $input-checkradio-size * .5);
+                        margin-right: -$form-check-gutter;
+                        margin-left: 0;
+                    }
+                }
+            }
+        }
+
         .form-check-label {
             display: inline;
             margin-bottom: 0; // Override default `<label>` bottom margin
@@ -144,6 +161,28 @@
                 }
             }
         }
+
+        @if $enable-form-check-reverse {
+            .form-check-reverse {
+                &.form-checkradio {
+                    padding-right: $form-checkradio-gutter;
+                    padding-left: 0;
+
+                    .form-check-input {
+                        margin-right: -$form-checkradio-gutter;
+                        margin-left: 0;
+                    }
+
+                    .form-check-label {
+                        &::before {
+                            float: right;
+                            margin-right: -$form-checkradio-gutter;
+                            margin-left: 0;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // Switch
@@ -246,6 +285,41 @@
                 }
                 &::after {
                     @include box-shadow($form-switch-thumb-checked-box-shadow, $form-switch-thumb-focus-box-shadow);
+                }
+            }
+        }
+
+        @if $enable-form-check-reverse {
+            .form-check-reverse {
+                &.form-switch {
+                    padding-right: $form-switch-gutter;
+                    padding-left: 0;
+
+                    .form-check-input {
+                        right: 0;
+                        left: auto;
+                    }
+
+                    .form-check-label {
+                        // Track
+                        &::before {
+                            right: 0;
+                            left: auto;
+                        }
+
+                        // Thumb
+                        &::after {
+                            right: subtract($form-switch-width, add($form-switch-thumb-width, $form-switch-thumb-offset, false));
+                            left: auto;
+                        }
+                    }
+
+                    .form-check-input:checked ~ .form-check-label {
+                        &::after {
+                            right: $form-switch-thumb-offset;
+                            left: auto;
+                        }
+                    }
                 }
             }
         }

--- a/site/4.2/content/forms.md
+++ b/site/4.2/content/forms.md
@@ -605,6 +605,51 @@ You can also set a `font-size` on the `.form-check` container, then reset `font-
 {% endcapture %}
 {% renderExample example %}
 
+### Reverse
+
+Put your checkboxes, radios, and switches on the opposite side with the `.form-check-reverse` modifier class. Also works with default checkbox and radio inputs using the `.form-check` markup.
+
+{% capture example %}
+<div class="form-group">
+  <div class="form-check form-check-reverse">
+    <input class="form-check-input" type="checkbox" value="" id="reverseCheck0">
+    <label class="form-check-label" for="reverseCheck0">Reverse default checkbox</label>
+  </div>
+  <div class="form-check form-checkradio form-check-reverse">
+    <input class="form-check-input" type="checkbox" value="" id="reverseCheck1">
+    <label class="form-check-label" for="reverseCheck1">Reverse custom checkbox</label>
+    <small class="text-muted d-block">Some additional help text could appear right here.</small>
+  </div>
+</div>
+
+<div class="form-group">
+  <div class="form-check form-check-reverse">
+    <input class="form-check-input" type="radio" name="reverseRadio" value="" id="reverseRadio0">
+    <label class="form-check-label" for="reverseRadio0">Reverse default radio</label>
+  </div>
+  <div class="form-check form-checkradio form-check-reverse">
+    <input class="form-check-input" type="radio" name="reverseRadio" value="" id="reverseRadio1">
+    <label class="form-check-label" for="reverseRadio1">Reverse custom radio</label>
+  </div>
+</div>
+
+<div class="form-group">
+  <div class="form-check form-switch form-check-reverse">
+    <input class="form-check-input" type="checkbox" value="" id="reverseSwitch0">
+    <label class="form-check-label" for="reverseSwitch0">Reverse switch checkbox</label>
+  </div>
+  <div class="form-check form-switch form-check-reverse">
+    <input class="form-check-input" type="radio" name="reverseSwitch" value="" id="reverseSwitch1" checked>
+    <label class="form-check-label" for="reverseSwitch1">Reverse switch radio</label>
+  </div>
+  <div class="form-check form-switch form-check-reverse">
+    <input class="form-check-input" type="radio" name="reverseSwitch" value="" id="reverseSwitch2">
+    <label class="form-check-label" for="reverseSwitch2">Reverse switch radio</label>
+  </div>
+</div>
+{% endcapture %}
+{% renderExample example %}
+
 ## File Browser
 
 Using `.form-file` as a wrapper, we hide the default file `<input>` via `opacity` and instead style the `<label>` with some additional child elements to recreate the filename text and button portions of the input.  A `width` and `height` are also set on the `<input>` for proper spacing for surrounding content.
@@ -1713,6 +1758,14 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$enable-form-check-reverse</code></td>
+        <td>boolean</td>
+        <td><code>true</code></td>
+        <td>
+          Enable the generation of the reverse layout styles checkbox and radio inputs.
+        </td>
+      </tr>
+      <tr>
         <td><code>$enable-form-file</code></td>
         <td>boolean</td>
         <td><code>true</code></td>
@@ -2001,6 +2054,14 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
         </td>
       </tr>
       <tr>
+        <td><code>$input-checkradio-size</code></td>
+        <td>string</td>
+        <td><code>.875rem</code></td>
+        <td>
+          Dimension for checkbox and radio inputs.
+        </td>
+      </tr>
+      <tr>
         <td><code>$form-label-font-weight</code></td>
         <td>string</td>
         <td><code>$font-weight-normal</code></td>
@@ -2251,7 +2312,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-checkradio-checkbox-icon</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-checkradio-checked-color}' d='M6.41 1l-.69.72L2.94 4.5l-.81-.78L1.41 3 0 4.41l.72.72 1.5 1.5.69.72.72-.72 3.5-3.5.72-.72L6.41 1z'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for custom styled checkbox inputs when in checked state.
         </td>
@@ -2267,7 +2328,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-checkradio-radio-icon</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle fill='#{$form-checkradio-checked-color}' r='3'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for custom styled radio inputs when in checked state.
         </td>
@@ -2291,7 +2352,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-checkradio-indeterminate-icon</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'><path stroke='#{$form-checkradio-checked-color}' d='M0 2h4'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for custom styled checkbox inputs when in indeterminate state.
         </td>
@@ -2563,7 +2624,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-select-indicator-image</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-select-indicator-color}' d='M3 0l-3 3h6l-3-3zm-3 5l3 3 3-3h-6z'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for visual indicator of custom select input.
         </td>
@@ -2844,7 +2905,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-feedback-icon-valid-image</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-feedback-icon-valid-color}' d='M6.41 1l-.69.72L2.94 4.5l-.81-.78L1.41 3 0 4.41l.72.72 1.5 1.5.69.72.72-.72 3.5-3.5.72-.72L6.41 1z'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for <em>valid</em> feedback state.
         </td>
@@ -2860,7 +2921,7 @@ The available [Customization options]({{ site.path }}/{{ version.docs }}/get-sta
       <tr>
         <td><code>$form-feedback-icon-invalid-image</code></td>
         <td>string</td>
-        <td><code>encode-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#{$form-feedback-icon-invalid-color}' d='M3.09 0c-.06 0-.1.04-.13.09L.02 6.9c-.02.05-.03.13-.03.19v.81c0 .05.04.09.09.09h6.81c.05 0 .09-.04.09-.09v-.81c0-.05-.01-.14-.03-.19L4.01.09A.142.142 0 0 0 3.88 0h-.81zM3 3h1v2H3V3zm0 3h1v1H3V6z'/></svg>"))</code></td>
+        <td>encoded svg</td>
         <td>
           Icon for <em>invalid</em> feedback state.
         </td>

--- a/test/visual/form-check.html
+++ b/test/visual/form-check.html
@@ -250,6 +250,46 @@
     <label class="form-check-label" for="resize2">Resized custom switch</label>
 </div>
 
+<h2>Reverse</h2>
+
+<div class="form-check form-check-reverse">
+  <input class="form-check-input" type="checkbox" value="" id="reverseCheck0">
+  <label class="form-check-label" for="reverseCheck0">Reverse default checkbox</label>
+</div>
+<div class="form-check form-checkradio form-check-reverse">
+  <input class="form-check-input" type="checkbox" value="" id="reverseCheck1">
+  <label class="form-check-label" for="reverseCheck1">Reverse custom checkbox</label>
+  <small class="text-muted d-block">Some additional help text could appear right here.</small>
+</div>
+<div class="form-check form-checkradio form-check-reverse">
+  <input class="form-check-input" type="checkbox" value="" id="reverseCheck2" disabled>
+  <label class="form-check-label" for="reverseCheck2">Disabled custom reverse checkbox</label>
+</div>
+
+<div class="form-check form-check-reverse">
+  <input class="form-check-input" type="radio" name="reverseRadio0" value="" id="reverseRadio0">
+  <label class="form-check-label" for="reverseRadio0">Reverse default radio</label>
+</div>
+<div class="form-check form-check-reverse">
+  <input class="form-check-input" type="radio" name="reverseRadio1" value="" id="reverseRadio1">
+  <label class="form-check-label" for="reverseRadio1">Reverse custom radio</label>
+</div>
+
+<div class="form-check form-switch form-check-reverse">
+  <input class="form-check-input" type="checkbox" id="reverseSwitch0">
+  <label class="form-check-label" for="reverseSwitch0">Reverse switch checkbox input</label>
+  <small class="text-muted d-block">Some additional help text could appear right here.</small>
+</div>
+<div class="form-check form-switch form-check-reverse">
+  <input class="form-check-input" type="radio" name="reverseSwitch" id="reverseSwitch1">
+  <label class="form-check-label" for="reverseSwitch1">Reverse switch radio input</label>
+</div>
+<div class="form-check form-switch form-check-reverse">
+  <input class="form-check-input" type="radio" name="reverseSwitch" id="reverseSwitch2">
+  <label class="form-check-label" for="reverseSwitch2">Reverse switch radio input</label>
+</div>
+
+
 </div>
 
 <script>


### PR DESCRIPTION
Add a reverse layout option to `.form-check` to end align the text and input - swapping the visual order of the input to the end side.

Also adds an opinionated sizing  to `_reboot.scss` for the default checkbox and radio inputs so we can get the alignment correct.