### PR TITLE
Drag: Improve dragStart handling, use namespace to check for conflicts

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -63,9 +63,13 @@
         _dragStart : function(e) {
             var $selfRef = this;
 
+            // ignore potential disabled handle
+            if ($.CFW_isDisabled(e.target)) { return; }
+
             // check for handle selector
-            if (this.settings.handle && !$(e.target).closest(this.settings.handle, e.currentTarget).not('.disabled, :disabled').length) {
-                return;
+            if (this.settings.handle) {
+                var $handle = this.$element[0].querySelector(this.settings.handle);
+                if (!$handle.contains(e.target)) { return; }
             }
 
             // check for disabled element
@@ -75,7 +79,6 @@
             this.dragging = true;
 
             $(document)
-                .off('.cfw.dragin.' + this.instance)
                 .on('mousemove.cfw.dragin.' + this.instance + ' touchmove.cfw.dragin.' + this.instance + ' MSPointerMove.cfw.dragin.' + this.instance, function(e) {
                     $selfRef._drag(e);
                 })

--- a/js/popover.js
+++ b/js/popover.js
@@ -146,14 +146,17 @@
         this.$target.off('.cfw.drag');
 
         this.$target
-            .on('dragStart.cfw.drag', function() {
+            .on('dragStart.cfw.drag', function(e) {
+                if (e.namespace !== 'cfw.drag') { return; }
                 $selfRef._updateZ();
                 $selfRef.$element.CFW_trigger('dragStart.cfw.' + $selfRef.type);
             })
             .on('drag.cfw.drag', function(e) {
+                if (e.namespace !== 'cfw.drag') { return; }
                 $selfRef.locateDragTip(e.offsetY, e.offsetX);
             })
-            .on('dragEnd.cfw.drag', function() {
+            .on('dragEnd.cfw.drag', function(e) {
+                if (e.namespace !== 'cfw.drag') { return; }
                 $selfRef.$element.CFW_trigger('dragEnd.cfw.' + $selfRef.type);
             })
             .on('keydown.cfw.drag', '[data-cfw-drag="' + this.type + '"]', function(e) {


### PR DESCRIPTION
May have to change Drag events in the future to prevent conflict  with names for browser drag events since vanilla JS does not use event namespaces.

Fixes #826