### PR TITLE
Popover: Improve z-index handling

### DIFF
--- a/js/popover.js
+++ b/js/popover.js
@@ -315,6 +315,8 @@
             this.$element.CFW_trigger('dragEnd.cfw.' + this.type);
             clearTimeout(this.keyTimer);
         }
+        // Reset z-index
+        this._resetZ(this.$target);
         // Call tooltip hide
         $.fn.CFW_Tooltip.Constructor.prototype.hide.call(this, force);
     };
@@ -337,20 +339,39 @@
         this.dragAdded = false;
     };
 
+    CFW_Widget_Popover.prototype._resetZ = function($item) {
+        // Reset z-index if one is already stored
+        var savedVal = $item.attr('data-cfw-zindex');
+        if (typeof savedVal !== 'undefined') {
+            $item.removeAttr('data-cfw-zindex');
+            $item[0].style.removeProperty('z-index');
+        }
+    };
+
     CFW_Widget_Popover.prototype._updateZ = function() {
+        var $selfRef = this;
         // Find highest z-indexed visible popover
         var zMax = 0;
         var $zObj = null;
         $('.popover:visible').each(function() {
-            var zCurr = parseInt($(this).css('z-index'), 10);
-            if (zCurr > zMax) {
+            var $item = $(this);
+            // Reset z-index
+            $selfRef._resetZ($item);
+
+            var zCurr = parseInt($item.css('z-index'), 10);
+            if (isNaN(zCurr)) { zCurr = 0; }
+            if (zCurr >= zMax) {
                 zMax = zCurr;
-                $zObj = $(this);
+                $zObj = $item;
             }
         });
-        // Only increase if highest is not current popover
-        if (this.$target[0] !== $zObj[0]) {
-            this.$target.css('z-index', ++zMax);
+        // Only increase if not highest
+        if ($zObj && this.$target[0] !== $zObj[0]) {
+            // Store
+            var actualVal = this.$target.css('z-index');
+            this.$target.attr('data-cfw-zindex', actualVal);
+            // Update
+            this.$target.css('z-index', parseInt(actualVal, 10) + 1);
         }
     };
 

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -1453,6 +1453,7 @@ $zindex-fixed:              1020 !default;
 $zindex-offcanvas-backdrop: 1030 !default;
 $zindex-offcanvas:          1035 !default;
 $zindex-popover:            1040 !default;
+$zindex-popover-draggable:  1045 !default;
 $zindex-tooltip:            1050 !default;
 $zindex-modal-backdrop:     1060 !default;
 $zindex-modal:              1065 !default;

--- a/scss/component/_popover.scss
+++ b/scss/component/_popover.scss
@@ -216,6 +216,7 @@
     // Draggable variant
     @if $enable-popover-draggable {
         .popover.draggable {
+            z-index: $zindex-popover-draggable;
             margin: 0;
 
             .popover-arrow {

--- a/site/4.3/layout/z-index.md
+++ b/site/4.3/layout/z-index.md
@@ -19,6 +19,7 @@ $zindex-fixed:              1020 !default;
 $zindex-offcanvas-backdrop: 1030 !default;
 $zindex-offcanvas:          1035 !default;
 $zindex-popover:            1040 !default;
+$zindex-popover-draggable:  1045 !default;
 $zindex-tooltip:            1050 !default;
 $zindex-modal-backdrop:     1060 !default;
 $zindex-modal:              1065 !default;

--- a/test/js/unit/popover.js
+++ b/test/js/unit/popover.js
@@ -538,4 +538,55 @@ $(function() {
 
         $popover.CFW_Popover('show');
     });
+
+    QUnit.test('should set and reset z-index when drag item is changed', function(assert) {
+        assert.expect(8);
+        var done = assert.async();
+        var $trigger0 = $('<button class="btn" title="popover title" data-cfw-popover-drag="true" data-cfw-popover-container="body">Popover</button>')
+            .appendTo('#qunit-fixture')
+            .CFW_Popover();
+        var $trigger1 = $('<button class="btn" title="popover title" data-cfw-popover-drag="true" data-cfw-popover-container="body">Popover</button>')
+            .appendTo('#qunit-fixture')
+            .CFW_Popover();
+        var $popover0 = null;
+        var $popover1 = null;
+
+        var getPopovers = function() {
+            $popover0 = $trigger0.data('cfw.popover').$target;
+            $popover1 = $trigger1.data('cfw.popover').$target;
+        };
+        var hasZ = function($node) {
+            var savedVal = $node.attr('data-cfw-zindex');
+            if (typeof savedVal !== 'undefined') {
+                return true;
+            }
+            return false;
+        };
+
+        $trigger1
+            .on('afterShow.cfw.popover', function() {
+                getPopovers();
+                assert.notOk(hasZ($popover0));
+                assert.notOk(hasZ($popover1));
+
+                $popover0.find('[data-cfw-drag="popover"]').trigger('mousedown');
+                assert.ok(hasZ($popover0));
+                assert.notOk(hasZ($popover1));
+                $popover0.find('[data-cfw-drag="popover"]').trigger('mouseup');
+
+                $popover1.find('[data-cfw-drag="popover"]').trigger('mousedown');
+                assert.notOk(hasZ($popover0));
+                assert.notOk(hasZ($popover1));
+                $popover0.find('[data-cfw-drag="popover"]').trigger('mouseup');
+
+                $popover0.find('[data-cfw-drag="popover"]').trigger('mousedown');
+                assert.ok(hasZ($popover0));
+                assert.notOk(hasZ($popover1));
+                $popover0.find('[data-cfw-drag="popover"]').trigger('mouseup');
+                done();
+            });
+
+        $trigger0.CFW_Popover('show');
+        $trigger1.CFW_Popover('show');
+    });
 });


### PR DESCRIPTION
- Draggable popovers now sit slightly above the standard ones
- Keeps popovers from rising above modals by resetting the z-index instead of using continuous increment
- z-index will reset once another popover is dragged
- z-index will reset when popover is hidden